### PR TITLE
feat(storage): signed upload URL with PUT/POST contracts

### DIFF
--- a/.changeset/signed-upload-url.md
+++ b/.changeset/signed-upload-url.md
@@ -1,0 +1,12 @@
+---
+'@tigrisdata/storage': minor
+---
+
+Add `getSignedUploadUrl(key, options)` (server) and `uploadToSignedUrl(name, data, signed, options)` (client) for direct browser-to-Tigris uploads.
+
+Returns a discriminated upload contract:
+
+- **PUT** (default): simple presigned URL. Submit the body as the request payload with any required headers. Supports `contentType`, `metadata`, and `access` via signed headers.
+- **POST** (S3 POST policy): triggered automatically when `maxSize`, `minSize`, or `successActionRedirect` is set — knobs that PUT can't express. Submit a `multipart/form-data` body with the returned `fields` followed by the `file` input.
+
+The client helper `uploadToSignedUrl` consumes either contract and exposes the same `UploadResponse` shape as the existing `upload()` helper.

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -62,6 +62,7 @@
     "@aws-crypto/sha256-js": "^5.2.0",
     "@aws-sdk/client-s3": "^3.1038.0",
     "@aws-sdk/lib-storage": "^3.1038.0",
+    "@aws-sdk/s3-presigned-post": "^3.1053.0",
     "@aws-sdk/s3-request-presigner": "^3.1038.0",
     "@aws-sdk/types": "^3.973.8",
     "@smithy/signature-v4": "^5.3.14",

--- a/packages/storage/src/client.ts
+++ b/packages/storage/src/client.ts
@@ -3,5 +3,8 @@ export {
   type UploadOptions,
   type UploadProgress,
   type UploadResponse,
+  type UploadToSignedUrlOptions,
   upload,
+  uploadToSignedUrl,
 } from './lib/upload/client';
+export type { SignedUploadUrlResponse } from './lib/upload/shared';

--- a/packages/storage/src/lib/object/signed-upload-url.ts
+++ b/packages/storage/src/lib/object/signed-upload-url.ts
@@ -4,6 +4,7 @@ import {
   type PresignedPostOptions,
 } from '@aws-sdk/s3-presigned-post';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { TigrisHeaders } from '@shared/headers';
 import { handleError } from '@shared/utils';
 import { config, missingConfigError } from '../config';
 import { createTigrisClient } from '../tigris-client';
@@ -112,11 +113,11 @@ async function createPutContract(
       headers['Content-Type'] = options.contentType;
     }
     if (acl) {
-      headers['x-amz-acl'] = acl;
+      headers[TigrisHeaders.ACL] = acl;
     }
     if (normalizedMetadata) {
       for (const [k, v] of Object.entries(normalizedMetadata)) {
-        headers[`x-amz-meta-${k}`] = v;
+        headers[`${TigrisHeaders.META_PREFIX}${k}`] = v;
       }
     }
 
