### PR TITLE
chore(shared): fix the release config for breaking changes

### DIFF
--- a/release.config.base.cjs
+++ b/release.config.base.cjs
@@ -28,6 +28,7 @@ module.exports = (packageName) => {
             { scope: `!(${scope})`, type: 'perf', release: false },
             { scope: `!(${scope})`, type: 'refactor', release: false },
             { scope: `!(${scope})`, type: 'chore', release: false },
+            { scope: `!(${scope})`, breaking: true, release: false },
           ],
         },
       ],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes semantic-release commit analysis rules, which can alter versioning/publishing behavior across packages. Risk is mainly around missed or unexpected releases if breaking-change commits are scoped differently than assumed.
> 
> **Overview**
> Updates `release.config.base.cjs` semantic-release `releaseRules` to explicitly ignore *breaking-change* commits whose scope does **not** match the current package.
> 
> This prevents a breaking change in another package’s scope from triggering a major release for this package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cba432fdec2e00b33f477c46fbf2d07a4dc3e6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->