### PR TITLE
chore(repo): optimize renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,9 +23,10 @@
   "postUpdateOptions": ["pnpmDedupe"],
   "packageRules": [
     {
-      "description": "Throttle major-version updates: only after 14 days of release age (~bi-weekly cadence)",
+      "description": "Throttle major-version updates: bi-weekly cadence (first and third Monday) with a 14-day staleness floor",
       "matchUpdateTypes": ["major"],
-      "minimumReleaseAge": "14 days"
+      "minimumReleaseAge": "14 days",
+      "schedule": ["* 0-5 1-7,15-21 * 1"]
     },
     {
       "description": "TypeScript and @types/node major updates: held 60 days post-release (~every 2 months)",

--- a/renovate.json
+++ b/renovate.json
@@ -3,9 +3,11 @@
   "extends": [
     "config:recommended",
     ":semanticCommitScope(deps)",
-    ":maintainLockFilesWeekly",
-    "schedule:weekly"
+    ":semanticCommitTypeAll(chore)",
+    ":maintainLockFilesWeekly"
   ],
+  "timezone": "UTC",
+  "schedule": ["* 5-23 * * 6"],
   "prHourlyLimit": 4,
   "prConcurrentLimit": 10,
   "rebaseWhen": "behind-base-branch",
@@ -16,14 +18,21 @@
   },
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 6am on monday"]
+    "schedule": ["* 0-5 * * 1"]
   },
   "postUpdateOptions": ["pnpmDedupe"],
   "packageRules": [
     {
-      "description": "Throttle major-version updates to every two weeks",
+      "description": "Throttle major-version updates: only after 14 days of release age (~bi-weekly cadence)",
       "matchUpdateTypes": ["major"],
-      "schedule": ["every 2 weeks on monday before 6am"]
+      "minimumReleaseAge": "14 days"
+    },
+    {
+      "description": "TypeScript and @types/node major updates: held 60 days post-release (~every 2 months)",
+      "matchPackageNames": ["typescript", "@types/node"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "typescript and node types (major)",
+      "minimumReleaseAge": "60 days"
     },
     {
       "description": "Group AWS SDK + S3 + Smithy ecosystem into one PR",
@@ -80,26 +89,6 @@
       "description": "Group pnpm bumps (packageManager field + workflows)",
       "matchPackageNames": ["pnpm"],
       "groupName": "pnpm"
-    },
-    {
-      "description": "Auto-merge devDependency patches and minors after CI passes",
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true,
-      "automergeType": "pr"
-    },
-    {
-      "description": "Auto-merge GitHub Actions patches and minors",
-      "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true,
-      "automergeType": "pr"
-    },
-    {
-      "description": "Auto-merge weekly lockfile maintenance",
-      "matchUpdateTypes": ["lockFileMaintenance"],
-      "automerge": true,
-      "automergeType": "pr"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Updates the existing Renovate config to:

- **Replace deprecated later.js text schedules with cron** — Renovate has deprecated later.js text in favor of cron. Affects top-level schedule (`"schedule:weekly"` preset → explicit `"* 5-23 * * 6"`), lockfile-maintenance schedule, and removes the major-rule's later.js schedule.
- **Add TypeScript + @types/node major hold** — bundles their major updates separately with a 60-day release-age hold (~every 2 months).
- **Simpler bi-weekly major cadence** — replaces `"every 2 weeks on monday before 6am"` schedule on the major rule with `minimumReleaseAge: "14 days"`. Same intent, no deprecated syntax.
- **Consistent commit prefix** — adds `:semanticCommitTypeAll(chore)` so every Renovate commit lands as `chore(deps): ...` (already passes commitlint since `scope-empty: never` is the only scope rule).
- **Drop automerge** — all three automerge rules removed (devDep patch/minor, GH Actions patch/minor, lockfile maintenance). All dependency PRs now go through human review.
- **Preserve everything else** — all package groupings (aws-sdk, changesets, commitlint, biome, react, keyv, github-actions, pnpm), OSV vulnerability alerts, lockfile maintenance (still weekly, Monday), Saturday schedule preference, and `:semanticCommitScope(deps)`.

## Test plan

- [ ] No deprecation warnings appear in next Renovate run logs
- [ ] Dependency Dashboard regenerates with the new groupings (typescript/@types/node group appears separately)
- [ ] No new PRs are auto-merged after this lands
- [ ] PR titles use `chore(deps):` prefix and pass commitlint

Assisted-by: Claude Opus 4.7 (1M context) via Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to `renovate.json` behavior (scheduling, grouping, and automerge policy) with no runtime code impact; main risk is unintentionally altering when/which dependency PRs are created.
> 
> **Overview**
> Updates `renovate.json` to use explicit cron scheduling (with `timezone: "UTC"`) for general runs, lockfile maintenance, and major-update throttling, replacing the prior weekly/later.js-style presets.
> 
> Adjusts major update policy by enforcing `minimumReleaseAge: "14 days"` with a bi-weekly Monday window, and adds a dedicated rule to delay and group `typescript` and `@types/node` major bumps for 60 days.
> 
> Standardizes Renovate commits to `chore(deps): …` via `:semanticCommitTypeAll(chore)` and removes all automerge rules so dependency updates require manual review.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd835d0f4177985b1c1e87378730665be9133114. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->