### PR TITLE
feat(storage): add forcePathStyle in storage config

### DIFF
--- a/packages/storage/src/lib/tigris-client.ts
+++ b/packages/storage/src/lib/tigris-client.ts
@@ -14,6 +14,7 @@ export function createTigrisClient(
   const secretAccessKey = options?.secretAccessKey ?? config.secretAccessKey;
   const endpoint = options?.endpoint ?? config.endpoint;
   const bucket = options?.bucket ?? config.bucket;
+  const forcePathStyle = options?.forcePathStyle ?? false;
 
   if (
     options?.credentialProvider !== undefined &&
@@ -59,6 +60,10 @@ export function createTigrisClient(
     key = `${options.sessionToken}-${options.organizationId}-${endpoint}`;
   }
 
+  if (forcePathStyle) {
+    key = `${key}-forcePathStyle`;
+  }
+
   if (key) {
     const cachedClient = cachedClients.get(key);
     if (cachedClient !== undefined) {
@@ -78,6 +83,7 @@ export function createTigrisClient(
     credentials,
     region: 'auto',
     endpoint: endpoint ?? 'https://t3.storage.dev',
+    forcePathStyle,
   });
 
   if (

--- a/packages/storage/src/lib/tigris-client.ts
+++ b/packages/storage/src/lib/tigris-client.ts
@@ -60,7 +60,7 @@ export function createTigrisClient(
     key = `${options.sessionToken}-${options.organizationId}-${endpoint}`;
   }
 
-  if (forcePathStyle) {
+  if (key && forcePathStyle) {
     key = `${key}-forcePathStyle`;
   }
 

--- a/packages/storage/src/lib/types.ts
+++ b/packages/storage/src/lib/types.ts
@@ -7,6 +7,7 @@ export type TigrisStorageConfig = {
   endpoint?: string;
   sessionToken?: string;
   organizationId?: string;
+  forcePathStyle?: boolean;
   credentialProvider?: () => Promise<{
     accessKeyId: string;
     secretAccessKey: string;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, additive configuration change; risk is limited to altered S3 request addressing when `forcePathStyle` is enabled and potential cache behavior differences for callers toggling it.
> 
> **Overview**
> Adds optional `forcePathStyle` to `TigrisStorageConfig` and wires it through `createTigrisClient` to pass `forcePathStyle` into the underlying AWS `S3Client` constructor.
> 
> Updates client caching so `forcePathStyle` becomes part of the cache key, preventing reuse of a cached client created with different addressing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c527238437ab83a30a55c225179feb1d7c5b8082. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->