### PR TITLE
feat(iam): implement whoami

### DIFF
--- a/packages/iam/src/index.ts
+++ b/packages/iam/src/index.ts
@@ -66,3 +66,4 @@ export {
   updateUserRole,
   type UpdateUserRoleOptions,
 } from './lib/users/update-role';
+export { whoami, type WhoamiOptions, type WhoamiResponse } from './lib/whoami';

--- a/packages/iam/src/lib/config.ts
+++ b/packages/iam/src/lib/config.ts
@@ -19,6 +19,8 @@ function loadIAMConfig(): TigrisIAMConfig {
     config.mgmtEndpoint = process.env.TIGRIS_MGMT_ENDPOINT;
     config.sessionToken = process.env.TIGRIS_SESSION_TOKEN;
     config.organizationId = process.env.TIGRIS_ORGANIZATION_ID;
+    config.accessKeyId = process.env.TIGRIS_STORAGE_ACCESS_KEY_ID;
+    config.secretAccessKey = process.env.TIGRIS_STORAGE_SECRET_ACCESS_KEY;
   }
 
   return config;

--- a/packages/iam/src/lib/http-client.ts
+++ b/packages/iam/src/lib/http-client.ts
@@ -3,6 +3,8 @@ import { config, DEFAULT_ENDPOINTS } from './config';
 import type { TigrisIAMConfig, TigrisIAMResponse } from './types';
 
 export const IAM_ENDPOINTS = {
+  // Whoami
+  whoami: '/users/whoami',
   // Users
   revokeInvitation: '/tigris-iam/invitations',
   removeUser: '/tigris-iam/namespaces',
@@ -37,16 +39,19 @@ function getManagementEndpoint(options?: TigrisIAMConfig): string {
 
 export function createIAMClient(
   options?: TigrisIAMConfig,
-  isManagement?: boolean
+  isManagement?: boolean,
+  skipCheck?: boolean
 ): TigrisIAMResponse<TigrisHttpClient, Error> {
   const sessionToken = options?.sessionToken ?? config.sessionToken;
   const organizationId = options?.organizationId ?? config.organizationId;
+  const accessKeyId = options?.accessKeyId ?? config.accessKeyId;
+  const secretAccessKey = options?.secretAccessKey ?? config.secretAccessKey;
 
-  if (!sessionToken || sessionToken === '') {
+  if (!skipCheck && (!sessionToken || sessionToken === '')) {
     return { error: new Error('Session token is required') };
   }
 
-  if (!organizationId || organizationId === '') {
+  if (!skipCheck && (!organizationId || organizationId === '')) {
     return { error: new Error('Organization ID is required') };
   }
 
@@ -56,5 +61,7 @@ export function createIAMClient(
       : getIAMEndpoint(options),
     sessionToken,
     organizationId,
+    accessKeyId,
+    secretAccessKey,
   });
 }

--- a/packages/iam/src/lib/types.ts
+++ b/packages/iam/src/lib/types.ts
@@ -3,6 +3,8 @@ import type { TigrisResponse } from '@shared/types';
 export type TigrisIAMConfig = {
   sessionToken?: string;
   organizationId?: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
   iamEndpoint?: string;
   mgmtEndpoint?: string;
 };

--- a/packages/iam/src/lib/whoami.ts
+++ b/packages/iam/src/lib/whoami.ts
@@ -1,0 +1,42 @@
+import { createIAMClient, IAM_ENDPOINTS } from './http-client';
+import { TigrisIAMConfig, TigrisIAMResponse } from './types';
+
+export type WhoamiOptions = {
+  config?: TigrisIAMConfig;
+};
+
+export type WhoamiResponse = {
+  userId: string;
+  organizationId: string;
+};
+
+type WhoamiApiResponse = {
+  UserId: string;
+  NamespaceId: string;
+};
+
+export async function whoami(
+  options?: WhoamiOptions
+): Promise<TigrisIAMResponse<WhoamiResponse, Error>> {
+  const { data: client, error } = createIAMClient(options?.config, true, true);
+
+  if (error) {
+    return { error };
+  }
+
+  const response = await client.request<unknown, WhoamiApiResponse>({
+    method: 'GET',
+    path: IAM_ENDPOINTS.whoami,
+  });
+
+  if (response.error) {
+    return { error: response.error };
+  }
+
+  return {
+    data: {
+      userId: response.data.UserId,
+      organizationId: response.data.NamespaceId,
+    },
+  };
+}

--- a/shared/http-client.ts
+++ b/shared/http-client.ts
@@ -13,19 +13,19 @@ export interface HttpClientRequest<T = unknown> {
 
 export type HttpClientResponse<T = unknown> =
   | {
-    status: number;
-    statusText: string;
-    headers: Headers;
-    data: T;
-    error?: never;
-  }
+      status: number;
+      statusText: string;
+      headers: Headers;
+      data: T;
+      error?: never;
+    }
   | {
-    status: number;
-    statusText: string;
-    headers: Headers;
-    error: Error;
-    data?: never;
-  };
+      status: number;
+      statusText: string;
+      headers: Headers;
+      error: Error;
+      data?: never;
+    };
 
 export interface TigrisHttpClient {
   request<TRequest = unknown, TResponse = unknown>(
@@ -184,7 +184,9 @@ export function createTigrisHttpClient(
             status: response.status,
             statusText: response.statusText,
             headers: response.headers,
-            error: new Error(error.Message ?? response.statusText ?? 'Unknown error'),
+            error: new Error(
+              error.Message ?? response.statusText ?? 'Unknown error'
+            ),
           };
         } catch {
           return {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new `whoami` call and extends client configuration/authentication inputs (including a `skipCheck` path) which could change how requests are authorized if misused, though scope is limited to IAM client wiring.
> 
> **Overview**
> Adds a new `whoami` API (`GET /users/whoami`) to the IAM package and exports it from the public `index.ts`, returning the current `userId` and `organizationId`.
> 
> Extends IAM config/client creation to accept `accessKeyId`/`secretAccessKey` (loaded from `TIGRIS_STORAGE_ACCESS_KEY_ID`/`TIGRIS_STORAGE_SECRET_ACCESS_KEY`) and introduces an optional `skipCheck` flag to bypass required `sessionToken`/`organizationId` validation when creating an IAM client.
> 
> Includes a small tweak to shared HTTP client error construction (formatting-only).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80de2092d38c79c1fd341391e5bb17f284e55643. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->