### PR TITLE
fix(storage): drop cross-bucket options from move

### DIFF
--- a/.changeset/move-same-bucket-only.md
+++ b/.changeset/move-same-bucket-only.md
@@ -1,0 +1,5 @@
+---
+'@tigrisdata/storage': patch
+---
+
+`move` no longer accepts `srcBucket` / `destBucket` options — cross-bucket moves are not supported by the server. Use `copy` followed by `remove` to move objects between buckets.

--- a/packages/storage/src/lib/object/move.ts
+++ b/packages/storage/src/lib/object/move.ts
@@ -1,13 +1,21 @@
-import type { TigrisStorageResponse } from '../types';
-import { type CopyOptions, type CopyResponse, copyOrMove } from './copy';
+import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
+import { type CopyResponse, copyOrMove } from './copy';
 
-export type MoveOptions = CopyOptions;
+export type MoveOptions = {
+  config?: TigrisStorageConfig;
+};
+
 export type MoveResponse = CopyResponse;
 
+/**
+ * Move (rename) an object within a bucket. Cross-bucket moves are not
+ * supported by the server; use `copy` followed by `remove` if you need
+ * to move between buckets.
+ */
 export async function move(
   src: string,
   dest: string,
   options?: MoveOptions
 ): Promise<TigrisStorageResponse<MoveResponse, Error>> {
-  return copyOrMove(src, dest, true, options);
+  return copyOrMove(src, dest, true, { config: options?.config });
 }


### PR DESCRIPTION
## Summary

- The server does not support cross-bucket move, so `MoveOptions` no longer accepts `srcBucket` / `destBucket`. Cross-bucket flows should use `copy` followed by `remove`.
- JSDoc on `move` now states the constraint and points at the `copy` + `remove` workaround.
- Changeset: patch bump for `@tigrisdata/storage`.

## Test plan

- [x] `pnpm --filter @tigrisdata/storage exec tsc --noEmit` — clean
- [x] `pnpm test` — copy/move integration tests pass
- [x] `biome check` — clean (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a user-facing API change: `move` no longer accepts `srcBucket`/`destBucket`, which will break callers relying on cross-bucket moves. Runtime behavior should be safer (aligned with server constraints), but downstream TypeScript compile errors are expected until updated.
> 
> **Overview**
> `move` is now explicitly limited to same-bucket renames: `MoveOptions` no longer inherits `CopyOptions` and only accepts `config`, removing `srcBucket`/`destBucket` support.
> 
> The implementation forwards only `config` into `copyOrMove`, and a changeset documents the breaking behavior change and recommends `copy` + `remove` for cross-bucket moves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5238daf45dda8fc73f32c45362a7fb234ae494a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->