### PR TITLE
chore: add devcontainer manifest

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/devcontainers/base:bookworm
+
+RUN mkdir -p /home/vscode/.local/share/fish \
+  && chown -R vscode:vscode /home/vscode/.local

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,3 +2,5 @@ FROM mcr.microsoft.com/devcontainers/base:bookworm
 
 RUN mkdir -p /home/vscode/.local/share/fish \
   && chown -R vscode:vscode /home/vscode/.local
+
+VOLUME /workspaces/storage/node_modules

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
     "ghcr.io/joshuanianji/devcontainer-features/aws-cli-persistence:1": {}
   },
   "initializeCommand": "mkdir -p ${localEnv:HOME}${localEnv:USERPROFILE}/.local/share/atuin",
-  "postCreateCommand": "npm ci",
+  "postCreateCommand": "sudo chown -R vscode:vscode /workspaces/storage/node_modules && npm ci",
   "mounts": [
     {
       "type": "bind",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,12 +25,10 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "unifiedjs.vscode-mdx",
         "esbenp.prettier-vscode",
         "streetsidesoftware.code-spell-checker",
         "ms-vscode.wordcount",
         "SirTori.indenticator",
-        "bpruitt-goddard.mermaid-markdown-syntax-highlighting",
         "ms-vsliveshare.vsliveshare"
       ]
     }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,43 @@
+{
+  "name": "Dev",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  // 👇 Features to add to the Dev Container. More info: https://containers.dev/implementors/features.
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/xe/devcontainer-features/fish:0.2.0": {
+      "fisher": true
+    },
+    "ghcr.io/devcontainer-community/devcontainer-features/atuin.sh:1": {},
+    "ghcr.io/devcontainers-extra/features/neovim-apt-get:1": {},
+    "ghcr.io/joshuanianji/devcontainer-features/aws-cli-persistence:1": {}
+  },
+  "initializeCommand": "mkdir -p ${localEnv:HOME}${localEnv:USERPROFILE}/.local/share/atuin",
+  "postCreateCommand": "npm ci",
+  "mounts": [
+    {
+      "type": "bind",
+      "source": "${localEnv:HOME}${localEnv:USERPROFILE}/.local/share/atuin",
+      "target": "/home/vscode/.local/share/atuin"
+    }
+  ],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "unifiedjs.vscode-mdx",
+        "esbenp.prettier-vscode",
+        "streetsidesoftware.code-spell-checker",
+        "ms-vscode.wordcount",
+        "SirTori.indenticator",
+        "bpruitt-goddard.mermaid-markdown-syntax-highlighting",
+        "ms-vsliveshare.vsliveshare"
+      ]
+    }
+  }
+  // 👇 Use 'postCreateCommand' to run commands after the container is created.
+  // 👇 Configure tool-specific properties.
+  // "customizations": {},
+  // 👇 Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
+}


### PR DESCRIPTION
Adds [development container](https://containers.dev/) support so that development can happen in an environment isolated from the host.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a Dev Container (Dockerfile + devcontainer.json) with Node/fish/Atuin/Neovim/AWS CLI features, persistent Atuin history, `node_modules` volume, and `npm ci` on create.
> 
> - **Dev Container Setup**:
>   - **Dockerfile** (`.devcontainer/Dockerfile`):
>     - Base image `mcr.microsoft.com/devcontainers/base:bookworm`.
>     - Prepares fish config directory with correct ownership.
>     - Declares volume `VOLUME /workspaces/storage/node_modules`.
>   - **Configuration** (`.devcontainer/devcontainer.json`):
>     - Adds features: Node, fish (with Fisher), Atuin, Neovim (apt-get), AWS CLI persistence.
>     - Initializes and bind-mounts Atuin data to persist shell history.
>     - `postCreateCommand`: chown `node_modules` and run `npm ci`.
>     - VS Code extensions: Prettier, spell checker, word count, Indenticator, Live Share.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83505d9981ccb8579ab35d48011242a673a6cb2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->