@@ -169,7 +170,7 @@ async function createPostContract(
 
   if (options.metadata) {
     for (const [k, v] of Object.entries(options.metadata)) {
-      const headerName = `x-amz-meta-${k.toLowerCase()}`;
+      const headerName = `${TigrisHeaders.META_PREFIX}${k.toLowerCase()}`;
       fields[headerName] = v;
       conditions.push({ [headerName]: v });
     }

--- a/packages/storage/src/lib/object/signed-upload-url.ts
+++ b/packages/storage/src/lib/object/signed-upload-url.ts
@@ -10,6 +10,13 @@ import { createTigrisClient } from '../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
 import type { SignedUploadUrlResponse } from '../upload/shared';
 
+/**
+ * S3's single-part PUT size limit (5 GiB). Used as the upper bound of a
+ * POST policy `content-length-range` when only `minSize` is supplied —
+ * some S3-compatible servers reject ranges with a larger maximum.
+ */
+const S3_MAX_SINGLE_PART_PUT_BYTES = 5 * 1024 * 1024 * 1024;
+
 export type GetSignedUploadUrlOptions = {
   config?: TigrisStorageConfig;
   /** Seconds until expiration. Default 3600. */
@@ -143,7 +150,7 @@ async function createPostContract(
 
   if (options.maxSize !== undefined || options.minSize !== undefined) {
     const min = options.minSize ?? 0;
-    const max = options.maxSize ?? Number.MAX_SAFE_INTEGER;
+    const max = options.maxSize ?? S3_MAX_SINGLE_PART_PUT_BYTES;
     conditions.push(['content-length-range', min, max]);
   }
 

--- a/packages/storage/src/lib/object/signed-upload-url.ts
+++ b/packages/storage/src/lib/object/signed-upload-url.ts
@@ -1,0 +1,191 @@
+import { PutObjectCommand, type S3Client } from '@aws-sdk/client-s3';
+import {
+  createPresignedPost,
+  type PresignedPostOptions,
+} from '@aws-sdk/s3-presigned-post';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { handleError } from '@shared/utils';
+import { config, missingConfigError } from '../config';
+import { createTigrisClient } from '../tigris-client';
+import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
+import type { SignedUploadUrlResponse } from '../upload/shared';
+
+export type GetSignedUploadUrlOptions = {
+  config?: TigrisStorageConfig;
+  /** Seconds until expiration. Default 3600. */
+  expiresIn?: number;
+  /**
+   * Locks the upload's `Content-Type`. With PUT, callers must send the
+   * matching header; with POST, the value is baked into the form.
+   */
+  contentType?: string;
+  /** Maximum body size in bytes. POST-only (no PUT equivalent). */
+  maxSize?: number;
+  /** Minimum body size in bytes. POST-only (no PUT equivalent). */
+  minSize?: number;
+  /**
+   * User metadata. Works in both contracts — on PUT it's returned as
+   * required `x-amz-meta-*` headers the client must include verbatim;
+   * on POST it's baked into the policy as `x-amz-meta-*` fields.
+   * Keys are lowercased to match S3 semantics.
+   */
+  metadata?: Record<string, string>;
+  /**
+   * Object ACL. Works in both contracts — on PUT it's returned as a
+   * required `x-amz-acl` header; on POST it's a form field.
+   */
+  access?: 'public' | 'private';
+  /** Browser redirect on 2xx. POST-only. */
+  successActionRedirect?: string;
+};
+
+/**
+ * POST is required only for knobs that PUT can't express: a body-size
+ * constraint or a browser redirect on success. Everything else (content
+ * type, metadata, ACL) works on a presigned PUT via signed headers.
+ */
+function shouldUsePost(options: GetSignedUploadUrlOptions): boolean {
+  return (
+    options.maxSize !== undefined ||
+    options.minSize !== undefined ||
+    options.successActionRedirect !== undefined
+  );
+}
+
+export async function getSignedUploadUrl(
+  key: string,
+  options?: GetSignedUploadUrlOptions
+): Promise<TigrisStorageResponse<SignedUploadUrlResponse, Error>> {
+  const bucket = options?.config?.bucket ?? config.bucket;
+  if (!bucket) return missingConfigError('bucket');
+
+  const { data: client, error } = createTigrisClient(options?.config);
+  if (error) return { error };
+
+  const expiresIn = options?.expiresIn ?? 3600;
+  const opts = options ?? {};
+
+  return shouldUsePost(opts)
+    ? createPostContract(client, bucket, key, expiresIn, opts)
+    : createPutContract(client, bucket, key, expiresIn, opts);
+}
+
+async function createPutContract(
+  client: S3Client,
+  bucket: string,
+  key: string,
+  expiresIn: number,
+  options: GetSignedUploadUrlOptions
+): Promise<TigrisStorageResponse<SignedUploadUrlResponse, Error>> {
+  try {
+    // S3 lowercases metadata keys on store, so normalize at sign time so
+    // the headers the client sends match what HEAD will return later.
+    const normalizedMetadata = options.metadata
+      ? Object.fromEntries(
+          Object.entries(options.metadata).map(([k, v]) => [k.toLowerCase(), v])
+        )
+      : undefined;
+    const acl = options.access
+      ? options.access === 'public'
+        ? 'public-read'
+        : 'private'
+      : undefined;
+
+    const command = new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      ContentType: options.contentType,
+      Metadata: normalizedMetadata,
+      ACL: acl,
+    });
+    const url = await getSignedUrl(client, command, { expiresIn });
+
+    const headers: Record<string, string> = {};
+    if (options.contentType) {
+      headers['Content-Type'] = options.contentType;
+    }
+    if (acl) {
+      headers['x-amz-acl'] = acl;
+    }
+    if (normalizedMetadata) {
+      for (const [k, v] of Object.entries(normalizedMetadata)) {
+        headers[`x-amz-meta-${k}`] = v;
+      }
+    }
+
+    return {
+      data: {
+        method: 'PUT',
+        url,
+        headers: Object.keys(headers).length > 0 ? headers : undefined,
+        expiresIn,
+      },
+    };
+  } catch (e) {
+    return handleError(e as Error);
+  }
+}
+
+async function createPostContract(
+  client: S3Client,
+  bucket: string,
+  key: string,
+  expiresIn: number,
+  options: GetSignedUploadUrlOptions
+): Promise<TigrisStorageResponse<SignedUploadUrlResponse, Error>> {
+  const conditions: NonNullable<PresignedPostOptions['Conditions']> = [];
+  const fields: Record<string, string> = {};
+
+  if (options.contentType) {
+    fields['Content-Type'] = options.contentType;
+    conditions.push({ 'Content-Type': options.contentType });
+  }
+
+  if (options.maxSize !== undefined || options.minSize !== undefined) {
+    const min = options.minSize ?? 0;
+    const max = options.maxSize ?? Number.MAX_SAFE_INTEGER;
+    conditions.push(['content-length-range', min, max]);
+  }
+
+  if (options.access) {
+    const acl = options.access === 'public' ? 'public-read' : 'private';
+    fields.acl = acl;
+    conditions.push({ acl });
+  }
+
+  if (options.successActionRedirect) {
+    fields.success_action_redirect = options.successActionRedirect;
+    conditions.push({
+      success_action_redirect: options.successActionRedirect,
+    });
+  }
+
+  if (options.metadata) {
+    for (const [k, v] of Object.entries(options.metadata)) {
+      const headerName = `x-amz-meta-${k.toLowerCase()}`;
+      fields[headerName] = v;
+      conditions.push({ [headerName]: v });
+    }
+  }
+
+  try {
+    const result = await createPresignedPost(client, {
+      Bucket: bucket,
+      Key: key,
+      Conditions: conditions.length > 0 ? conditions : undefined,
+      Fields: Object.keys(fields).length > 0 ? fields : undefined,
+      Expires: expiresIn,
+    });
+
+    return {
+      data: {
+        method: 'POST',
+        url: result.url,
+        fields: result.fields,
+        expiresIn,
+      },
+    };
+  } catch (e) {
+    return handleError(e as Error);
+  }
+}

--- a/packages/storage/src/lib/upload/client.ts
+++ b/packages/storage/src/lib/upload/client.ts
@@ -1,7 +1,7 @@
 import { executeWithConcurrency } from '@shared/utils';
 import type { TigrisStorageResponse } from '../types';
 import { addRandomSuffix } from '../utils';
-import { UploadAction } from './shared';
+import { type SignedUploadUrlResponse, UploadAction } from './shared';
 
 export type UploadOptions = {
   access?: 'public' | 'private';
@@ -349,4 +349,154 @@ async function uploadMultipart(
       ),
     };
   }
+}
+
+export type UploadToSignedUrlOptions = {
+  contentType?: string;
+  onUploadProgress?: (progress: UploadProgress) => void;
+};
+
+/**
+ * Uploads a file using the contract returned by `getSignedUploadUrl`.
+ * Branches on `signed.method`: PUT sends the body as the request payload
+ * (applying any required headers), POST submits a multipart/form-data
+ * body with the policy `fields` followed by the `file` input.
+ */
+export async function uploadToSignedUrl(
+  name: string,
+  data: File | Blob,
+  signed: SignedUploadUrlResponse,
+  options?: UploadToSignedUrlOptions
+): Promise<TigrisStorageResponse<UploadResponse, Error>> {
+  if (signed.method === 'PUT') {
+    return uploadToPutUrl(name, data, signed, options);
+  }
+  return uploadToPostUrl(name, data, signed, options);
+}
+
+function trackProgress(
+  xhr: XMLHttpRequest,
+  total: number,
+  onUploadProgress?: (progress: UploadProgress) => void
+): void {
+  if (!onUploadProgress) return;
+  xhr.upload.addEventListener('progress', (event) => {
+    if (event.lengthComputable) {
+      onUploadProgress({
+        loaded: event.loaded,
+        total: event.total,
+        percentage: Math.round((event.loaded / event.total) * 100),
+      });
+    } else {
+      onUploadProgress({
+        loaded: event.loaded,
+        total,
+        percentage: total > 0 ? Math.round((event.loaded / total) * 100) : 0,
+      });
+    }
+  });
+}
+
+async function uploadToPutUrl(
+  name: string,
+  data: File | Blob,
+  signed: Extract<SignedUploadUrlResponse, { method: 'PUT' }>,
+  options?: UploadToSignedUrlOptions
+): Promise<TigrisStorageResponse<UploadResponse, Error>> {
+  const contentType =
+    options?.contentType ?? signed.headers?.['Content-Type'] ?? data.type;
+
+  return new Promise<TigrisStorageResponse<UploadResponse, Error>>(
+    (resolve) => {
+      const xhr = new XMLHttpRequest();
+      trackProgress(xhr, data.size, options?.onUploadProgress);
+
+      xhr.addEventListener('load', () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          resolve({
+            data: {
+              contentType,
+              modified: new Date(),
+              name,
+              size: data.size,
+              url: signed.url.replace('x-id=PutObject', 'x-id=GetObject'),
+            },
+          });
+        } else {
+          resolve({
+            error: new Error(`Upload failed with status: ${xhr.status}`),
+          });
+        }
+      });
+
+      xhr.addEventListener('error', () => {
+        resolve({ error: new Error('Upload failed due to network error') });
+      });
+
+      xhr.open('PUT', signed.url);
+
+      if (signed.headers) {
+        for (const [k, v] of Object.entries(signed.headers)) {
+          xhr.setRequestHeader(k, v);
+        }
+      }
+      // Caller override wins over signed headers.
+      if (options?.contentType) {
+        xhr.setRequestHeader('Content-Type', options.contentType);
+      } else if (!signed.headers?.['Content-Type'] && data.type) {
+        xhr.setRequestHeader('Content-Type', data.type);
+      }
+
+      xhr.send(data);
+    }
+  );
+}
+
+async function uploadToPostUrl(
+  name: string,
+  data: File | Blob,
+  signed: Extract<SignedUploadUrlResponse, { method: 'POST' }>,
+  options?: UploadToSignedUrlOptions
+): Promise<TigrisStorageResponse<UploadResponse, Error>> {
+  const form = new FormData();
+  for (const [k, v] of Object.entries(signed.fields)) {
+    form.append(k, v);
+  }
+  // `file` must be appended last per S3 POST policy semantics.
+  form.append('file', data);
+
+  return new Promise<TigrisStorageResponse<UploadResponse, Error>>(
+    (resolve) => {
+      const xhr = new XMLHttpRequest();
+      trackProgress(xhr, data.size, options?.onUploadProgress);
+
+      xhr.addEventListener('load', () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          resolve({
+            data: {
+              contentType:
+                options?.contentType ??
+                signed.fields['Content-Type'] ??
+                data.type,
+              modified: new Date(),
+              name,
+              size: data.size,
+              url: `${signed.url}${signed.fields.key ?? name}`,
+            },
+          });
+        } else {
+          resolve({
+            error: new Error(`Upload failed with status: ${xhr.status}`),
+          });
+        }
+      });
+
+      xhr.addEventListener('error', () => {
+        resolve({ error: new Error('Upload failed due to network error') });
+      });
+
+      xhr.open('POST', signed.url);
+      xhr.send(form);
+    }
+  );
 }

