### PR TITLE
fix(agent-kit): rename sandbox to forks

### DIFF
--- a/packages/agent-kit/README.md
+++ b/packages/agent-kit/README.md
@@ -30,28 +30,28 @@ const config = {
 
 All functions return a `TigrisResponse<T>` — a discriminated union of `{ data: T }` or `{ error: Error }`.
 
-## Storage Sandboxes
+## Forks
 
 Give each agent its own isolated copy of a shared dataset using copy-on-write storage forks. Each fork is an independent bucket — agents can read and write freely without affecting the original data or each other. Forks are instant at any size with zero data duplication.
 
 ```typescript
-import { createSandbox, teardownSandbox } from '@tigrisdata/agent-kit';
+import { createForks, teardownForks } from '@tigrisdata/agent-kit';
 
 // 'my-dataset' must have snapshots enabled
-const { data: sandbox, error } = await createSandbox('my-dataset', 3, {
+const { data: forkSet, error } = await createForks('my-dataset', 3, {
   prefix: 'experiment-run-42',    // optional, controls fork bucket names
   credentials: { role: 'Editor' }, // optional, creates scoped keys per fork
 });
 
 // Each fork is its own bucket with isolated storage
-for (const fork of sandbox.forks) {
+for (const fork of forkSet.forks) {
   console.log(fork.bucket);
   // fork.credentials?.accessKeyId
   // fork.credentials?.secretAccessKey
 }
 
 // Clean up — revokes credentials, deletes all fork buckets
-await teardownSandbox(sandbox);
+await teardownForks(forkSet);
 ```
 
 ## Workspaces
@@ -122,12 +122,12 @@ await teardownCoordination('pipeline-bucket');
 
 ## API Reference
 
-### Storage Sandboxes
+### Forks
 
 | Function | Description |
 |---|---|
-| `createSandbox(baseBucket, count, options?)` | Snapshot + fork N times + scoped credentials |
-| `teardownSandbox(sandbox, options?)` | Revoke credentials + delete forks |
+| `createForks(baseBucket, count, options?)` | Snapshot + fork N times + scoped credentials |
+| `teardownForks(forkSet, options?)` | Revoke credentials + delete forks |
 
 ### Workspaces
 

--- a/packages/agent-kit/package.json
+++ b/packages/agent-kit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tigrisdata/agent-kit",
   "version": "0.0.1",
-  "description": "Composed workflows for AI agents on Tigris — sandboxes, workspaces, checkpoints, and coordination",
+  "description": "Composed workflows for AI agents on Tigris — forks, workspaces, checkpoints, and coordination",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -43,7 +43,7 @@
     "agents",
     "tigris",
     "storage",
-    "sandbox",
+    "forks",
     "checkpoint"
   ],
   "author": "Tigris Data",

--- a/packages/agent-kit/src/forks.ts
+++ b/packages/agent-kit/src/forks.ts
@@ -10,8 +10,8 @@ import { toStorageConfig, toIAMConfig } from './config';
 
 // -- Types --
 
