### PR TITLE
fix(storage): bundle input and response

### DIFF
--- a/packages/storage/src/lib/object/bundle.test.ts
+++ b/packages/storage/src/lib/object/bundle.test.ts
@@ -117,6 +117,27 @@ describe('bundle', () => {
     expect(result.data?.body.getReader).toBeDefined();
   });
 
+  it('returns error when response has no body', async () => {
+    globalThis.fetch = vi.fn(async () => {
+      return new Response(null, {
+        status: 200,
+        headers: { 'content-type': 'application/x-tar' },
+      });
+    }) as typeof fetch;
+
+    const result = await bundle(['a.jpg'], {
+      config: {
+        bucket: 'my-bucket',
+        endpoint: 'https://test.endpoint.dev',
+        accessKeyId: 'test-key',
+        secretAccessKey: 'test-secret',
+      },
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.data).toBeUndefined();
+  });
+
   it('sends custom compression and error mode', async () => {
     let capturedInit: RequestInit | undefined;
 

--- a/packages/storage/src/lib/object/bundle.test.ts
+++ b/packages/storage/src/lib/object/bundle.test.ts
@@ -9,20 +9,37 @@ describe('bundle', () => {
     vi.restoreAllMocks();
   });
 
-  it('returns error for empty bucket name', async () => {
-    const result = await bundle('', ['key1']);
+  it('returns error when bucket is not configured', async () => {
+    const result = await bundle(['key1'], {
+      config: {
+        bucket: '',
+        accessKeyId: 'test-key',
+        secretAccessKey: 'test-secret',
+      },
+    });
     expect(result.error).toBeDefined();
-    expect(result.error?.message).toContain('Bucket name is required');
   });
 
   it('returns error for empty keys', async () => {
-    const result = await bundle('my-bucket', []);
+    const result = await bundle([], {
+      config: {
+        bucket: 'my-bucket',
+        accessKeyId: 'test-key',
+        secretAccessKey: 'test-secret',
+      },
+    });
     expect(result.error).toBeDefined();
     expect(result.error?.message).toContain('At least one key is required');
   });
 
   it('returns error for undefined keys', async () => {
-    const result = await bundle('my-bucket', undefined as unknown as string[]);
+    const result = await bundle(undefined as unknown as string[], {
+      config: {
+        bucket: 'my-bucket',
+        accessKeyId: 'test-key',
+        secretAccessKey: 'test-secret',
+      },
+    });
     expect(result.error).toBeDefined();
     expect(result.error?.message).toContain('At least one key is required');
   });
@@ -40,8 +57,9 @@ describe('bundle', () => {
       });
     }) as typeof fetch;
 
-    const result = await bundle('my-bucket', ['a.jpg', 'b.jpg'], {
+    const result = await bundle(['a.jpg', 'b.jpg'], {
       config: {
+        bucket: 'my-bucket',
         endpoint: 'https://test.endpoint.dev',
         accessKeyId: 'test-key',
         secretAccessKey: 'test-secret',
@@ -75,6 +93,30 @@ describe('bundle', () => {
     expect(result.data?.contentType).toBe('application/x-tar');
   });
 
+  it('returns a ReadableStream body', async () => {
+    const stream = new ReadableStream();
+
+    globalThis.fetch = vi.fn(async () => {
+      return new Response(stream, {
+        status: 200,
+        headers: { 'content-type': 'application/x-tar' },
+      });
+    }) as typeof fetch;
+
+    const result = await bundle(['a.jpg'], {
+      config: {
+        bucket: 'my-bucket',
+        endpoint: 'https://test.endpoint.dev',
+        accessKeyId: 'test-key',
+        secretAccessKey: 'test-secret',
+      },
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.data?.body).toBeInstanceOf(ReadableStream);
+    expect(result.data?.body.getReader).toBeDefined();
+  });
+
   it('sends custom compression and error mode', async () => {
     let capturedInit: RequestInit | undefined;
 
@@ -86,10 +128,11 @@ describe('bundle', () => {
       });
     }) as typeof fetch;
 
-    const result = await bundle('my-bucket', ['x.txt'], {
+    const result = await bundle(['x.txt'], {
       compression: 'gzip',
       onError: 'fail',
       config: {
+        bucket: 'my-bucket',
         endpoint: 'https://test.endpoint.dev',
         accessKeyId: 'test-key',
         secretAccessKey: 'test-secret',
@@ -106,14 +149,16 @@ describe('bundle', () => {
 
   it('returns error on HTTP failure', async () => {
     globalThis.fetch = vi.fn(async () => {
-      return new Response('<Error><Code>InvalidArgument</Code></Error>', {
+      return new Response(JSON.stringify({ Message: 'Invalid request' }), {
         status: 400,
         statusText: 'Bad Request',
+        headers: { 'content-type': 'application/json' },
       });
     }) as typeof fetch;
 
-    const result = await bundle('my-bucket', ['a.jpg'], {
+    const result = await bundle(['a.jpg'], {
       config: {
+        bucket: 'my-bucket',
         endpoint: 'https://test.endpoint.dev',
         accessKeyId: 'test-key',
         secretAccessKey: 'test-secret',
@@ -121,28 +166,7 @@ describe('bundle', () => {
     });
 
     expect(result.error).toBeDefined();
-    expect(result.error?.message).toContain('HTTP 400');
     expect(result.data).toBeUndefined();
-  });
-
-  it('returns error when response has no body', async () => {
-    globalThis.fetch = vi.fn(async () => {
-      return new Response(null, {
-        status: 200,
-        headers: { 'content-type': 'application/x-tar' },
-      });
-    }) as typeof fetch;
-
-    const result = await bundle('my-bucket', ['a.jpg'], {
-      config: {
-        endpoint: 'https://test.endpoint.dev',
-        accessKeyId: 'test-key',
-        secretAccessKey: 'test-secret',
-      },
-    });
-
-    expect(result.error).toBeDefined();
-    expect(result.error?.message).toContain('No body');
   });
 
   it('uses session token auth when provided', async () => {
@@ -156,8 +180,9 @@ describe('bundle', () => {
       });
     }) as typeof fetch;
 
-    await bundle('my-bucket', ['a.jpg'], {
+    await bundle(['a.jpg'], {
       config: {
+        bucket: 'my-bucket',
         endpoint: 'https://test.endpoint.dev',
         sessionToken: 'my-session-token',
         organizationId: 'my-org',

--- a/packages/storage/src/lib/object/bundle.ts
+++ b/packages/storage/src/lib/object/bundle.ts
@@ -1,4 +1,4 @@
-import { TigrisHeaders } from '@shared/index';
+import { TigrisHeaders, toError } from '@shared/index';
 import { config, missingConfigError } from '../config';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
 import { createStorageClient } from '../http-client';
@@ -70,28 +70,33 @@ export async function bundle(
   const compression = options?.compression ?? 'none';
   const onError = options?.onError ?? 'skip';
 
-  const response = await storageHttpClient.request<unknown, ReadableStream>({
-    method: 'POST',
-    path: `/${bucket}`,
-    query: { bundle: '' },
-    body: { keys },
-    stream: true,
-    headers: {
-      'Content-Type': 'application/json',
-      [TigrisHeaders.BUNDLE_FORMAT]: 'tar',
-      [TigrisHeaders.BUNDLE_COMPRESSION]: compression,
-      [TigrisHeaders.BUNDLE_ON_ERROR]: onError,
-    },
-  });
+  try {
+    const response = await storageHttpClient.request<unknown, ReadableStream>({
+      method: 'POST',
+      path: `/${bucket}`,
+      query: { bundle: '' },
+      body: { keys },
+      stream: true,
+      headers: {
+        'Content-Type': 'application/json',
+        [TigrisHeaders.BUNDLE_FORMAT]: 'tar',
+        [TigrisHeaders.BUNDLE_COMPRESSION]: compression,
+        [TigrisHeaders.BUNDLE_ON_ERROR]: onError,
+      },
+    });
 
-  if (response.error) {
-    return { error: response.error };
+    if (response.error) {
+      return { error: response.error };
+    }
+
+    return {
+      data: {
+        body: response.data,
+        contentType:
+          response.headers.get('content-type') ?? 'application/x-tar',
+      },
+    };
+  } catch (error) {
+    return { error: toError(error) };
   }
-
-  return {
-    data: {
-      body: response.data,
-      contentType: response.headers.get('content-type') ?? 'application/x-tar',
-    },
-  };
 }

--- a/packages/storage/src/lib/object/bundle.ts
+++ b/packages/storage/src/lib/object/bundle.ts
@@ -1,6 +1,7 @@
-import { generateSignatureHeaders, TigrisHeaders } from '@shared/index';
-import { config } from '../config';
+import { TigrisHeaders } from '@shared/index';
+import { config, missingConfigError } from '../config';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
+import { createStorageClient } from '../http-client';
 
 export type BundleOptions = {
   config?: TigrisStorageConfig;
@@ -21,7 +22,7 @@ export type BundleOptions = {
 
 export type BundleResponse = {
   /** The streaming tar archive body. Caller is responsible for consuming and closing. */
-  body: ReadableStream<Uint8Array>;
+  body: ReadableStream;
   /** The response Content-Type (e.g. "application/x-tar", "application/gzip"). */
   contentType: string;
 };
@@ -46,98 +47,51 @@ export type BundleResponse = {
  * @param options - Optional configuration for compression and error handling.
  */
 export async function bundle(
-  bucketName: string,
   keys: string[],
   options?: BundleOptions
 ): Promise<TigrisStorageResponse<BundleResponse, Error>> {
-  if (!bucketName) {
-    return { error: new Error('Bucket name is required') };
+  const bucket = options?.config?.bucket ?? config.bucket;
+
+  if (!bucket) {
+    return missingConfigError('bucket');
   }
 
   if (!keys || keys.length === 0) {
     return { error: new Error('At least one key is required') };
   }
 
-  const endpoint =
-    options?.config?.endpoint ?? config.endpoint ?? 'https://t3.storage.dev';
-  const accessKeyId = options?.config?.accessKeyId ?? config.accessKeyId;
-  const secretAccessKey =
-    options?.config?.secretAccessKey ?? config.secretAccessKey;
-  const sessionToken = options?.config?.sessionToken ?? config.sessionToken;
-  const organizationId =
-    options?.config?.organizationId ?? config.organizationId;
+  const { data: storageHttpClient, error: storageHttpClientError } =
+    createStorageClient(options?.config);
+
+  if (storageHttpClientError) {
+    return { error: storageHttpClientError };
+  }
 
   const compression = options?.compression ?? 'none';
   const onError = options?.onError ?? 'skip';
 
-  try {
-    const url = new URL(`/${bucketName}`, endpoint);
-    url.searchParams.set('bundle', '');
-
-    const bodyString = JSON.stringify({ keys });
-
-    const headers: Record<string, string> = {
+  const response = await storageHttpClient.request<unknown, ReadableStream>({
+    method: 'POST',
+    path: `/${bucket}`,
+    query: { bundle: '' },
+    body: { keys },
+    stream: true,
+    headers: {
       'Content-Type': 'application/json',
       [TigrisHeaders.BUNDLE_FORMAT]: 'tar',
       [TigrisHeaders.BUNDLE_COMPRESSION]: compression,
       [TigrisHeaders.BUNDLE_ON_ERROR]: onError,
-    };
+    },
+  });
 
-    if (accessKeyId && secretAccessKey && !sessionToken) {
-      const signedHeaders = await generateSignatureHeaders(
-        'POST',
-        url,
-        headers,
-        bodyString,
-        accessKeyId,
-        secretAccessKey
-      );
-      Object.assign(headers, signedHeaders);
-    } else {
-      if (sessionToken) {
-        headers[TigrisHeaders.SESSION_TOKEN] = sessionToken;
-      }
-      if (organizationId) {
-        headers[TigrisHeaders.NAMESPACE] = organizationId;
-      }
-    }
-    const response = await fetch(url.toString(), {
-      method: 'POST',
-      headers,
-      body: bodyString,
-    });
-
-    if (!response.ok) {
-      let errorMessage: string;
-      try {
-        const text = await response.text();
-        errorMessage = text || response.statusText;
-      } catch {
-        errorMessage = response.statusText;
-      }
-      return {
-        error: new Error(
-          `Bundle request failed (HTTP ${response.status}): ${errorMessage}`
-        ),
-      };
-    }
-
-    if (!response.body) {
-      return { error: new Error('No body returned from bundle request') };
-    }
-
-    return {
-      data: {
-        body: response.body,
-        contentType:
-          response.headers.get('content-type') ?? 'application/x-tar',
-      },
-    };
-  } catch (error) {
-    return {
-      error: new Error(
-        `Bundle request failed: ${(error as Error).message ?? 'Unknown error'}`
-      ),
-    };
+  if (response.error) {
+    return { error: response.error };
   }
+
+  return {
+    data: {
+      body: response.data,
+      contentType: response.headers.get('content-type') ?? 'application/x-tar',
+    },
+  };
 }

--- a/packages/storage/src/lib/object/bundle.ts
+++ b/packages/storage/src/lib/object/bundle.ts
@@ -35,16 +35,16 @@ export type BundleResponse = {
  *
  * @example
  * ```ts
- * const result = await bundle("my-bucket", ["img_001.jpg", "img_002.jpg"]);
+ * const result = await bundle(["img_001.jpg", "img_002.jpg"], {
+ *   config: { bucket: "my-bucket" },
+ * });
  * if (result.error) throw result.error;
  *
- * // Pipe to file, or process with a tar library
  * const reader = result.data.body.getReader();
  * ```
  *
- * @param bucketName - The bucket containing the objects.
  * @param keys - Array of object keys to include in the bundle (max 5,000).
- * @param options - Optional configuration for compression and error handling.
+ * @param options - Optional configuration including bucket, compression, and error handling.
  */
 export async function bundle(
   keys: string[],

--- a/shared/http-client.ts
+++ b/shared/http-client.ts
@@ -9,6 +9,8 @@ export interface HttpClientRequest<T = unknown> {
   headers?: Record<string, string>;
   body?: T;
   query?: Record<string, string | number | boolean>;
+  /** Return the raw response body as a ReadableStream instead of parsing it. */
+  stream?: boolean;
 }
 
 export type HttpClientResponse<T = unknown> =
@@ -199,12 +201,16 @@ export function createTigrisHttpClient(
       }
 
       let data: TResponse;
-      const contentType = response.headers.get('content-type');
 
-      if (contentType && contentType.includes('application/json')) {
-        data = (await response.json()) as TResponse;
+      if (req.stream) {
+        data = response.body as TResponse;
       } else {
-        data = (await response.text()) as TResponse;
+        const contentType = response.headers.get('content-type');
+        if (contentType && contentType.includes('application/json')) {
+          data = (await response.json()) as TResponse;
+        } else {
+          data = (await response.text()) as TResponse;
+        }
       }
 
       return {

--- a/shared/http-client.ts
+++ b/shared/http-client.ts
@@ -203,6 +203,14 @@ export function createTigrisHttpClient(
       let data: TResponse;
 
       if (req.stream) {
+        if (!response.body) {
+          return {
+            status: response.status,
+            statusText: response.statusText,
+            headers: response.headers,
+            error: new Error('No body returned from stream request'),
+          };
+        }
         data = response.body as TResponse;
       } else {
         const contentType = response.headers.get('content-type');


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk due to a breaking `bundle()` signature change and new streaming-path handling in the shared HTTP client, which could affect existing callers and error handling behavior.
> 
> **Overview**
> `bundle()` now takes only `keys` plus an options object (bucket comes from `options.config.bucket` or global config) and routes requests through `createStorageClient()` instead of manually building/singing `fetch` requests.
> 
> The shared HTTP client adds a `stream` mode to return the raw `ReadableStream` body (and error if missing), and `bundle()` surfaces client errors directly while returning `body` as a stream.
> 
> Tests are updated to match the new API and to cover stream body success, missing-body errors, and updated error response parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e6dc0d493f6712efd2b512f2ccdd4abe0fabf58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->