### PR TITLE
fix(storage): handleClientUpload throwing errors

### DIFF
--- a/packages/storage/src/lib/object/multipart.ts
+++ b/packages/storage/src/lib/object/multipart.ts
@@ -32,17 +32,24 @@ export async function initMultipartUpload(
     Key: path,
   });
 
-  const { UploadId } = await tigrisClient.send(createCommand);
+  try {
+    const { UploadId } = await tigrisClient.send(createCommand);
 
-  if (!UploadId) {
-    return { error: new Error('Unable to initialize multipart upload') };
+    if (!UploadId) {
+      return { error: new Error('Unable to initialize multipart upload') };
+    }
+
+    return {
+      data: {
+        uploadId: UploadId,
+      },
+    };
+  } catch (error) {
+    const { message } = error as { message: string };
+    return {
+      error: new Error(`Unable to initialize multipart upload: ${message}`),
+    };
   }
-
-  return {
-    data: {
-      uploadId: UploadId,
-    },
-  };
 }
 
 export type GetPartsPresignedUrlsOptions = {

--- a/packages/storage/src/lib/object/multipart.ts
+++ b/packages/storage/src/lib/object/multipart.ts
@@ -4,6 +4,7 @@ import {
   UploadPartCommand,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { toError } from '@shared/utils';
 import { config } from '../config';
 import { createTigrisClient } from '../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
@@ -45,9 +46,10 @@ export async function initMultipartUpload(
       },
     };
   } catch (error) {
-    const { message } = error as { message: string };
     return {
-      error: new Error(`Unable to initialize multipart upload: ${message}`),
+      error: new Error(
+        `Unable to initialize multipart upload: ${toError(error).message}`
+      ),
     };
   }
 }

--- a/packages/storage/src/lib/object/put.ts
+++ b/packages/storage/src/lib/object/put.ts
@@ -1,6 +1,7 @@
 import { GetObjectCommand } from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { toError } from '@shared/utils';
 import { config } from '../config';
 import { createTigrisClient } from '../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
@@ -115,15 +116,8 @@ export async function put(
 
   try {
     await upload.done();
-  } catch (error: unknown) {
-    const { message } = error as {
-      message: string;
-    };
-    return {
-      error: message
-        ? new Error(message)
-        : new Error(`Unexpected error while uploading to Tigris Storage`),
-    };
+  } catch (error) {
+    return { error: toError(error) };
   }
 
   let signedUrl: string;

--- a/packages/storage/src/lib/upload/server.ts
+++ b/packages/storage/src/lib/upload/server.ts
@@ -6,6 +6,7 @@ import {
 import { getPresignedUrl } from '../object/presigned-url';
 import { TigrisStorageConfig, TigrisStorageResponse } from '../types';
 import { UploadAction } from './shared';
+import { toError } from '@shared/utils';
 
 export interface ClientUploadRequest {
   action: UploadAction;
@@ -62,12 +63,7 @@ export async function handleClientUpload(
           error: new Error(`Invalid action: ${action}`),
         };
     }
-  } catch (error: unknown) {
-    const { message } = error as { message: string };
-    return {
-      error: message
-        ? new Error(message)
-        : new Error('Unexpected error in handleClientUpload'),
-    };
+  } catch (error) {
+    return { error: toError(error) };
   }
 }

--- a/packages/storage/src/lib/upload/server.ts
+++ b/packages/storage/src/lib/upload/server.ts
@@ -22,43 +22,52 @@ export async function handleClientUpload(
 ): Promise<TigrisStorageResponse<unknown, Error>> {
   const { action, name, contentType, uploadId, parts, partIds } = request;
 
-  switch (action) {
-    case UploadAction.SinglepartInit:
-      return await getPresignedUrl(name, {
-        contentType,
-        operation: 'put',
-        expiresIn: 3600, // 1 hour
-        config,
-      });
-    case UploadAction.MultipartInit:
-      return await initMultipartUpload(name, {
-        config,
-      });
-    case UploadAction.MultipartGetParts:
-      if (!uploadId || !parts) {
+  try {
+    switch (action) {
+      case UploadAction.SinglepartInit:
+        return await getPresignedUrl(name, {
+          contentType,
+          operation: 'put',
+          expiresIn: 3600, // 1 hour
+          config,
+        });
+      case UploadAction.MultipartInit:
+        return await initMultipartUpload(name, {
+          config,
+        });
+      case UploadAction.MultipartGetParts:
+        if (!uploadId || !parts) {
+          return {
+            error: new Error(
+              'uploadId and parts are required for multipart-parts'
+            ),
+          };
+        }
+        return await getPartsPresignedUrls(name, parts, uploadId, {
+          config,
+        });
+      case UploadAction.MultipartComplete:
+        if (!uploadId || !partIds) {
+          return {
+            error: new Error(
+              'uploadId and partIds are required for multipart-complete'
+            ),
+          };
+        }
+        return await completeMultipartUpload(name, uploadId, partIds, {
+          config,
+        });
+      default:
         return {
-          error: new Error(
-            'uploadId and parts are required for multipart-parts'
-          ),
+          error: new Error(`Invalid action: ${action}`),
         };
-      }
-      return await getPartsPresignedUrls(name, parts, uploadId, {
-        config,
-      });
-    case UploadAction.MultipartComplete:
-      if (!uploadId || !partIds) {
-        return {
-          error: new Error(
-            'uploadId and partIds are required for multipart-complete'
-          ),
-        };
-      }
-      return await completeMultipartUpload(name, uploadId, partIds, {
-        config,
-      });
-    default:
-      return {
-        error: new Error(`Invalid action: ${action}`),
-      };
+    }
+  } catch (error: unknown) {
+    const { message } = error as { message: string };
+    return {
+      error: message
+        ? new Error(message)
+        : new Error('Unexpected error in handleClientUpload'),
+    };
   }
 }

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -1,6 +1,6 @@
 export { isNode, loadEnv, missingConfigError } from './config';
 export type { TigrisResponse } from './types';
-export { executeWithConcurrency, handleError } from './utils';
+export { executeWithConcurrency, handleError, toError } from './utils';
 export { TigrisHeaders } from './headers';
 export {
   createTigrisHttpClient,

--- a/shared/utils.ts
+++ b/shared/utils.ts
@@ -31,6 +31,12 @@ export async function executeWithConcurrency<T>(
   return results;
 }
 
+export function toError(value: unknown): Error {
+  if (value instanceof Error) return value;
+  if (typeof value === 'string') return new Error(value);
+  return new Error('An unexpected error occurred');
+}
+
 export const handleError = (error: Error) => {
   let errorMessage: string | undefined;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to error handling/wrapping in storage upload helpers and add a small shared `toError` utility; main behavior change is returning structured errors instead of throwing.
> 
> **Overview**
> Prevents server-side upload helpers from throwing by **normalizing unknown exceptions into `Error` responses**.
> 
> Adds shared `toError` and uses it in `handleClientUpload`, `put`, and `initMultipartUpload` to wrap/catch failures (including adding more descriptive multipart-init errors), so callers consistently receive `{ error: Error }` rather than uncaught exceptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9474601fd90e1bae111f523833c0f2e8cb5e05be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->