-export type CreateSandboxOptions = {
-  /** Prefix for fork bucket names. Defaults to `${baseBucket}-sandbox-${timestamp}`. */
+export type CreateForksOptions = {
+  /** Prefix for fork bucket names. Defaults to `${baseBucket}-fork-${timestamp}`. */
   prefix?: string;
   /** If provided, creates a scoped access key per fork with this role. */
   credentials?: {
@@ -20,7 +20,7 @@ export type CreateSandboxOptions = {
   config?: TigrisAgentKitConfig;
 };
 
-export type SandboxFork = {
+export type Fork = {
   bucket: string;
   credentials?: {
     accessKeyId: string;
@@ -28,23 +28,23 @@ export type SandboxFork = {
   };
 };
 
-export type Sandbox = {
+export type Forks = {
   baseBucket: string;
   snapshotId: string;
-  forks: SandboxFork[];
+  forks: Fork[];
 };
 
-export type TeardownSandboxOptions = {
+export type TeardownForksOptions = {
   config?: TigrisAgentKitConfig;
 };
 
 // -- Functions --
 
-export async function createSandbox(
+export async function createForks(
   baseBucket: string,
   count: number,
-  options?: CreateSandboxOptions
-): Promise<TigrisResponse<Sandbox>> {
+  options?: CreateForksOptions
+): Promise<TigrisResponse<Forks>> {
   const { prefix, credentials, config } = options ?? {};
   const storageConfig = toStorageConfig(config);
   const iamConfig = toIAMConfig(config);
@@ -63,8 +63,8 @@ export async function createSandbox(
   }
 
   const snapshotId = snapshotResult.data.snapshotVersion;
-  const forkPrefix = prefix ?? `${baseBucket}-sandbox-${Date.now()}`;
-  const forks: SandboxFork[] = [];
+  const forkPrefix = prefix ?? `${baseBucket}-fork-${Date.now()}`;
+  const forks: Fork[] = [];
 
   // Step 2: Create forks with optional scoped credentials
   for (let i = 0; i < count; i++) {
@@ -81,7 +81,7 @@ export async function createSandbox(
       break;
     }
 
-    const fork: SandboxFork = { bucket: forkName };
+    const fork: Fork = { bucket: forkName };
 
     if (credentials) {
       const keyResult = await createAccessKey(`${forkName}-key`, {
@@ -102,7 +102,7 @@ export async function createSandbox(
 
   if (forks.length === 0) {
     return {
-      error: new Error('Failed to create any forks for sandbox'),
+      error: new Error('Failed to create any forks'),
     };
   }
 
@@ -115,15 +115,15 @@ export async function createSandbox(
   };
 }
 
-export async function teardownSandbox(
-  sandbox: Sandbox,
-  options?: TeardownSandboxOptions
+export async function teardownForks(
+  forkSet: Forks,
+  options?: TeardownForksOptions
 ): Promise<TigrisResponse<void>> {
   const storageConfig = toStorageConfig(options?.config);
   const iamConfig = toIAMConfig(options?.config);
   const errors: string[] = [];
 
-  for (const fork of sandbox.forks) {
+  for (const fork of forkSet.forks) {
     // Revoke credentials first
     if (fork.credentials) {
       const keyResult = await removeAccessKey(fork.credentials.accessKeyId, {
@@ -151,7 +151,7 @@ export async function teardownSandbox(
   if (errors.length > 0) {
     return {
       error: new Error(
-        `Sandbox teardown completed with errors:\n${errors.join('\n')}`
+        `Fork teardown completed with errors:\n${errors.join('\n')}`
       ),
     };
   }

--- a/packages/agent-kit/src/index.ts
+++ b/packages/agent-kit/src/index.ts
@@ -1,11 +1,11 @@
-// Sandbox — isolated copy-on-write forks for parallel agent work
-export { createSandbox, teardownSandbox } from './sandbox';
+// Forks — isolated copy-on-write forks for parallel agent work
+export { createForks, teardownForks } from './forks';
 export type {
-  CreateSandboxOptions,
-  Sandbox,
-  SandboxFork,
-  TeardownSandboxOptions,
-} from './sandbox';
+  CreateForksOptions,
+  Forks,
+  Fork,
+  TeardownForksOptions,
+} from './forks';
 
 // Workspace — single-agent working area with optional TTL and credentials
 export { createWorkspace, teardownWorkspace } from './workspace';

--- a/packages/agent-kit/test/integration.test.ts
+++ b/packages/agent-kit/test/integration.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { put, get, removeBucket, getBucketInfo } from '@tigrisdata/storage';
 import { createWorkspace, teardownWorkspace } from '../src/workspace';
-import { createSandbox, teardownSandbox } from '../src/sandbox';
-import type { Sandbox } from '../src/sandbox';
+import { createForks, teardownForks } from '../src/forks';
+import type { Forks } from '../src/forks';
 import { checkpoint, restore, listCheckpoints } from '../src/checkpoint';
 import { setupCoordination, teardownCoordination } from '../src/coordination';
 import type { Workspace } from '../src/workspace';
@@ -182,16 +182,16 @@ describe.skipIf(skipTests)('checkpoint / restore / listCheckpoints', () => {
   });
 });
 
-// ── Sandbox ──
+// ── Forks ──
 
-describe.skipIf(skipTests)('createSandbox / teardownSandbox', () => {
-  let sandbox: Sandbox | undefined;
+describe.skipIf(skipTests)('createForks / teardownForks', () => {
+  let forkSet: Forks | undefined;
   const extraBucketsToCleanup: string[] = [];
 
   afterEach(async () => {
-    if (sandbox) {
-      await teardownSandbox(sandbox);
-      sandbox = undefined;
+    if (forkSet) {
+      await teardownForks(forkSet);
+      forkSet = undefined;
     }
     for (const bucket of extraBucketsToCleanup) {
       await removeBucket(bucket, { force: true });
@@ -199,9 +199,9 @@ describe.skipIf(skipTests)('createSandbox / teardownSandbox', () => {
     extraBucketsToCleanup.length = 0;
   });
 
-  it('should create a sandbox with multiple forks', async () => {
+  it('should create forks from a base bucket', async () => {
     // Create a base bucket with snapshots and data
-    const baseBucket = uniqueName('sandbox-base');
+    const baseBucket = uniqueName('forks-base');
     const wsResult = await createWorkspace(baseBucket, {
       enableSnapshots: true,
     });
@@ -212,18 +212,18 @@ describe.skipIf(skipTests)('createSandbox / teardownSandbox', () => {
       config: { bucket: baseBucket },
     });
 
-    // Create sandbox with 2 forks
-    const result = await createSandbox(baseBucket, 2, {
-      prefix: uniqueName('sandbox-fork'),
+    // Create 2 forks
+    const result = await createForks(baseBucket, 2, {
+      prefix: uniqueName('fork'),
     });
 
     expect(result.error).toBeUndefined();
     expect(result.data!.forks).toHaveLength(2);
     expect(result.data!.snapshotId).toBeTruthy();
-    sandbox = result.data!;
+    forkSet = result.data!;
 
     // Verify each fork has the data from the base bucket
-    for (const fork of sandbox.forks) {
+    for (const fork of forkSet.forks) {
       const getResult = await get('dataset.json', 'string', {
         config: { bucket: fork.bucket },
       });
@@ -233,40 +233,40 @@ describe.skipIf(skipTests)('createSandbox / teardownSandbox', () => {
 
     // Verify forks are isolated — write to fork 0, fork 1 unchanged
     await put('fork-0-only.txt', 'only in fork 0', {
-      config: { bucket: sandbox.forks[0].bucket },
+      config: { bucket: forkSet.forks[0].bucket },
     });
 
     const fork1Check = await get('fork-0-only.txt', 'string', {
-      config: { bucket: sandbox.forks[1].bucket },
+      config: { bucket: forkSet.forks[1].bucket },
     });
     expect(fork1Check.error).toBeDefined();
   });
 
-  it('should create a sandbox with scoped credentials per fork', async () => {
-    const baseBucket = uniqueName('sandbox-creds');
+  it('should create forks with scoped credentials', async () => {
+    const baseBucket = uniqueName('forks-creds');
     const wsResult = await createWorkspace(baseBucket, {
       enableSnapshots: true,
     });
     expect(wsResult.error).toBeUndefined();
     extraBucketsToCleanup.push(baseBucket);
 
-    const result = await createSandbox(baseBucket, 2, {
-      prefix: uniqueName('sandbox-cfork'),
+    const result = await createForks(baseBucket, 2, {
+      prefix: uniqueName('fork-cred'),
       credentials: { role: 'Editor' },
     });
 
     expect(result.error).toBeUndefined();
-    sandbox = result.data!;
+    forkSet = result.data!;
 
     // Each fork should have its own credentials
-    for (const fork of sandbox.forks) {
+    for (const fork of forkSet.forks) {
       expect(fork.credentials).toBeDefined();
       expect(fork.credentials!.accessKeyId).toBeTruthy();
       expect(fork.credentials!.secretAccessKey).toBeTruthy();
     }
 
     // Verify scoped credentials can write to their own fork
-    const fork = sandbox.forks[0];
+    const fork = forkSet.forks[0];
     const putResult = await put('scoped-write.txt', 'written with scoped key', {
       config: {
         bucket: fork.bucket,
@@ -277,25 +277,25 @@ describe.skipIf(skipTests)('createSandbox / teardownSandbox', () => {
     expect(putResult.error).toBeUndefined();
   });
 
-  it('should teardown a sandbox cleanly', async () => {
-    const baseBucket = uniqueName('sandbox-td');
+  it('should teardown forks cleanly', async () => {
+    const baseBucket = uniqueName('forks-td');
     const wsResult = await createWorkspace(baseBucket, {
       enableSnapshots: true,
     });
     expect(wsResult.error).toBeUndefined();
     extraBucketsToCleanup.push(baseBucket);
 
-    const result = await createSandbox(baseBucket, 2, {
-      prefix: uniqueName('sandbox-tdfork'),
+    const result = await createForks(baseBucket, 2, {
+      prefix: uniqueName('fork-td'),
       credentials: { role: 'Editor' },
     });
     expect(result.error).toBeUndefined();
-    const sbx = result.data!;
+    const created = result.data!;
 
-    const forkBuckets = sbx.forks.map((f) => f.bucket);
+    const forkBuckets = created.forks.map((f) => f.bucket);
 
     // Teardown
-    const teardown = await teardownSandbox(sbx);
+    const teardown = await teardownForks(created);
     expect(teardown.error).toBeUndefined();
 
     // Verify forks are deleted
@@ -304,8 +304,8 @@ describe.skipIf(skipTests)('createSandbox / teardownSandbox', () => {
       expect(info.error).toBeDefined();
     }
 
-    // sandbox is cleaned up, don't double-teardown in afterEach
-    sandbox = undefined;
+    // Forks cleaned up, don't double-teardown in afterEach
+    forkSet = undefined;
   });
 });
 

--- a/packages/storage/src/lib/object/migrate.ts
+++ b/packages/storage/src/lib/object/migrate.ts
@@ -85,8 +85,9 @@ export async function isMigrated(
       .then(async () => {
         return {
           data:
-            responseHeaders[TigrisHeaders.READ_SOURCE.toLowerCase()]?.toLowerCase() !==
-            'block_shadow',
+            responseHeaders[
+              TigrisHeaders.READ_SOURCE.toLowerCase()
+            ]?.toLowerCase() !== 'block_shadow',
         };
       })
       .catch(handleError);


### PR DESCRIPTION
## Summary

- Rename all "sandbox" references to "forks" across `@tigrisdata/agent-kit`
- Aligns with Tigris terminology used in CLI (`tigris forks create`), docs, and SDK
- Avoids confusion with compute sandboxes

### What changed

| Before | After |
|---|---|
| `createSandbox` | `createForks` |
| `teardownSandbox` | `teardownForks` |
| `Sandbox` | `Forks` |
| `SandboxFork` | `Fork` |
| `CreateSandboxOptions` | `CreateForksOptions` |
| `TeardownSandboxOptions` | `TeardownForksOptions` |
| `sandbox.ts` | `forks.ts` |

Updated: source, types, tests, README, package.json

## Test plan

- [x] `npm run build` — all packages build
- [x] `npm run lint` — no lint errors
- [x] `npm run format:check` — all formatted
- [x] `npm test` — 11/11 agent-kit tests passing
- [x] Zero instances of "sandbox" remaining in agent-kit package


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily a terminology/API rename, but it is a breaking change for consumers importing `createSandbox`/`Sandbox` types. Runtime logic is effectively unchanged aside from default fork name prefix and updated error messages.
> 
> **Overview**
> Renames the Agent Kit copy-on-write “sandbox” workflow to **Forks**, updating the public API (`createForks`/`teardownForks`, `Forks`/`Fork` and option types), barrel exports, and all README/package metadata references.
> 
> Updates integration tests to use the new names and tweaks fork bucket default prefix and related error/teardown messaging; also includes a small formatting-only change in `storage`’s `migrate.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4646cf8e429a9a0bf4d7d71300f7f9cc96114d01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->