### PR TITLE
fix: storage package publish with correct tag

### DIFF
--- a/packages/storage/release.config.cjs
+++ b/packages/storage/release.config.cjs
@@ -1,5 +1,4 @@
 module.exports = {
-  tagFormat: 'storage-v${version}',
   branches: [
     'main',
     {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the custom tagFormat from the storage package’s semantic-release config.
> 
> - **Release config (`packages/storage/release.config.cjs`)**:
>   - Remove `tagFormat: 'storage-v${version}'` from semantic-release configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c0f038b7beeb68a7c679c7515cd577a3bf909a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->