### PR TITLE
feat(storage): add types for bucket notification webhook payloads

### DIFF
--- a/packages/storage/src/lib/bucket/types.ts
+++ b/packages/storage/src/lib/bucket/types.ts
@@ -105,6 +105,62 @@ export type BucketNotification =
   | BucketNotificationBasicAuth
   | BucketNotificationTokenAuth;
 
+/**
+ * Recognized event types Tigris fires for object notifications.
+ *
+ * The union is open — when Tigris adds new event types, consumers
+ * keep autocomplete on the known values without crashing on unknowns.
+ * See https://www.tigrisdata.com/docs/buckets/object-notifications/
+ */
+export type NotificationEventName =
+  | 'OBJECT_CREATED_PUT'
+  | 'OBJECT_DELETED'
+  // Open-union pattern: `string & {}` preserves autocomplete on the
+  // literal members above while still accepting future event types
+  // Tigris adds without a breaking change.
+  | (string & {});
+
+/**
+ * A single event in a bucket-notification webhook delivery. Mirrors the
+ * wire format Tigris POSTs to the configured webhook URL — no
+ * normalization, no flattening. Cast `await req.json()` to
+ * `NotificationResponse` (or run a runtime validator like Zod) at the
+ * receiving end and switch on `eventName`.
+ *
+ * See https://www.tigrisdata.com/docs/buckets/object-notifications/
+ */
+export type NotificationEvent = {
+  /** Schema version of the event payload. */
+  eventVersion: string;
+  /** Source identifier (`"tigris"` today). */
+  eventSource: string;
+  /** Event type. Open union: see {@link NotificationEventName}. */
+  eventName: NotificationEventName;
+  /** RFC 3339 timestamp the event occurred at. */
+  eventTime: string;
+  /** Bucket the object belongs to. */
+  bucket: string;
+  /** Object metadata. */
+  object: {
+    /** Object key inside the bucket. */
+    key: string;
+    /** Object size in bytes. */
+    size: number;
+    /** Object ETag (typically MD5 hex). */
+    eTag: string;
+  };
+};
+
+/**
+ * Top-level shape of a bucket-notification webhook POST body. A single
+ * delivery may carry multiple events — iterate `response.events`.
+ *
+ * See https://www.tigrisdata.com/docs/buckets/object-notifications/
+ */
+export type NotificationResponse = {
+  events: NotificationEvent[];
+};
+
 export type UpdateBucketResponse = {
   bucket: string;
   updated: boolean;

--- a/packages/storage/src/server.ts
+++ b/packages/storage/src/server.ts
@@ -50,6 +50,9 @@ export type {
   BucketMigration,
   BucketNotification,
   BucketTtl,
+  NotificationEvent,
+  NotificationEventName,
+  NotificationResponse,
   StorageClass,
   UpdateBucketResponse,
 } from './lib/bucket/types';


### PR DESCRIPTION
## Summary

Adds three TypeScript types to `@tigrisdata/storage` covering the wire format Tigris POSTs to bucket-notification webhook URLs:

- `NotificationResponse` — top-level body shape (`{ events: NotificationEvent[] }`)
- `NotificationEvent` — per-event shape (`eventVersion`, `eventSource`, `eventName`, `eventTime`, `bucket`, `object: { key, size, eTag }`)
- `NotificationEventName` — open union: `'OBJECT_CREATED_PUT' | 'OBJECT_DELETED' | (string & {})` so consumers keep autocomplete on known event types while accepting future ones

Reference: https://www.tigrisdata.com/docs/buckets/object-notifications/

## Why types-only (no runtime parser)

A runtime parser would just be `JSON.parse` plus shape validation — consumers can do that in three lines. Types give consumers IDE autocomplete and compile-time safety on access patterns without taking on a runtime dependency or maintenance burden.

```ts
import type { NotificationResponse } from '@tigrisdata/storage';

export default {
  async fetch(req: Request) {
    const { events } = (await req.json()) as NotificationResponse;
    for (const event of events) {
      if (event.eventName !== 'OBJECT_CREATED_PUT') continue;
      if (!event.object.key.endsWith('.mp4')) continue;
      // event.bucket, event.object.{key,size,eTag} all typed
    }
    return new Response('ok');
  },
};
```

Auth verification (`Authorization: Bearer …` / `Basic …`) is intentionally not included — it's a generic HTTP concern that frameworks like Express, Hono, and Cloudflare Workers middleware already handle idiomatically.

## Test plan

- [x] `npm run build --workspace=@tigrisdata/storage` clean
- [x] Existing 114 tests still pass (no runtime code added → no new tests needed)
- [x] `biome check` clean
- [x] Names follow the existing `*Response` pattern (`BucketInfoResponse`, `ListBucketsResponse`, `BundleResponse`, `GetResponse`, …)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Types-only change that adds new exports without altering runtime behavior; risk is limited to potential minor API-surface/typing compatibility concerns for downstream consumers.
> 
> **Overview**
> Adds first-class TypeScript typings for bucket-notification webhook deliveries: `NotificationEventName` (open union of known event names), `NotificationEvent` (per-event payload shape), and `NotificationResponse` (top-level `{ events: ... }`).
> 
> Re-exports these new types from `packages/storage/src/server.ts` so consumers of `@tigrisdata/storage` can import them directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95591eca9e0921867ace3b9d7ebaba8decd13590. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->