### PR TITLE
fix(storage): use correct header in isMigrated

### DIFF
--- a/packages/storage/src/lib/object/migrate.ts
+++ b/packages/storage/src/lib/object/migrate.ts
@@ -84,7 +84,9 @@ export async function isMigrated(
       .send(head)
       .then(async () => {
         return {
-          data: TigrisHeaders.SERVED_FROM.toLowerCase() in responseHeaders,
+          data:
+            responseHeaders[TigrisHeaders.READ_SOURCE]?.toLowerCase() !==
+            'block_shadow',
         };
       })
       .catch(handleError);

--- a/packages/storage/src/lib/object/migrate.ts
+++ b/packages/storage/src/lib/object/migrate.ts
@@ -85,7 +85,7 @@ export async function isMigrated(
       .then(async () => {
         return {
           data:
-            responseHeaders[TigrisHeaders.READ_SOURCE]?.toLowerCase() !==
+            responseHeaders[TigrisHeaders.READ_SOURCE.toLowerCase()]?.toLowerCase() !==
             'block_shadow',
         };
       })

--- a/shared/headers.ts
+++ b/shared/headers.ts
@@ -9,6 +9,7 @@ export enum TigrisHeaders {
   BUCKET_LIST_SOURCE = 'X-Tigris-List-Source', // tigris or shadow
   SCHEDULE_MIGRATION = 'X-Tigris-Schedule-Migration',
   SERVED_FROM = 'X-Tigris-Served-From',
+  READ_SOURCE = 'X-Tigris-Read-Source',
 
   REGIONS = 'X-Tigris-Regions',
   SNAPSHOT = 'X-Tigris-Snapshot',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the logic that decides whether an object is considered migrated, which can affect read routing/behavior for storage objects. Risk is limited in scope but could cause incorrect migration state detection if upstream header values differ from expectations.
> 
> **Overview**
> Updates `isMigrated` to determine migration status by reading `X-Tigris-Read-Source` from the `HeadObject` response and treating `block_shadow` as *not migrated*, replacing the prior check that inferred migration from the presence of `X-Tigris-Served-From`.
> 
> Adds the new `TigrisHeaders.READ_SOURCE` enum value to standardize use of this header across the codebase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32c3ccee7a00613fb7f15845a2ecabdfde819da4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->