### PR TITLE
feat(iam): add key rotation and enhances policy management

### DIFF
--- a/packages/iam/src/index.ts
+++ b/packages/iam/src/index.ts
@@ -14,6 +14,15 @@ export {
   type ListAccessKeysResponse,
 } from './lib/access-key/list';
 export {
+  attachPolicyToAccessKey,
+  detachPolicyFromAccessKey,
+  listPoliciesForAccessKey,
+  type AttachPolicyToAccessKeyOptions,
+  type DetachPolicyFromAccessKeyOptions,
+  type ListPoliciesForAccessKeyOptions,
+  type ListPoliciesForAccessKeyResponse,
+} from './lib/access-key/policy';
+export {
   removeAccessKey,
   type RemoveAccessKeyOptions,
 } from './lib/access-key/remove';

--- a/packages/iam/src/index.ts
+++ b/packages/iam/src/index.ts
@@ -22,6 +22,11 @@ export {
   type RevokeAllBucketRolesOptions,
 } from './lib/access-key/revoke';
 export {
+  rotateAccessKey,
+  type RotateAccessKeyOptions,
+  type RotateAccessKeyResponse,
+} from './lib/access-key/rotate';
+export {
   createOrganization,
   type CreateOrganizationOptions,
   type CreateOrganizationResponse,

--- a/packages/iam/src/lib/access-key/list.ts
+++ b/packages/iam/src/lib/access-key/list.ts
@@ -56,7 +56,10 @@ export async function listAccessKeys(
   const formData = new URLSearchParams();
   formData.append('Action', 'ListAccessKeys');
   formData.append('MaxItems', options?.limit?.toString() ?? '1000');
-  formData.append('Marker', options?.paginationToken ?? '0');
+
+  if (options?.paginationToken) {
+    formData.append('Marker', options.paginationToken);
+  }
 
   const headers = {
     'Content-Type': 'application/x-www-form-urlencoded',

--- a/packages/iam/src/lib/access-key/policy.ts
+++ b/packages/iam/src/lib/access-key/policy.ts
@@ -131,10 +131,9 @@ export async function listPoliciesForAccessKey(
 
   return {
     data: {
-      paginationToken:
-        response.data.ListUserPoliciesResult.Marker !== ''
-          ? response.data.ListUserPoliciesResult.Marker
-          : undefined,
+      paginationToken: response.data.ListUserPoliciesResult.IsTruncated
+        ? response.data.ListUserPoliciesResult.Marker || undefined
+        : undefined,
       policies: response.data.ListUserPoliciesResult.PolicyNames ?? [],
     },
   };

--- a/packages/iam/src/lib/access-key/policy.ts
+++ b/packages/iam/src/lib/access-key/policy.ts
@@ -1,0 +1,141 @@
+import { createIAMClient, IAM_ENDPOINTS } from '../http-client';
+import { TigrisIAMConfig, TigrisIAMResponse } from '../types';
+
+export type AttachPolicyToAccessKeyOptions = {
+  config?: TigrisIAMConfig;
+};
+
+export async function attachPolicyToAccessKey(
+  accessKeyId: string,
+  policyArn: string,
+  options?: AttachPolicyToAccessKeyOptions
+): Promise<TigrisIAMResponse<void, Error>> {
+  const { data: client, error } = createIAMClient(options?.config);
+  if (error) {
+    return { error };
+  }
+
+  const formData = new URLSearchParams();
+  formData.append('PolicyArn', policyArn);
+  formData.append('UserName', accessKeyId);
+
+  const headers = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+    Accept: 'application/json',
+  };
+
+  const response = await client.request<URLSearchParams, unknown>({
+    method: 'POST',
+    path: IAM_ENDPOINTS.attachPolicy,
+    body: formData,
+    headers,
+  });
+
+  if (response.error) {
+    return { error: response.error };
+  }
+
+  return { data: undefined };
+}
+
+export type DetachPolicyFromAccessKeyOptions = {
+  config?: TigrisIAMConfig;
+};
+
+export async function detachPolicyFromAccessKey(
+  accessKeyId: string,
+  policyArn: string,
+  options?: DetachPolicyFromAccessKeyOptions
+): Promise<TigrisIAMResponse<void, Error>> {
+  const { data: client, error } = createIAMClient(options?.config);
+  if (error) {
+    return { error };
+  }
+
+  const formData = new URLSearchParams();
+  formData.append('PolicyArn', policyArn);
+  formData.append('UserName', accessKeyId);
+
+  const headers = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+    Accept: 'application/json',
+  };
+
+  const response = await client.request<URLSearchParams, unknown>({
+    method: 'POST',
+    path: IAM_ENDPOINTS.detachPolicy,
+    body: formData,
+    headers,
+  });
+
+  if (response.error) {
+    return { error: response.error };
+  }
+
+  return { data: undefined };
+}
+
+export type ListPoliciesForAccessKeyOptions = {
+  config?: TigrisIAMConfig;
+  paginationToken?: string;
+  limit?: number;
+};
+
+export type ListPoliciesForAccessKeyResponse = {
+  paginationToken?: string;
+  policies: string[]; // policy names
+};
+
+type ListPoliciesForAccessKeyApiResponse = {
+  ListUserPoliciesResult: {
+    IsTruncated: boolean;
+    Marker: string;
+    PolicyNames: string[];
+  };
+};
+
+export async function listPoliciesForAccessKey(
+  accessKeyId: string,
+  options?: ListPoliciesForAccessKeyOptions
+): Promise<TigrisIAMResponse<ListPoliciesForAccessKeyResponse, Error>> {
+  const { data: client, error } = createIAMClient(options?.config);
+  if (error) {
+    return { error };
+  }
+
+  const formData = new URLSearchParams();
+  formData.append('UserName', accessKeyId);
+  formData.append('MaxItems', options?.limit?.toString() ?? '1000');
+  if (options?.paginationToken) {
+    formData.append('Marker', options.paginationToken);
+  }
+
+  const headers = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+    Accept: 'application/json',
+  };
+
+  const response = await client.request<
+    URLSearchParams,
+    ListPoliciesForAccessKeyApiResponse
+  >({
+    method: 'POST',
+    path: IAM_ENDPOINTS.listPoliciesForAccessKey,
+    body: formData,
+    headers,
+  });
+
+  if (response.error) {
+    return { error: response.error };
+  }
+
+  return {
+    data: {
+      paginationToken:
+        response.data.ListUserPoliciesResult.Marker !== ''
+          ? response.data.ListUserPoliciesResult.Marker
+          : undefined,
+      policies: response.data.ListUserPoliciesResult.PolicyNames ?? [],
+    },
+  };
+}

--- a/packages/iam/src/lib/access-key/rotate.ts
+++ b/packages/iam/src/lib/access-key/rotate.ts
@@ -1,0 +1,64 @@
+import { createIAMClient, IAM_ENDPOINTS } from '../http-client';
+import { TigrisIAMConfig, TigrisIAMResponse } from '../types';
+
+export type RotateAccessKeyOptions = {
+  config?: TigrisIAMConfig;
+};
+
+export type RotateAccessKeyResponse = {
+  id: string;
+  newSecret: string;
+};
+
+type IAMRotateAccessKeyResponse = {
+  message: string;
+  rotate_access_key_result: {
+    id: string;
+    new_secret: string;
+  };
+  status: string;
+};
+
+export async function rotateAccessKey(
+  accessKeyId: string,
+  options?: RotateAccessKeyOptions
+): Promise<TigrisIAMResponse<RotateAccessKeyResponse, Error>> {
+  const { data: client, error } = createIAMClient(options?.config);
+  if (error) {
+    return { error };
+  }
+
+  const formData = new URLSearchParams();
+  formData.append('Action', 'RotateAccessKey');
+  formData.append('AccessKeyId', accessKeyId);
+
+  const headers = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+    Accept: 'application/json',
+  };
+
+  const response = await client.request<
+    URLSearchParams,
+    IAMRotateAccessKeyResponse
+  >({
+    method: 'POST',
+    path: IAM_ENDPOINTS.rotateAccessKey,
+    body: formData,
+    headers,
+  });
+
+  if (response.error || response.data?.status !== 'success') {
+    return {
+      error:
+        response.error ??
+        new Error(response.data?.message ?? 'Unable to rotate access key'),
+    };
+  }
+
+  return {
+    data: {
+      id: response.data?.rotate_access_key_result.id,
+      newSecret: response.data?.rotate_access_key_result.new_secret,
+    },
+  };
+}

