### PR TITLE
feat: simplify client upload server implementation

### DIFF
--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -825,7 +825,7 @@ import { upload } from '@tigrisdata/storage/client';
 
 `upload` accepts the following parameters:
 
-- `path`: (Required) A string specifying the path to the object
+- `name`: (Required) A string specifying the name of object
 - `body`: (Required) A blob object as File or Blob
 - `options`: (Optional) A JSON object with the following optional parameters:
 
@@ -843,7 +843,7 @@ In case of successful upload, the `data` property will be set to the upload and 
 - `contentDisposition`: content disposition of the object
 - `contentType`: content type of the object
 - `modified`: Last modified date of the object
-- `path`: Path to the object
+- `name`: Name of the object
 - `size`: Size of the object
 - `url`: A presigned URL to the object
 

--- a/packages/storage/src/client.ts
+++ b/packages/storage/src/client.ts
@@ -3,4 +3,4 @@ export {
   type UploadOptions,
   type UploadProgress,
   type UploadResponse,
-} from './lib/upload';
+} from './lib/upload/client';

--- a/packages/storage/src/lib/upload/server.ts
+++ b/packages/storage/src/lib/upload/server.ts
@@ -1,0 +1,64 @@
+import {
+  completeMultipartUpload,
+  getPartsPresignedUrls,
+  initMultipartUpload,
+} from '../object/multipart';
+import { getPresignedUrl } from '../object/presigned-url';
+import { TigrisStorageConfig, TigrisStorageResponse } from '../types';
+import { UploadAction } from './shared';
+
+export interface ClientUploadRequest {
+  action: UploadAction;
+  name: string;
+  contentType?: string;
+  uploadId?: string;
+  parts?: number[];
+  partIds?: Array<{ [key: number]: string }>;
+}
+
+export async function handleClientUpload(
+  request: ClientUploadRequest,
+  config?: TigrisStorageConfig
+): Promise<TigrisStorageResponse<unknown, Error>> {
+  const { action, name, contentType, uploadId, parts, partIds } = request;
+
+  switch (action) {
+    case UploadAction.SinglepartInit:
+      return await getPresignedUrl(name, {
+        contentType,
+        operation: 'put',
+        expiresIn: 3600, // 1 hour
+        config,
+      });
+    case UploadAction.MultipartInit:
+      return await initMultipartUpload(name, {
+        config,
+      });
+    case UploadAction.MultipartGetParts:
+      if (!uploadId || !parts) {
+        return {
+          error: new Error(
+            'uploadId and parts are required for multipart-parts'
+          ),
+        };
+      }
+      return await getPartsPresignedUrls(name, parts, uploadId, {
+        config,
+      });
+    case UploadAction.MultipartComplete:
+      if (!uploadId || !partIds) {
+        return {
+          error: new Error(
+            'uploadId and partIds are required for multipart-complete'
+          ),
+        };
+      }
+      return await completeMultipartUpload(name, uploadId, partIds, {
+        config,
+      });
+    default:
+      return {
+        error: new Error(`Invalid action: ${action}`),
+      };
+  }
+}

--- a/packages/storage/src/lib/upload/shared.ts
+++ b/packages/storage/src/lib/upload/shared.ts
@@ -1,0 +1,6 @@
+export enum UploadAction {
+  SinglepartInit = 'singlepart-init',
+  MultipartInit = 'multipart-init',
+  MultipartGetParts = 'multipart-get-parts',
+  MultipartComplete = 'multipart-complete',
+}

--- a/packages/storage/src/server.ts
+++ b/packages/storage/src/server.ts
@@ -51,7 +51,11 @@ export {
 } from './lib/object/presigned-url';
 export { put, type PutOptions, type PutResponse } from './lib/object/put';
 export { remove, type RemoveOptions } from './lib/object/remove';
-export { UploadAction } from './lib/upload';
+export {
+  createOrganization,
+  type CreateOrganizationOptions,
+  type CreateOrganizationResponse,
+} from './lib/organization/create';
 export {
   listOrganizations,
   type ListOrganizationsOptions,
@@ -59,7 +63,7 @@ export {
   type Organization,
 } from './lib/organization/list';
 export {
-  createOrganization,
-  type CreateOrganizationOptions,
-  type CreateOrganizationResponse,
-} from './lib/organization/create';
+  handleClientUpload,
+  type ClientUploadRequest,
+} from './lib/upload/server';
+export { UploadAction } from './lib/upload/shared';


### PR DESCRIPTION
Server side implementation of client upload was quite complex. Consumer needs to know a lot of ins and outs. This PR simplifies by exposing a single method.

Based on feedback from community,
https://community.fly.io/t/tigris-setting-bucket-path-in-client/26497

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `handleClientUpload` server API for presigned/multipart orchestration, switches client upload to use `name` (deprecates `path`), and updates docs/exports accordingly.
> 
> - **Client Uploads**
>   - Switch `upload` signature to `name` (replaces `path`; `path` retained in response as deprecated).
>   - Move client upload implementation to `lib/upload/client` and reference shared `UploadAction` from `lib/upload/shared`.
> - **Server API**
>   - Add `handleClientUpload(request, config?)` in `lib/upload/server` handling `SinglepartInit`, `MultipartInit`, `MultipartGetParts`, and `MultipartComplete`.
>   - Export `handleClientUpload`, `ClientUploadRequest`, and `UploadAction` from `src/server`.
> - **Docs**
>   - Update README client upload section to use `name` param and show simplified example.
> - **Exports**
>   - Update `src/client.ts` and `src/server.ts` exports to new paths and shared enum.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67e18c9661fde28b6b7ec6e8e67217ee4f36ce81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->