### PR TITLE
fix(storage): separate query string from path in SigV4 signing

### DIFF
--- a/packages/storage/src/test/integration.test.ts
+++ b/packages/storage/src/test/integration.test.ts
@@ -260,16 +260,18 @@ describe.skipIf(skipTests)('Tigris Storage Integration Tests', () => {
       expect(result.error?.message).toBe('No update options provided');
     });
 
-    it('should return error on rename failure', async () => {
+    it('should rename an object', async () => {
       const newKey = `test-renamed-${Date.now()}.txt`;
       const result = await updateObject(updateFileName, {
         key: newKey,
         config,
       });
 
-      // Rename via HTTP client requires CopyObject permission
-      expect(result.error).toBeDefined();
-      expect(result.data).toBeUndefined();
+      expect(result.error).toBeUndefined();
+      expect(result.data?.path).toBe(newKey);
+
+      // Rename back so subsequent tests still find the original file
+      await updateObject(newKey, { key: updateFileName, config });
     });
 
     it('should update access to public', async () => {
@@ -292,18 +294,24 @@ describe.skipIf(skipTests)('Tigris Storage Integration Tests', () => {
       expect(result.data?.path).toBe(updateFileName);
     });
 
-    it('should not update access when rename fails', async () => {
+    it('should rename and update access together', async () => {
       const newKey = `test-renamed-public-${Date.now()}.txt`;
 
-      // When rename fails, access update should not run
       const result = await updateObject(updateFileName, {
         key: newKey,
         access: 'public',
         config,
       });
 
-      expect(result.error).toBeDefined();
-      expect(result.data).toBeUndefined();
+      expect(result.error).toBeUndefined();
+      expect(result.data?.path).toBe(newKey);
+
+      // Rename back so subsequent tests still find the original file
+      await updateObject(newKey, {
+        key: updateFileName,
+        access: 'private',
+        config,
+      });
     });
   });
 

--- a/shared/http-client.ts
+++ b/shared/http-client.ts
@@ -46,7 +46,7 @@ const cachedHttpClients = new Map<string, TigrisHttpClient>();
 /**
  * Generate AWS Signature V4 headers for a request
  */
-async function generateSignatureHeaders(
+export async function generateSignatureHeaders(
   method: string,
   url: URL,
   headers: Record<string, string>,
@@ -64,12 +64,18 @@ async function generateSignatureHeaders(
     sha256: Sha256,
   });
 
+  const query: Record<string, string> = {};
+  url.searchParams.forEach((value, key) => {
+    query[key] = value;
+  });
+
   const request = {
     method,
     protocol: url.protocol,
     hostname: url.hostname,
     port: url.port ? parseInt(url.port) : undefined,
-    path: url.pathname + url.search,
+    path: url.pathname,
+    ...(Object.keys(query).length > 0 && { query }),
     headers: {
       ...headers,
       host: url.host,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches SigV4 signing used for credential-based authentication; mistakes could break request auth for any endpoints that use query params. Scope is small and covered by updated integration expectations around rename behavior.
> 
> **Overview**
> Fixes AWS SigV4 signing in `shared/http-client.ts` by signing `url.pathname` as the request `path` and passing query parameters via a dedicated `query` object (instead of including `url.search` in the path), and exports `generateSignatureHeaders` for reuse/testing.
> 
> Updates storage `updateObject` integration tests to expect renames (and rename+access updates) to succeed, and adds cleanup steps to rename objects back so subsequent tests remain stable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32e3f18e2101cb9e6f84cfe517a82b774247ae75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->