### PR TITLE
fix: storage package publish

### DIFF
--- a/packages/storage/release.config.cjs
+++ b/packages/storage/release.config.cjs
@@ -1,5 +1,5 @@
 module.exports = {
-  tagFormat: 'v${version}',
+  tagFormat: 'storage-v${version}',
   branches: [
     'main',
     {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Change semantic-release tag format to `storage-v${version}` for the storage package.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ba48ae68799d2c78b3d562f6b58bd43b35bc8d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->