### PR TITLE
chore(storage): add changeset for list forks + delete snapshot

### DIFF
--- a/.changeset/list-forks-delete-snapshot.md
+++ b/.changeset/list-forks-delete-snapshot.md
@@ -1,0 +1,9 @@
+---
+'@tigrisdata/storage': minor
+---
+
+Add fork listing and snapshot deletion, and expand bucket listing fields:
+
+- New `listForks(sourceBucketName?)` returns every bucket that forks from the given source as `ForkedBucket[]` (name, creation date, fork timestamp, source snapshot, snapshot creation date).
+- New `deleteBucketSnapshot(sourceBucketName, snapshotVersion)` deletes a specific snapshot version of a bucket.
+- `listBuckets` and `getStats` now return additional bucket metadata: `regions`, `type` (`Regular` | `Snapshot`), and `visibility` (`public` | `private`).


### PR DESCRIPTION
## Summary

- Adds the missing changeset for the previously-merged work in #115 (listForks, deleteBucketSnapshot, expanded `listBuckets` / `getStats` fields).
- Marks `@tigrisdata/storage` for a minor bump.

## Test plan

- [ ] CI green
- [ ] Verify the Version Packages PR picks this up and proposes a minor bump for `@tigrisdata/storage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only adds a Changesets entry for versioning/release notes and does not modify runtime code.
> 
> **Overview**
> Adds a new Changesets file to mark `@tigrisdata/storage` for a **minor** release and document the previously added storage APIs: `listForks(...)`, `deleteBucketSnapshot(...)`, and additional metadata returned by `listBuckets`/`getStats` (`regions`, `type`, `visibility`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ae6ab13ada63251f13f4e2c8b795b58ec3960bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->