### PR TITLE
fix(cli): remove publishing of CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,12 +62,6 @@
         {
           "pkgRoot": "packages/storage"
         }
-      ],
-      [
-        "@semantic-release/npm",
-        {
-          "pkgRoot": "packages/cli"
-        }
       ]
     ]
   },


### PR DESCRIPTION
BREAKING CHANGE: Adding it here so it bumps the version

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the `@semantic-release/npm` config for `packages/cli`, so only `packages/storage` is published.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec0401c5a78ab210797653d7682e35581233785e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->