### PR TITLE
fix(keyv-tigris): fix docs for constructor options

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ Tigris is a globally distributed object storage service that provides low latenc
 This monorepo contains multiple packages for Tigris object storage:
 
 - [`@tigrisdata/storage`](./packages/storage) - Tigris Storage SDK
+- [`@tigrisdata/keyv-tigris`](./packages/keyv-tigris/) - Tigris adapter for [Keyv](https://keyv.org/)

--- a/packages/keyv-tigris/README.md
+++ b/packages/keyv-tigris/README.md
@@ -32,12 +32,10 @@ const store = new KeyvTigris();
 // Or pass the configuration directly:
 
 const store = new KeyvTigris({
-  config: {
-    bucket: 'your-bucket-name',
-    accessKeyId: 'your-access-key',
-    secretAccessKey: 'your-secret-key',
-    endpoint: 'https://t3.storage.dev',
-  },
+  bucket: 'your-bucket-name',
+  accessKeyId: 'your-access-key',
+  secretAccessKey: 'your-secret-key',
+  endpoint: 'https://t3.storage.dev',
 });
 
 const keyv = new Keyv({ store });
@@ -58,9 +56,6 @@ await keyv.set('foo', 'bar');
 
 // Get a value
 const value = await keyv.get('foo'); // 'bar'
-
-// Set with TTL (in milliseconds)
-await keyv.set('temporary', 'data', 60000); // expires in 1 minute
 
 // Delete a key
 await keyv.delete('foo');
@@ -129,13 +124,7 @@ const keyv = new Keyv({ store });
 
 ## API
 
-### `KeyvTigrisOptions`
-
-| Option   | Type                      | Description                                                  |
-| -------- | ------------------------- | ------------------------------------------------------------ |
-| `config` | `TigrisStorageCoreConfig` | Tigris storage configuration (bucket, credentials, endpoint) |
-
-### `TigrisStorageCoreConfig`
+### Constructor Options (`TigrisStorageCoreConfig`)
 
 | Option            | Type     | Description                                             |
 | ----------------- | -------- | ------------------------------------------------------- |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update Keyv Tigris README to use direct constructor options and streamline usage/API; add package link to root README.
> 
> - **Docs**
>   - **`packages/keyv-tigris/README.md`**:
>     - Update configuration example to pass options directly to `new KeyvTigris({ ... })` (no nested `config`).
>     - Streamline usage by removing TTL example and clarifying basic operations.
>     - Consolidate API section to “Constructor Options (`TigrisStorageCoreConfig`)” and remove `KeyvTigrisOptions`.
>   - **`README.md`**:
>     - Add link to `@tigrisdata/keyv-tigris` package.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e6e0e45706667181159919948a8b3dcfff14b97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->