--- a/packages/storage/src/lib/upload/client.ts
+++ b/packages/storage/src/lib/upload/client.ts
@@ -435,16 +435,19 @@ async function uploadToPutUrl(
 
       xhr.open('PUT', signed.url);
 
+      // XHR's setRequestHeader merges repeated calls for the same name
+      // (per spec), which would produce `Content-Type: a, b` and break
+      // the SigV4 check. Set Content-Type exactly once.
       if (signed.headers) {
         for (const [k, v] of Object.entries(signed.headers)) {
+          if (k.toLowerCase() === 'content-type') continue;
           xhr.setRequestHeader(k, v);
         }
       }
-      // Caller override wins over signed headers.
-      if (options?.contentType) {
-        xhr.setRequestHeader('Content-Type', options.contentType);
-      } else if (!signed.headers?.['Content-Type'] && data.type) {
-        xhr.setRequestHeader('Content-Type', data.type);
+      const resolvedContentType =
+        options?.contentType ?? signed.headers?.['Content-Type'] ?? data.type;
+      if (resolvedContentType) {
+        xhr.setRequestHeader('Content-Type', resolvedContentType);
       }
 
       xhr.send(data);

--- a/packages/storage/src/lib/upload/client.ts
+++ b/packages/storage/src/lib/upload/client.ts
@@ -474,7 +474,12 @@ async function uploadToPostUrl(
       trackProgress(xhr, data.size, options?.onUploadProgress);
 
       xhr.addEventListener('load', () => {
-        if (xhr.status >= 200 && xhr.status < 300) {
+        // POST policy returns 204 by default, or 3xx when
+        // success_action_redirect is set. XHR normally follows the
+        // redirect, but accept 2xx-3xx defensively for implementations
+        // that don't (and so a redirect target's status doesn't get
+        // mis-reported as an S3 rejection).
+        if (xhr.status >= 200 && xhr.status < 400) {
           resolve({
             data: {
               contentType:

--- a/packages/storage/src/lib/upload/client.ts
+++ b/packages/storage/src/lib/upload/client.ts
@@ -481,7 +481,10 @@ async function uploadToPostUrl(
               modified: new Date(),
               name,
               size: data.size,
-              url: `${signed.url}${signed.fields.key ?? name}`,
+              // Object location. POST policy has no signed-GET equivalent,
+              // so callers wanting auth-bearing reads should use
+              // `getPresignedUrl({ operation: 'get' })`.
+              url: new URL(signed.fields.key ?? name, signed.url).toString(),
             },
           });
         } else {

--- a/packages/storage/src/lib/upload/shared.ts
+++ b/packages/storage/src/lib/upload/shared.ts
@@ -4,3 +4,28 @@ export enum UploadAction {
   MultipartGetParts = 'multipart-get-parts',
   MultipartComplete = 'multipart-complete',
 }
+
+/**
+ * Discriminated upload contract returned by `getSignedUploadUrl`.
+ *
+ * PUT: simple presigned URL. Submit the body as the request payload,
+ * including any required headers (notably `Content-Type` when one was
+ * baked into the signature).
+ *
+ * POST: S3 POST policy. Submit a `multipart/form-data` request with the
+ * provided `fields` as hidden inputs (verbatim, in order), followed by
+ * the `file` input last.
+ */
+export type SignedUploadUrlResponse =
+  | {
+      method: 'PUT';
+      url: string;
+      headers?: Record<string, string>;
+      expiresIn: number;
+    }
+  | {
+      method: 'POST';
+      url: string;
+      fields: Record<string, string>;
+      expiresIn: number;
+    };

--- a/packages/storage/src/server.ts
+++ b/packages/storage/src/server.ts
@@ -118,6 +118,10 @@ export {
   setObjectAccess,
 } from './lib/object/set/access';
 export {
+  type GetSignedUploadUrlOptions,
+  getSignedUploadUrl,
+} from './lib/object/signed-upload-url';
+export {
   type UpdateObjectOptions,
   type UpdateObjectResponse,
   updateObject,
@@ -131,4 +135,7 @@ export {
   type ClientUploadRequest,
   handleClientUpload,
 } from './lib/upload/server';
-export { UploadAction } from './lib/upload/shared';
+export {
+  type SignedUploadUrlResponse,
+  UploadAction,
+} from './lib/upload/shared';

--- a/packages/storage/src/test/integration.test.ts
+++ b/packages/storage/src/test/integration.test.ts
@@ -24,6 +24,7 @@ import { move } from '../lib/object/move';
 import { put } from '../lib/object/put';
 import { remove } from '../lib/object/remove';
 import { setObjectAccess } from '../lib/object/set/access';
+import { getSignedUploadUrl } from '../lib/object/signed-upload-url';
 import { shouldSkipIntegrationTests } from './setup';
 
 const skipTests = shouldSkipIntegrationTests();
@@ -633,6 +634,103 @@ describe.skipIf(skipTests)('Tigris Storage Integration Tests', () => {
 
       expect(result.error).toBeUndefined();
       expect(result.data?.forks).toEqual([]);
+    });
+  });
+
+  describe('getSignedUploadUrl', () => {
+    const createdKeys: string[] = [];
+
+    afterEach(async () => {
+      await Promise.all(createdKeys.map((k) => remove(k, { config })));
+      createdKeys.length = 0;
+    });
+
+    it('returns a PUT contract by default and lets the client upload', async () => {
+      const key = `test-signed-put-${Date.now()}.txt`;
+      createdKeys.push(key);
+
+      const signed = await getSignedUploadUrl(key, {
+        config,
+        contentType: 'text/plain',
+      });
+      expect(signed.error).toBeUndefined();
+      expect(signed.data?.method).toBe('PUT');
+      if (signed.data?.method !== 'PUT') return;
+      expect(signed.data.url).toMatch(/^https:\/\//);
+      expect(signed.data.headers?.['Content-Type']).toBe('text/plain');
+
+      const res = await fetch(signed.data.url, {
+        method: 'PUT',
+        body: 'hello from put',
+        headers: signed.data.headers,
+      });
+      expect(res.status).toBeGreaterThanOrEqual(200);
+      expect(res.status).toBeLessThan(300);
+
+      const got = await get(key, 'string', { config });
+      expect(got.data).toBe('hello from put');
+    });
+
+    it('returns a POST contract when a size bound is set', async () => {
+      const key = `test-signed-post-${Date.now()}.txt`;
+      createdKeys.push(key);
+      const body = 'hello from post';
+
+      const signed = await getSignedUploadUrl(key, {
+        config,
+        contentType: 'text/plain',
+        maxSize: 1024,
+      });
+      expect(signed.error).toBeUndefined();
+      expect(signed.data?.method).toBe('POST');
+      if (signed.data?.method !== 'POST') return;
+      expect(signed.data.url).toMatch(/^https:\/\//);
+      expect(signed.data.fields.key).toBe(key);
+      expect(signed.data.fields['Content-Type']).toBe('text/plain');
+
+      const form = new FormData();
+      for (const [k, v] of Object.entries(signed.data.fields)) {
+        form.append(k, v);
+      }
+      form.append('file', new Blob([body], { type: 'text/plain' }), key);
+
+      const res = await fetch(signed.data.url, { method: 'POST', body: form });
+      expect(res.status).toBeGreaterThanOrEqual(200);
+      expect(res.status).toBeLessThan(300);
+
+      const got = await get(key, 'string', { config });
+      expect(got.data).toBe(body);
+    });
+
+    it('round-trips metadata via the PUT contract', async () => {
+      const key = `test-signed-put-meta-${Date.now()}.txt`;
+      createdKeys.push(key);
+
+      const signed = await getSignedUploadUrl(key, {
+        config,
+        contentType: 'text/plain',
+        metadata: { Author: 'tigris', 'Project-Id': 'abc-123' },
+      });
+      expect(signed.data?.method).toBe('PUT');
+      if (signed.data?.method !== 'PUT') return;
+      // Required headers — caller must send them verbatim or the signature
+      // check fails. Keys are lowercased to match what HEAD returns.
+      expect(signed.data.headers?.['x-amz-meta-author']).toBe('tigris');
+      expect(signed.data.headers?.['x-amz-meta-project-id']).toBe('abc-123');
+
+      const res = await fetch(signed.data.url, {
+        method: 'PUT',
+        body: 'meta via put',
+        headers: signed.data.headers,
+      });
+      expect(res.status).toBeGreaterThanOrEqual(200);
+      expect(res.status).toBeLessThan(300);
+
+      const headResult = await head(key, { config });
+      expect(headResult.data?.metadata).toEqual({
+        author: 'tigris',
+        'project-id': 'abc-123',
+      });
     });
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,9 @@ importers:
       '@aws-sdk/lib-storage':
         specifier: ^3.1038.0
         version: 3.1053.0(@aws-sdk/client-s3@3.1053.0)
+      '@aws-sdk/s3-presigned-post':
+        specifier: ^3.1053.0
+        version: 3.1053.0
       '@aws-sdk/s3-request-presigner':
         specifier: ^3.1038.0
         version: 3.1053.0
@@ -265,6 +268,10 @@ packages:
 
   '@aws-sdk/nested-clients@3.997.11':
     resolution: {integrity: sha512-nWXXJ1r/r8N2Gw1pWolRgED38/A9A8DHR2ETWIv220zh4PZHcybbR4hUVWWktmNXTRHzDJwRluapHn0rZxuoqA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/s3-presigned-post@3.1053.0':
+    resolution: {integrity: sha512-7BAOxPfFd9HZLtamgffpqSqACpQIuEwiTWAHbr1j3Ddr0mwWgiuk5uWAAbZU1PduPlpuwtJKcT7Zc1aGuRkUyA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/s3-request-presigner@3.1053.0':
@@ -3005,6 +3012,16 @@ snapshots:
       '@smithy/core': 3.24.4
       '@smithy/fetch-http-handler': 5.4.4
       '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/s3-presigned-post@3.1053.0':
+    dependencies:
+      '@aws-sdk/client-s3': 3.1053.0
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/signature-v4': 5.4.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 

--- a/shared/headers.ts
+++ b/shared/headers.ts
@@ -5,6 +5,8 @@ export enum TigrisHeaders {
   SESSION_TOKEN = 'x-amz-security-token',
   NAMESPACE = 'X-Tigris-Namespace',
   STORAGE_CLASS = 'X-Amz-Storage-Class',
+  /** Prefix for user metadata headers; concatenate with a key, e.g. `${TigrisHeaders.META_PREFIX}author`. */
+  META_PREFIX = 'x-amz-meta-',
 
   BUCKET_LIST_SOURCE = 'X-Tigris-List-Source', // tigris or shadow
   SCHEDULE_MIGRATION = 'X-Tigris-Schedule-Migration',


### PR DESCRIPTION
## Summary

- Adds `getSignedUploadUrl(key, options)` (server) and `uploadToSignedUrl(name, data, signed, options)` (client) for direct browser-to-Tigris uploads.
- Returns a discriminated contract — PUT by default, POST (S3 POST policy) when a knob PUT can't express is requested.

## Contract

```ts
type SignedUploadUrlResponse =
  | { method: 'PUT';  url; headers?; expiresIn }
  | { method: 'POST'; url; fields;   expiresIn };
```

Inspired by [files-sdk's `signedUploadUrl`](https://files-sdk.dev/api/signed-upload-url) shape — one entry point, two contracts, picked automatically.

## Switching rule

POST is triggered **only** when an option exists that PUT can't express:

| Knob | PUT | POST |
|---|---|---|
| `contentType` | ✅ header | ✅ field |
| `metadata` | ✅ signed `x-amz-meta-*` headers | ✅ form fields |
| `access` | ✅ signed `x-amz-acl` header | ✅ form field |
| `maxSize`/`minSize` | ❌ | ✅ `content-length-range` |
| `successActionRedirect` | ❌ | ✅ |

So `getSignedUploadUrl(key, { metadata: { Author: 'tigris' } })` returns a PUT — `metadata` no longer forces POST.

## Client usage

```ts
const { data } = await getSignedUploadUrl('uploads/avatar.png', {
  contentType: 'image/png',
  maxSize: 5 * 1024 * 1024,
});

if (data.method === 'PUT') {
  await fetch(data.url, { method: 'PUT', body: file, headers: data.headers });
} else {
  const form = new FormData();
  for (const [k, v] of Object.entries(data.fields)) form.append(k, v);
  form.append('file', file);
  await fetch(data.url, { method: 'POST', body: form });
}
```

Or use `uploadToSignedUrl(name, data, signed, options?)` from `@tigrisdata/storage/client`, which branches on `signed.method` and returns the same `UploadResponse` shape as the existing `upload()` helper.

## Notes

- New dep: `@aws-sdk/s3-presigned-post` for POST policy signing.
- Metadata keys are lowercased at sign time (PUT branch) to match S3 storage semantics, so the headers the client sends line up with what `head()` returns. Same normalization we shipped in #118.

## Test plan

- [x] `pnpm --filter @tigrisdata/storage build` — clean
- [x] `pnpm --filter @tigrisdata/storage test` — 165/165 pass
- New integration tests against the real gateway:
  - [x] PUT contract round-trip via `fetch` → `get()` verifies body
  - [x] POST contract round-trip via `FormData` → `get()` verifies body
  - [x] PUT metadata round-trip — sign with `{ Author, 'Project-Id' }`, PUT with returned headers, `head()` returns `{ author, 'project-id' }`
- [ ] Confirm with the gateway team whether `x-amz-meta-*` form fields on POST policy uploads are persisted as object metadata — observed during development that POST metadata didn't round-trip via `head()`. Not blocking since PUT is now the recommended path for metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New presigned upload surface affects object writes and signature/header correctness; scope is additive with integration coverage rather than changes to core auth.
> 
> **Overview**
> Adds **direct browser-to-storage uploads** via server `getSignedUploadUrl` and client `uploadToSignedUrl`, so apps can mint upload credentials on the server and upload from the browser without proxying bytes through their API.
> 
> `getSignedUploadUrl` returns a **discriminated contract**: **PUT** (presigned `PutObject` + optional signed headers for `Content-Type`, ACL, and lowercased `x-amz-meta-*`) by default; **POST** (S3 POST policy via new `@aws-sdk/s3-presigned-post`) when options need PUT-only gaps—`maxSize`/`minSize`, or `successActionRedirect`. Metadata and ACL no longer force POST unless those POST-only knobs are set.
> 
> `uploadToSignedUrl` branches on `signed.method`, uses XHR with progress, avoids duplicate `Content-Type` on PUT (SigV4), builds POST `FormData` with policy fields then `file` last, and returns the same **`UploadResponse`** shape as `upload()`. Public exports land on `@tigrisdata/storage` / `./client`; `TigrisHeaders.META_PREFIX` centralizes metadata header names. Integration tests cover PUT/POST upload round-trips and PUT metadata via `head()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baf54e98a6c68a118f4a0a50ebd4c66129a0c3dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->