### PR TITLE
feat(storage): expose object etag on put, head, and list

### DIFF
--- a/.changeset/expose-object-etag.md
+++ b/.changeset/expose-object-etag.md
@@ -1,0 +1,5 @@
+---
+'@tigrisdata/storage': patch
+---
+
+Expose object ETag on `PutResponse`, `HeadResponse`, and `ListItem` (`etag: string`). Populated from the underlying S3 PUT, HEAD, and ListObjectsV2 responses.

--- a/packages/storage/src/lib/object/head.ts
+++ b/packages/storage/src/lib/object/head.ts
@@ -15,6 +15,7 @@ export type HeadOptions = {
 export type HeadResponse = {
   contentDisposition: string;
   contentType: string;
+  etag: string;
   metadata: Record<string, string>;
   modified: Date;
   path: string;
@@ -65,6 +66,7 @@ export async function head(
             modified: res.LastModified ?? new Date(),
             contentType: res.ContentType ?? '',
             contentDisposition: res.ContentDisposition ?? '',
+            etag: res.ETag ?? '',
             metadata: res.Metadata ?? {},
             url: await getSignedUrl(tigrisClient, head, {
               expiresIn: 3600,

--- a/packages/storage/src/lib/object/list.ts
+++ b/packages/storage/src/lib/object/list.ts
@@ -20,6 +20,7 @@ export type ListItem = {
   name: string;
   size: number;
   lastModified: Date;
+  etag: string;
 };
 
 export type ListResponse = {
@@ -91,6 +92,7 @@ export async function list(
                 name: item.Key ?? '',
                 size: item.Size ?? 0,
                 lastModified: item.LastModified ?? new Date(),
+                etag: item.ETag ?? '',
               })) ?? [],
             commonPrefixes:
               res.CommonPrefixes?.map((p) => p.Prefix ?? '').filter(Boolean) ??

--- a/packages/storage/src/lib/object/put.ts
+++ b/packages/storage/src/lib/object/put.ts
@@ -36,6 +36,7 @@ export type PutOptions = {
 export type PutResponse = {
   contentDisposition: string | undefined;
   contentType: string | undefined;
+  etag: string;
   metadata: Record<string, string> | undefined;
   modified: Date;
   path: string;
@@ -116,8 +117,10 @@ export async function put(
     }
   });
 
+  let etag = '';
   try {
-    await upload.done();
+    const result = await upload.done();
+    etag = result.ETag ?? '';
   } catch (error) {
     return { error: toError(error) };
   }
@@ -156,6 +159,7 @@ export async function put(
     data: {
       contentDisposition: options?.contentDisposition ?? undefined,
       contentType: options?.contentType ?? undefined,
+      etag,
       // S3 lowercases x-amz-meta-* header names on write; mirror that
       // here so PutResponse.metadata matches what a subsequent head()
       // will return.

--- a/packages/storage/src/test/integration.test.ts
+++ b/packages/storage/src/test/integration.test.ts
@@ -174,15 +174,21 @@ describe.skipIf(skipTests)('Tigris Storage Integration Tests', () => {
 
       const putResult = await put(etagFileName, testFileContent, { config });
       expect(putResult.error).toBeUndefined();
+      // Guard against a vacuous comparison if put returned an empty etag.
+      expect(putResult.data?.etag).toMatch(/^".+"$/);
+      const expectedEtag = putResult.data?.etag;
 
       const headResult = await head(etagFileName, { config });
-      expect(headResult.data?.etag).toBe(putResult.data?.etag);
+      expect(headResult.error).toBeUndefined();
+      expect(headResult.data?.etag).toBe(expectedEtag);
 
       const listResult = await list({ prefix: etagFileName, config });
+      expect(listResult.error).toBeUndefined();
       const listed = listResult.data?.items.find(
         (i) => i.name === etagFileName
       );
-      expect(listed?.etag).toBe(putResult.data?.etag);
+      expect(listed).toBeDefined();
+      expect(listed?.etag).toBe(expectedEtag);
 
       await remove(etagFileName, { config });
     });

--- a/packages/storage/src/test/integration.test.ts
+++ b/packages/storage/src/test/integration.test.ts
@@ -49,6 +49,7 @@ describe.skipIf(skipTests)('Tigris Storage Integration Tests', () => {
       expect(result.data?.size).toBeGreaterThan(0);
       expect(result.data?.url).toBeDefined();
       expect(result.data?.modified).toBeInstanceOf(Date);
+      expect(result.data?.etag).toMatch(/^".+"$/);
     });
 
     it('should not prevent overwriting by default', async () => {
@@ -165,6 +166,25 @@ describe.skipIf(skipTests)('Tigris Storage Integration Tests', () => {
       expect(result.data?.contentType).toBeDefined();
       expect(result.data?.contentDisposition).toBeDefined();
       expect(result.data?.metadata).toEqual({});
+      expect(result.data?.etag).toMatch(/^".+"$/);
+    });
+
+    it('should expose the same etag across put, head, and list', async () => {
+      const etagFileName = `test-etag-${Date.now()}.txt`;
+
+      const putResult = await put(etagFileName, testFileContent, { config });
+      expect(putResult.error).toBeUndefined();
+
+      const headResult = await head(etagFileName, { config });
+      expect(headResult.data?.etag).toBe(putResult.data?.etag);
+
+      const listResult = await list({ prefix: etagFileName, config });
+      const listed = listResult.data?.items.find(
+        (i) => i.name === etagFileName
+      );
+      expect(listed?.etag).toBe(putResult.data?.etag);
+
+      await remove(etagFileName, { config });
     });
 
     it('should return undefined data for non-existent files', async () => {


### PR DESCRIPTION
## Summary

- Adds `etag: string` to `PutResponse`, `HeadResponse`, and `ListItem`, populated from the underlying S3 PUT, HEAD, and ListObjectsV2 responses. Quoted per RFC 7232 (e.g. `"abc123…"`).
- Lets callers identify the version they just wrote (or listed) without chaining a `head()` round-trip.
- Patch changeset on `@tigrisdata/storage`.

## Notes

- Multi-part PUTs return S3's `MD5(MD5(parts))-N`, not a content hash. SSE-KMS objects return an opaque etag. The field uniquely identifies the version but should not be treated as a content checksum.
- `GetResponse` is intentionally not changed — its current shape (`string | File | ReadableStream`) can't carry an etag without a breaking restructure.

## Test plan

- [x] `pnpm --filter @tigrisdata/storage build` — clean
- [x] `pnpm --filter @tigrisdata/storage test` — 162 tests pass
- [x] Existing put/head integration tests assert the etag matches `/^".+"$/`
- [x] New integration test asserts the same etag value is returned by `put`, `head`, and `list` for one object

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: additive API surface only (new `etag` fields) with straightforward plumbing from S3 responses; main risk is downstream TypeScript compile breakage for consumers expecting the previous response shapes.
> 
> **Overview**
> Adds `etag: string` to storage object responses (`PutResponse`, `HeadResponse`, `ListItem`) and populates it from the underlying S3 `ETag` returned by PUT, HEAD, and `ListObjectsV2`.
> 
> Updates integration tests to assert `etag` is present/quoted and that the same value is returned consistently across `put()`, `head()`, and `list()` for a single object, and publishes as a patch via a changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1881351ca131c89006be0342a6fc280adebc939. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->