### PR TITLE
feat(storage)!: add pagination to listBucketSnapshots and remove deprecated fields

### DIFF
--- a/packages/storage/src/lib/bucket/create.ts
+++ b/packages/storage/src/lib/bucket/create.ts
@@ -3,11 +3,7 @@ import type { HttpRequest } from '@aws-sdk/types';
 import { TigrisHeaders } from '@shared/index';
 import { createTigrisClient } from '../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
-import {
-  availableRegions,
-  validateLocationValues,
-  validateRegions,
-} from './utils/regions';
+import { validateLocationValues } from './utils/regions';
 import type { BucketLocations, StorageClass } from './types';
 
 export type CreateBucketOptions = {
@@ -16,16 +12,6 @@ export type CreateBucketOptions = {
   sourceBucketSnapshot?: string;
   access?: 'public' | 'private';
   defaultTier?: StorageClass;
-  /**
-   * @deprecated This property is deprecated and will be removed in the next major version. Use locations instead.
-   * @see https://www.tigrisdata.com/docs/buckets/locations/
-   */
-  consistency?: 'strict' | 'default';
-  /**
-   * @deprecated This property is deprecated and will be removed in the next major version. Use locations instead.
-   * @see https://www.tigrisdata.com/docs/buckets/locations/
-   */
-  region?: string | string[];
   locations?: BucketLocations;
   config?: Omit<TigrisStorageConfig, 'bucket'>;
 };
@@ -48,20 +34,6 @@ export async function createBucket(
 
   if (error) {
     return { error };
-  }
-
-  if (options?.region && options?.region !== undefined) {
-    console.warn(
-      'The region property is deprecated and will be removed in the next major version. Use locations instead.'
-    );
-    if (!validateRegions(options.region)) {
-      return {
-        error: new Error(
-          'Invalid regions specified, possible values are: ' +
-            availableRegions.join(', ')
-        ),
-      };
-    }
   }
 
   if (options?.locations && options?.locations !== undefined) {
@@ -103,18 +75,6 @@ export async function createBucket(
       // Set storage class
       if (options?.defaultTier) {
         req.headers[TigrisHeaders.STORAGE_CLASS] = options.defaultTier;
-      }
-
-      // Set consistency level
-      if (options?.consistency === 'strict') {
-        req.headers[TigrisHeaders.CONSISTENT] = 'true';
-      }
-
-      // Set regions
-      if (options?.region && options?.region !== undefined) {
-        req.headers[TigrisHeaders.REGIONS] = Array.isArray(options.region)
-          ? options.region.join(',')
-          : options.region;
       }
 
       // Set locations

--- a/packages/storage/src/lib/bucket/info.ts
+++ b/packages/storage/src/lib/bucket/info.ts
@@ -16,25 +16,6 @@ export type GetBucketInfoOptions = {
 
 export type BucketInfoResponse = {
   isSnapshotEnabled: boolean;
-  /**
-   * @deprecated
-   * @see forkInfo.hasChildren
-   * This property is deprecated and will be removed in the next major version
-   */
-  hasForks: boolean;
-  /**
-   * @deprecated
-   * @see forkInfo.parents[0].bucketName
-   * This property is deprecated and will be removed in the next major version
-   */
-  sourceBucketName?: string;
-  /**
-   * @deprecated
-   * @see forkInfo.parents[0].snapshot
-   * This property is deprecated and will be removed in the next major version
-   */
-  sourceBucketSnapshot?: string;
-
   forkInfo:
     | {
         hasChildren: boolean;
@@ -120,10 +101,6 @@ export async function getBucketInfo(
 
     const data: BucketInfoResponse = {
       isSnapshotEnabled: response.data.type === 1,
-      hasForks: response.data.ForkInfo?.HasChildren ?? false,
-      sourceBucketName: response.data.ForkInfo?.Parents?.[0]?.BucketName,
-      sourceBucketSnapshot: response.data.ForkInfo?.Parents?.[0]?.Snapshot,
-
       forkInfo: response.data.ForkInfo
         ? {
             hasChildren: response.data.ForkInfo.HasChildren,

--- a/packages/storage/src/lib/bucket/snapshot.ts
+++ b/packages/storage/src/lib/bucket/snapshot.ts
@@ -7,17 +7,20 @@ import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
 
 export type ListBucketSnapshotsOptions = {
   config?: Omit<TigrisStorageConfig, 'bucket'>;
+  paginationToken?: string;
+  limit?: number;
 };
 
-export type ListBucketSnapshotsResponse = Array<{
+export type BucketSnapshot = {
   name?: string | undefined;
   version: string | undefined;
-  /**
-   * @deprecated Use name and version instead, will be removed in the next major version
-   */
-  snapshotName: string | undefined;
   creationDate: Date | undefined;
-}>;
+};
+
+export type ListBucketSnapshotsResponse = {
+  snapshots: BucketSnapshot[];
+  paginationToken?: string;
+};
 
 export async function listBucketSnapshots(
   options?: ListBucketSnapshotsOptions
@@ -50,7 +53,10 @@ export async function listBucketSnapshots(
     return { error: new Error('Source bucket name is required') };
   }
 
-  const command = new ListBucketsCommand({});
+  const command = new ListBucketsCommand({
+    ContinuationToken: options?.paginationToken,
+    MaxBuckets: options?.limit,
+  });
   command.middlewareStack.add(
     (next) => async (args) => {
       (args.request as HttpRequest).headers[TigrisHeaders.SNAPSHOT] =
@@ -65,16 +71,15 @@ export async function listBucketSnapshots(
       .send(command)
       .then((res) => {
         return {
-          data:
-            res.Buckets?.map((bucket) => ({
-              name: bucket.Name?.split('; name=')[1],
-              version: bucket.Name?.split(';')[0],
-              /**
-               * @deprecated Use name and version instead, will be removed in the next major version
-               */
-              snapshotName: bucket.Name,
-              creationDate: bucket.CreationDate,
-            })) ?? [],
+          data: {
+            snapshots:
+              res.Buckets?.map((bucket) => ({
+                name: bucket.Name?.split('; name=')[1],
+                version: bucket.Name?.split(';')[0],
+                creationDate: bucket.CreationDate,
+              })) ?? [],
+            paginationToken: res.ContinuationToken,
+          },
         };
       })
       .catch((error) => {
@@ -89,10 +94,6 @@ export async function listBucketSnapshots(
 
 export type CreateBucketSnapshotOptions = {
   name?: string;
-  /**
-   * @deprecated Use name instead, will be removed in the next major version
-   */
-  description?: string;
   config?: Omit<TigrisStorageConfig, 'bucket'>;
 };
 
@@ -136,8 +137,8 @@ export async function createBucketSnapshot(
   command.middlewareStack.add(
     (next) => async (args) => {
       let header = 'true';
-      if (options?.name ?? options?.description) {
-        header = `${header}; name=${options?.name ?? options?.description}`;
+      if (options?.name) {
+        header = `${header}; name=${options.name}`;
       }
       (args.request as HttpRequest).headers[TigrisHeaders.SNAPSHOT] = header;
       return next(args);

--- a/packages/storage/src/lib/bucket/update.ts
+++ b/packages/storage/src/lib/bucket/update.ts
@@ -22,11 +22,6 @@ export type UpdateBucketOptions = {
   allowObjectAcl?: boolean;
   disableDirectoryListing?: boolean;
   // storage settings
-  /**
-   * @deprecated This property is deprecated and will be removed in the next major version. Use locations instead.
-   * @see https://www.tigrisdata.com/docs/buckets/locations/
-   */
-  regions?: string | string[];
   locations?: BucketLocations;
   cacheControl?: string;
   customDomain?: string;
@@ -64,15 +59,6 @@ export async function updateBucket(
   }
 
   // storage settings
-  if (options?.regions !== undefined) {
-    console.warn(
-      'The regions property is deprecated and will be removed in the next major version. Use locations instead.'
-    );
-    body.object_regions = Array.isArray(options.regions)
-      ? options.regions.join(',')
-      : options.regions;
-  }
-
   if (options?.locations && options?.locations !== undefined) {
     const validation = validateLocationValues(options.locations);
     if (validation.valid) {

--- a/packages/storage/src/lib/bucket/utils/regions.ts
+++ b/packages/storage/src/lib/bucket/utils/regions.ts
@@ -4,18 +4,6 @@ import {
   type BucketLocations,
 } from '../types';
 
-export const availableRegions: string[] = [
-  ...multiRegions,
-  ...singleOrDualRegions,
-];
-
-export const validateRegions = (regions: string | string[]): boolean => {
-  if (Array.isArray(regions)) {
-    return regions.every((region) => availableRegions.includes(region));
-  }
-  return availableRegions.includes(regions);
-};
-
 export function validateLocationValues(
   locations: BucketLocations
 ): { valid: true } | { valid: false; error: string } {

--- a/packages/storage/src/lib/object/presigned-url.ts
+++ b/packages/storage/src/lib/object/presigned-url.ts
@@ -25,10 +25,6 @@ export type GetPresignedUrlOptions = {
    * Default is 3600 seconds (1 hour).
    */
   expiresIn?: number;
-  /**
-   @deprecated This property is deprecated and will be removed in the next major version.
-   */
-  contentType?: string;
   config?: TigrisStorageConfig;
 } & MethodOrOperation;
 

--- a/packages/storage/src/lib/upload/client.ts
+++ b/packages/storage/src/lib/upload/client.ts
@@ -31,10 +31,6 @@ export type UploadResponse = {
   contentType?: string;
   modified: Date;
   name: string;
-  /**
-   * @deprecated Use `name` instead. Will be removed in the next major version.
-   */
-  path?: string;
   size: number;
   url: string;
 };
@@ -83,7 +79,6 @@ async function uploadSingle(
       },
       body: JSON.stringify({
         name,
-        path: name,
         action: UploadAction.SinglepartInit,
         operation: 'put',
         contentType: options?.contentType ?? data.type,
@@ -158,7 +153,6 @@ async function uploadSingle(
             contentType: options?.contentType ?? data.type,
             modified: new Date(),
             name,
-            path: name,
             size: data.size,
             url: presignedUrl.replace('x-id=PutObject', 'x-id=GetObject'),
           },
@@ -199,7 +193,6 @@ async function uploadMultipart(
       },
       body: JSON.stringify({
         name,
-        path: name,
         action: UploadAction.MultipartInit,
         contentType: options?.contentType ?? data.type,
       }),
@@ -227,7 +220,6 @@ async function uploadMultipart(
       },
       body: JSON.stringify({
         name,
-        path: name,
         action: UploadAction.MultipartGetParts,
         uploadId,
         parts,
@@ -324,7 +316,6 @@ async function uploadMultipart(
       },
       body: JSON.stringify({
         name,
-        path: name,
         action: UploadAction.MultipartComplete,
         uploadId,
         partIds,
@@ -347,7 +338,6 @@ async function uploadMultipart(
         contentType: options?.contentType ?? data.type,
         modified: new Date(),
         name,
-        path: name,
         size: data.size,
         url: completeData?.url ?? '',
       },

--- a/packages/storage/src/lib/upload/server.ts
+++ b/packages/storage/src/lib/upload/server.ts
@@ -21,13 +21,12 @@ export async function handleClientUpload(
   request: ClientUploadRequest,
   config?: TigrisStorageConfig
 ): Promise<TigrisStorageResponse<unknown, Error>> {
-  const { action, name, contentType, uploadId, parts, partIds } = request;
+  const { action, name, uploadId, parts, partIds } = request;
 
   try {
     switch (action) {
       case UploadAction.SinglepartInit:
         return await getPresignedUrl(name, {
-          contentType,
           operation: 'put',
           expiresIn: 3600, // 1 hour
           config,

--- a/packages/storage/src/lib/upload/server.ts
+++ b/packages/storage/src/lib/upload/server.ts
@@ -11,6 +11,7 @@ import { toError } from '@shared/utils';
 export interface ClientUploadRequest {
   action: UploadAction;
   name: string;
+  /** @deprecated This property is no longer used by the server handler. Will be removed in the next major version. */
   contentType?: string;
   uploadId?: string;
   parts?: number[];

--- a/packages/storage/src/server.ts
+++ b/packages/storage/src/server.ts
@@ -38,6 +38,7 @@ export {
   listBucketSnapshots,
   type CreateBucketSnapshotOptions,
   type CreateBucketSnapshotResponse,
+  type BucketSnapshot,
   type ListBucketSnapshotsOptions,
   type ListBucketSnapshotsResponse,
 } from './lib/bucket/snapshot';

--- a/packages/storage/src/test/bucket-create.integration.test.ts
+++ b/packages/storage/src/test/bucket-create.integration.test.ts
@@ -139,16 +139,6 @@ describe.skipIf(skipTests)('createBucket Integration Tests', () => {
 
   // ── Validation errors ──
 
-  it('should return error for invalid region', async () => {
-    const result = await createBucket(testBucket('bad-region'), {
-      region: 'invalid-region',
-      config,
-    });
-
-    expect(result.error).toBeDefined();
-    expect(result.error?.message).toContain('Invalid regions specified');
-  });
-
   it('should return error for invalid location', async () => {
     const result = await createBucket(testBucket('bad-loc'), {
       locations: { type: 'single', values: 'invalid' as 'iad' },

--- a/shared/headers.ts
+++ b/shared/headers.ts
@@ -5,7 +5,7 @@ export enum TigrisHeaders {
   SESSION_TOKEN = 'x-amz-security-token',
   NAMESPACE = 'X-Tigris-Namespace',
   STORAGE_CLASS = 'X-Amz-Storage-Class',
-  CONSISTENT = 'X-Tigris-Consistent',
+
   REGIONS = 'X-Tigris-Regions',
   SNAPSHOT = 'X-Tigris-Snapshot',
   SNAPSHOT_VERSION = 'X-Tigris-Snapshot-Version',


### PR DESCRIPTION
add pagination to listBucketSnapshots and remove deprecated fields

Add paginationToken and limit support to listBucketSnapshots. Remove all deprecated fields across the storage package: snapshotName, description, consistency, region, regions, hasForks, sourceBucketName, sourceBucketSnapshot, contentType (presigned-url), and path (upload).

BREAKING CHANGE: listBucketSnapshots now returns { snapshots, paginationToken } instead of an array. Removed deprecated fields from CreateBucketOptions, UpdateBucketOptions, BucketInfoResponse, GetPresignedUrlOptions, CreateBucketSnapshotOptions, and UploadResponse.

Assisted-by: Claude Opus 4.6 via Claude Code


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces breaking API shape changes (notably `listBucketSnapshots` response) and removes previously accepted options/fields, requiring downstream updates; runtime logic changes are limited to snapshot listing pagination and header handling.
> 
> **Overview**
> Adds pagination support to `listBucketSnapshots` by accepting `paginationToken`/`limit`, forwarding them to S3 `ListBucketsCommand`, and returning `{ snapshots, paginationToken }` (with a new exported `BucketSnapshot` type) instead of an array.
> 
> Removes a set of deprecated fields and behaviors across the storage package: legacy bucket `region`/`regions` + consistency handling, deprecated fork fields on `BucketInfoResponse`, deprecated snapshot fields (`snapshotName`, snapshot `description`), deprecated `contentType` option for `getPresignedUrl`, and deprecated `path` field from upload client requests/responses; tests and headers are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 792a0b0e145990f7164dccfbad1ed3e09984cb9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->