--- a/packages/iam/src/lib/access-key/rotate.ts
+++ b/packages/iam/src/lib/access-key/rotate.ts
@@ -55,10 +55,14 @@ export async function rotateAccessKey(
     };
   }
 
-  return {
-    data: {
-      id: response.data?.rotate_access_key_result.id,
-      newSecret: response.data?.rotate_access_key_result.new_secret,
-    },
-  };
+  const id = response.data?.rotate_access_key_result?.id;
+  const newSecret = response.data?.rotate_access_key_result?.new_secret;
+
+  if (!id || !newSecret) {
+    return {
+      error: new Error('Invalid response: missing access key id or secret'),
+    };
+  }
+
+  return { data: { id, newSecret } };
 }

--- a/packages/iam/src/lib/http-client.ts
+++ b/packages/iam/src/lib/http-client.ts
@@ -28,6 +28,11 @@ export const IAM_ENDPOINTS = {
   editPolicy: '/?Action=UpdatePolicy',
   getPolicy: '/?Action=GetPolicyDetailed',
   listPolicies: '/?Action=ListPolicies',
+
+  // policy and access key
+  attachPolicy: '/?Action=AttachUserPolicy',
+  detachPolicy: '/?Action=DetachUserPolicy',
+  listPoliciesForAccessKey: '/?Action=ListUserPolicies',
 };
 
 function getIAMEndpoint(options?: TigrisIAMConfig): string {

--- a/packages/iam/src/lib/http-client.ts
+++ b/packages/iam/src/lib/http-client.ts
@@ -21,6 +21,7 @@ export const IAM_ENDPOINTS = {
   listAccessKeys: '/?Detailed',
   removeAccessKey: '/?Action=DeleteAccessKey',
   revokeAccessKey: '/?Action=UpdateAccessKeyWithBucketsRole',
+  rotateAccessKey: '/?Action=RotateAccessKey',
   // Policies
   addPolicy: '/?Action=CreatePolicy',
   deletePolicy: '/?Action=ForceDeletePolicy',

--- a/packages/iam/src/lib/policy/get.ts
+++ b/packages/iam/src/lib/policy/get.ts
@@ -9,7 +9,10 @@ export type GetPolicyOptions = {
 
 export type GetPolicyResponse = Policy & {
   document: PolicyDocument;
-  users: string[];
+  users: {
+    id: string;
+    name: string;
+  }[];
 };
 
 type GetPolicyApiResponse = {
@@ -27,7 +30,10 @@ type GetPolicyApiResponse = {
     PolicyName: string;
     Tags: null;
     UpdateDate: string;
-    Users: string[];
+    Users: {
+      UserId: string;
+      UserName: string;
+    }[];
   };
 };
 
@@ -100,7 +106,11 @@ export async function getPolicy(
       path: policy.Path,
       resource: policy.Arn,
       updateDate: new Date(policy.UpdateDate),
-      users: policy.Users ?? [],
+      users:
+        policy.Users?.map((user) => ({
+          id: user.UserId,
+          name: user.UserName,
+        })) ?? [],
     },
   };
 }

--- a/packages/iam/src/lib/policy/list.ts
+++ b/packages/iam/src/lib/policy/list.ts
@@ -45,7 +45,10 @@ export async function listPolicies(
 
   const formData = new URLSearchParams();
   formData.append('MaxItems', options?.limit?.toString() ?? '1000');
-  formData.append('Marker', options?.paginationToken ?? '0');
+
+  if (options?.paginationToken) {
+    formData.append('Marker', options.paginationToken);
+  }
 
   const headers = {
     'Content-Type': 'application/x-www-form-urlencoded',


### PR DESCRIPTION
## Summary

- Implement `rotateAccessKey` for rotating IAM access keys
- Add `attachKeyPolicy`, `detachKeyPolicy`, and `listKeyPolicies` methods for managing access key policy associations
- Fix pagination markers for list keys and list policies
- Fix `getPolicy` user output

## Test plan

- [ ] Run `npm test` and confirm all tests pass
- [ ] Test IAM key rotation flow end-to-end
- [ ] Test key-to-policy attach/detach/list operations
- [ ] Verify pagination works correctly for keys and policies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new IAM client operations for rotating access keys and attaching/detaching/listing policies, and changes pagination marker behavior; these touch credential/policy management flows and could affect permissions if the new endpoints or response parsing are incorrect.
> 
> **Overview**
> Adds new IAM SDK surface for **access key rotation** via `rotateAccessKey`, returning the rotated key id and newly-issued secret.
> 
> Introduces **access-key policy association** helpers (`attachPolicyToAccessKey`, `detachPolicyFromAccessKey`, `listPoliciesForAccessKey`) and wires new IAM endpoints for these operations.
> 
> Fixes pagination handling in `listAccessKeys` and `listPolicies` by only sending `Marker` when a token is provided (instead of defaulting to `'0'`), and adjusts `getPolicy` to return attached users as `{id, name}` objects rather than raw strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aba913103b9d502248fe6d0f80a49db5ee7399f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->