### PR TITLE
fix: extend createBucket to include fork options

### DIFF
--- a/packages/storage/src/lib/bucket/create.ts
+++ b/packages/storage/src/lib/bucket/create.ts
@@ -5,6 +5,8 @@ import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
 
 export type CreateBucketOptions = {
   enableSnapshot?: boolean;
+  sourceBucketName?: string;
+  sourceBucketSnapshot?: string;
   config?: Omit<TigrisStorageConfig, 'bucket'>;
 };
 
@@ -30,6 +32,28 @@ export async function createBucket(
       (next) => async (args) => {
         (args.request as HttpRequest).headers['X-Tigris-Enable-Snapshot'] =
           'true';
+        return next(args);
+      },
+      { step: 'build' }
+    );
+  }
+
+  if (options?.sourceBucketName && options.sourceBucketName !== '') {
+    const sourceBucketName = options.sourceBucketName;
+    command.middlewareStack.add(
+      (next) => async (args) => {
+        (args.request as HttpRequest).headers['X-Tigris-Fork-Source-Bucket'] =
+          sourceBucketName;
+
+        if (
+          options?.sourceBucketSnapshot &&
+          options.sourceBucketSnapshot !== ''
+        ) {
+          (args.request as HttpRequest).headers[
+            'X-Tigris-Fork-Source-Bucket-Snapshot'
+          ] = options.sourceBucketSnapshot;
+        }
+
         return next(args);
       },
       { step: 'build' }

--- a/packages/storage/src/lib/bucket/fork.ts
+++ b/packages/storage/src/lib/bucket/fork.ts
@@ -9,6 +9,11 @@ export type CreateBucketForkOptions = {
   config?: Omit<TigrisStorageConfig, 'bucket'>;
 };
 
+/**
+ * @deprecated
+ * Use createBucket with config.sourceBucketName and config.sourceBucketSnapshot instead
+ * Will be removed in the next major version
+ */
 export async function createBucketFork(
   forkName: string,
   options?: CreateBucketForkOptions

--- a/packages/storage/src/lib/object/list.ts
+++ b/packages/storage/src/lib/object/list.ts
@@ -8,6 +8,7 @@ export type ListOptions = {
   paginationToken?: string;
   /**
    * @deprecated Use paginationToken instead
+   * Will be removed in the next major version
    */
   paginationMarker?: string;
   config?: TigrisStorageConfig;
@@ -15,6 +16,7 @@ export type ListOptions = {
 
 /**
  * @deprecated Use ListItem instead
+ * Will be removed in the next major version
  */
 export type Item = {
   id: string;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds fork-from-bucket support to createBucket (with optional snapshot) and deprecates createBucketFork; marks paginationMarker and Item as deprecated in object listing.
> 
> - **Buckets**:
>   - **createBucket**: Adds `sourceBucketName` and `sourceBucketSnapshot` options; sets `X-Tigris-Fork-Source-Bucket` and optional `X-Tigris-Fork-Source-Bucket-Snapshot` headers when provided.
>   - **createBucketFork**: Marked as deprecated in favor of `createBucket` with source options.
> - **Objects**:
>   - **list**: Adds deprecation notes for `paginationMarker` and `Item` (will be removed next major).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5116d59b528ecf29c65f998352c0c78e0a619aa4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->