### PR TITLE
fix: put body param and get id response

### DIFF
--- a/packages/storage/src/lib/list.ts
+++ b/packages/storage/src/lib/list.ts
@@ -6,7 +6,9 @@ import type { TigrisStorageConfig, TigrisStorageResponse } from './types';
 export type ListOptions = {
   limit?: number;
   paginationToken?: string;
-  // @deprecated
+  /**
+   * @deprecated Use paginationToken instead
+   */
   paginationMarker?: string;
   config?: TigrisStorageConfig;
 };
@@ -50,7 +52,7 @@ export async function list(
         data: {
           items:
             res.Contents?.map((item) => ({
-              id: item.ETag?.replace(/"/g, '') ?? '',
+              id: item.Key ?? '',
               name: item.Key ?? '',
               size: item.Size ?? 0,
               lastModified: item.LastModified ?? new Date(),

--- a/packages/storage/src/lib/put.ts
+++ b/packages/storage/src/lib/put.ts
@@ -39,7 +39,7 @@ export type PutResponse = {
 
 export async function put(
   path: string,
-  data: string | ReadableStream | Blob | Buffer,
+  body: string | ReadableStream | Blob | Buffer,
   options?: PutOptions
 ): Promise<TigrisStorageResponse<PutResponse, Error>> {
   const { data: tigrisClient, error } = createTigrisClient(options?.config);
@@ -78,7 +78,7 @@ export async function put(
     params: {
       Bucket: options?.config?.bucket ?? config.bucket,
       Key: path,
-      Body: data,
+      Body: body,
       ContentType: options?.contentType ?? undefined,
       ContentDisposition: contentDisposition,
       ACL: access,


### PR DESCRIPTION
- Marks `paginationMarker` deprecated.
- Fix the `id` in list response
- Fix `body` param name in `put`