### PR TITLE
feat(storage): metadata round-trip + sub-delim encoding fix

### DIFF
--- a/.changeset/metadata-and-sub-delim-encoding.md
+++ b/.changeset/metadata-and-sub-delim-encoding.md
@@ -1,0 +1,8 @@
+---
+'@tigrisdata/storage': minor
+---
+
+Add user-metadata round-trip and fix SigV4 path encoding for keys with sub-delim characters:
+
+- `put` now accepts a `metadata?: Record<string, string>` option and forwards it to S3 as `x-amz-meta-*` headers. `HeadResponse.metadata` (and `PutResponse.metadata`) surface the round-tripped values; key casing follows S3 semantics (lowercased on read).
+- Fix: `copy`, `move`, and `updateObject` returned `403 SignatureDoesNotMatch` for keys containing `!`, `'`, `(`, `)`, or `*` (e.g. `holiday (2024).jpg`). `encodeObjectKey` now matches AWS's canonical-URI encoding (`encodeURIComponent` plus the sub-delims that it leaves alone), aligning the client's signed canonical path with the gateway's recomputed canonical.

--- a/packages/storage/src/lib/object/head.ts
+++ b/packages/storage/src/lib/object/head.ts
@@ -15,6 +15,7 @@ export type HeadOptions = {
 export type HeadResponse = {
   contentDisposition: string;
   contentType: string;
+  metadata: Record<string, string>;
   modified: Date;
   path: string;
   size: number;
@@ -64,6 +65,7 @@ export async function head(
             modified: res.LastModified ?? new Date(),
             contentType: res.ContentType ?? '',
             contentDisposition: res.ContentDisposition ?? '',
+            metadata: res.Metadata ?? {},
             url: await getSignedUrl(tigrisClient, head, {
               expiresIn: 3600,
             }),

--- a/packages/storage/src/lib/object/put.ts
+++ b/packages/storage/src/lib/object/put.ts
@@ -24,6 +24,7 @@ export type PutOptions = {
   allowOverwrite?: boolean;
   contentType?: string;
   contentDisposition?: 'attachment' | 'inline';
+  metadata?: Record<string, string>;
   multipart?: boolean;
   partSize?: number;
   queueSize?: number;
@@ -35,6 +36,7 @@ export type PutOptions = {
 export type PutResponse = {
   contentDisposition: string | undefined;
   contentType: string | undefined;
+  metadata: Record<string, string> | undefined;
   modified: Date;
   path: string;
   size: number;
@@ -84,6 +86,7 @@ export async function put(
       Body: body,
       ContentType: options?.contentType ?? undefined,
       ContentDisposition: contentDisposition,
+      Metadata: options?.metadata,
       ACL: access,
     },
     partSize: options?.partSize ?? (options?.multipart ? 1024 * 1024 * 5 : 0),
@@ -153,6 +156,7 @@ export async function put(
     data: {
       contentDisposition: options?.contentDisposition ?? undefined,
       contentType: options?.contentType ?? undefined,
+      metadata: options?.metadata,
       modified: new Date(),
       size: contentSize,
       path,

--- a/packages/storage/src/lib/object/put.ts
+++ b/packages/storage/src/lib/object/put.ts
@@ -156,7 +156,17 @@ export async function put(
     data: {
       contentDisposition: options?.contentDisposition ?? undefined,
       contentType: options?.contentType ?? undefined,
-      metadata: options?.metadata,
+      // S3 lowercases x-amz-meta-* header names on write; mirror that
+      // here so PutResponse.metadata matches what a subsequent head()
+      // will return.
+      metadata: options?.metadata
+        ? Object.fromEntries(
+            Object.entries(options.metadata).map(([k, v]) => [
+              k.toLowerCase(),
+              v,
+            ])
+          )
+        : undefined,
       modified: new Date(),
       size: contentSize,
       path,

--- a/packages/storage/src/test/integration.test.ts
+++ b/packages/storage/src/test/integration.test.ts
@@ -164,6 +164,7 @@ describe.skipIf(skipTests)('Tigris Storage Integration Tests', () => {
       expect(result.data?.url).toBeDefined();
       expect(result.data?.contentType).toBeDefined();
       expect(result.data?.contentDisposition).toBeDefined();
+      expect(result.data?.metadata).toEqual({});
     });
 
     it('should return undefined data for non-existent files', async () => {
@@ -173,6 +174,31 @@ describe.skipIf(skipTests)('Tigris Storage Integration Tests', () => {
 
       expect(result.error).toBeUndefined();
       expect(result.data).toBeUndefined();
+    });
+
+    it('should round-trip user metadata from put to head', async () => {
+      const metaFileName = `test-meta-${Date.now()}.txt`;
+      const metadata = {
+        author: 'tigris',
+        'project-id': 'abc-123',
+      };
+
+      const putResult = await put(metaFileName, testFileContent, {
+        config,
+        metadata,
+      });
+      expect(putResult.error).toBeUndefined();
+      expect(putResult.data?.metadata).toEqual(metadata);
+
+      const headResult = await head(metaFileName, { config });
+      expect(headResult.error).toBeUndefined();
+      // S3 lowercases metadata keys on retrieval.
+      expect(headResult.data?.metadata).toEqual({
+        author: 'tigris',
+        'project-id': 'abc-123',
+      });
+
+      await remove(metaFileName, { config });
     });
   });
 

--- a/packages/storage/src/test/integration.test.ts
+++ b/packages/storage/src/test/integration.test.ts
@@ -178,21 +178,22 @@ describe.skipIf(skipTests)('Tigris Storage Integration Tests', () => {
 
     it('should round-trip user metadata from put to head', async () => {
       const metaFileName = `test-meta-${Date.now()}.txt`;
-      const metadata = {
-        author: 'tigris',
-        'project-id': 'abc-123',
-      };
-
+      // Mixed-case keys to assert S3-style lowercasing on both sides.
       const putResult = await put(metaFileName, testFileContent, {
         config,
-        metadata,
+        metadata: {
+          Author: 'tigris',
+          'Project-Id': 'abc-123',
+        },
       });
       expect(putResult.error).toBeUndefined();
-      expect(putResult.data?.metadata).toEqual(metadata);
+      expect(putResult.data?.metadata).toEqual({
+        author: 'tigris',
+        'project-id': 'abc-123',
+      });
 
       const headResult = await head(metaFileName, { config });
       expect(headResult.error).toBeUndefined();
-      // S3 lowercases metadata keys on retrieval.
       expect(headResult.data?.metadata).toEqual({
         author: 'tigris',
         'project-id': 'abc-123',

--- a/shared/utils.test.ts
+++ b/shared/utils.test.ts
@@ -157,6 +157,25 @@ describe('encodeObjectKey', () => {
     );
   });
 
+  it("encodes sub-delims !'()* that encodeURIComponent leaves alone", () => {
+    // Regression: AWS's SigV4 canonical URI encodes every byte outside
+    // A-Za-z0-9-._~, including these sub-delims. `encodeURIComponent`
+    // does not, so leaving them literal in the wire path causes the
+    // server's recomputed canonical to diverge → SignatureDoesNotMatch.
+    expect(encodeObjectKey('photos/holiday (2024).jpg')).toBe(
+      'photos/holiday%20%282024%29.jpg'
+    );
+    expect(encodeObjectKey("it's a *test! file.txt")).toBe(
+      'it%27s%20a%20%2Atest%21%20file.txt'
+    );
+  });
+
+  it('encodes multi-byte UTF-8 sequences', () => {
+    expect(encodeObjectKey('photos/holiday ☀️.jpg')).toBe(
+      'photos/holiday%20%E2%98%80%EF%B8%8F.jpg'
+    );
+  });
+
   it('preserves trailing slash (folder markers)', () => {
     expect(encodeObjectKey('folder/')).toBe('folder/');
   });

--- a/shared/utils.ts
+++ b/shared/utils.ts
@@ -34,18 +34,31 @@ export async function executeWithConcurrency<T>(
 /**
  * Encode an object key for use in an S3-style request path or
  * `X-Amz-Copy-Source` header. Encodes each path segment with
- * `encodeURIComponent` and rejoins with `/`, so the slash separators
- * survive verbatim.
+ * AWS-compatible URI escaping and rejoins with `/`, so the slash
+ * separators survive verbatim.
  *
- * Why this matters: when the request is signed with SigV4 (access-key
- * auth path), the signer URI-escapes the path again during canonical
- * request construction. If the key was already escaped with a plain
- * `encodeURIComponent`, the `/` becomes `%2F` and then `%252F` —
- * mismatch against the server's canonical (which decodes `%2F`
- * back to `/` first). Result: `SignatureDoesNotMatch`.
+ * Why not bare `encodeURIComponent`: AWS's SigV4 canonical-URI scheme
+ * (and the S3 gateway's server-side canonicalization) percent-encode
+ * every byte except `A-Za-z0-9-._~` — that includes the sub-delims
+ * `!'()*`, which `encodeURIComponent` leaves alone. If we sign and
+ * send a path with literal `(` but the server canonicalizes it to
+ * `%28` before checking, we get `SignatureDoesNotMatch` on keys that
+ * contain those characters (e.g. `holiday (2024).jpg`).
+ *
+ * The slash-preserving split also matters: a single `encodeURIComponent`
+ * on the whole key would turn `/` into `%2F`, which the signer or server
+ * would then encode again to `%252F` — same divergence symptom.
  */
 export function encodeObjectKey(key: string): string {
-  return key.split('/').map(encodeURIComponent).join('/');
+  return key.split('/').map(escapeUriSegment).join('/');
+}
+
+/** AWS-compatible URI escape for a single path segment. */
+function escapeUriSegment(segment: string): string {
+  return encodeURIComponent(segment).replace(
+    /[!'()*]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`
+  );
 }
 
 export function toError(value: unknown): Error {


### PR DESCRIPTION
## Summary

- Adds `put` option `metadata?: Record<string, string>` and surfaces `metadata` on `HeadResponse` (and `PutResponse`), mapped to/from S3's `x-amz-meta-*` headers. Lowercased on read per S3 semantics.
- Fixes `403 SignatureDoesNotMatch` from `copy`, `move`, and `updateObject` when keys contain `!`, `'`, `(`, `)`, or `*` (e.g. `holiday (2024).jpg`). `encodeObjectKey` previously used bare `encodeURIComponent`, which leaves those sub-delims literal — but AWS's SigV4 canonical-URI scheme (and the Tigris gateway's recomputed canonical) percent-encode every byte outside `A-Za-z0-9-._~`, producing a client/server canonical mismatch. Now matches `@smithy/util-uri-escape`'s `escapeUri` semantics.
- Minor changeset on `@tigrisdata/storage`.

## Test plan

- [x] `pnpm test` — all 161 storage tests + agent-kit / react / keyv-tigris pass
- [x] `pnpm --filter @tigrisdata/storage build` — clean tsc + tsup output
- [x] New unit tests in `shared/utils.test.ts` cover the failing sub-delims (`(`, `)`, `'`, `*`, `!`) and a multi-byte UTF-8 segment as a regression guard
- [x] New integration test in `packages/storage/src/test/integration.test.ts` exercises put → head metadata round-trip
- [ ] Run the storagesdk conformance suite against this branch to confirm the `holiday (2024) ☀️ .jpg` copy repro is resolved end-to-end with real SigV4 auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new public API surface (`metadata` on `put`/`head`) and changes SigV4 canonical path escaping used by `copy`/`move`/`updateObject`, which could affect compatibility for edge-case object keys and downstream callers relying on response shapes.
> 
> **Overview**
> Adds *user-defined object metadata* support: `put` now accepts `metadata?: Record<string,string>` (sent as S3 `x-amz-meta-*`), `head` now returns `metadata`, and `PutResponse.metadata` mirrors S3’s lowercased header-key behavior; integration tests cover put→head round-trip.
> 
> Fixes SigV4 signing failures for object keys containing sub-delims like `!'()*` by updating `encodeObjectKey` to AWS-compatible escaping (segment-wise `encodeURIComponent` plus percent-encoding those characters); unit tests add regressions for sub-delims and multibyte UTF-8 keys. Also includes a minor changeset bump for `@tigrisdata/storage`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 249ed217868304a83cc10e2e117ee149a1462117. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->