### PR TITLE
fix(storage): add region in bucket info

### DIFF
--- a/.changeset/legal-cameras-ask.md
+++ b/.changeset/legal-cameras-ask.md
@@ -1,0 +1,5 @@
+---
+"@tigrisdata/storage": patch
+---
+
+add regions in getBucketInfo response

--- a/packages/storage/src/lib/bucket/info.ts
+++ b/packages/storage/src/lib/bucket/info.ts
@@ -15,6 +15,7 @@ export type GetBucketInfoOptions = {
 };
 
 export type BucketInfoResponse = {
+  regions: string[];
   isSnapshotEnabled: boolean;
   forkInfo:
     | {
@@ -126,6 +127,13 @@ export async function getBucketInfo(
       }) ?? [];
 
     const data: BucketInfoResponse = {
+      regions:
+        response.data.object_regions && response.data.object_regions !== ''
+          ? response.data.object_regions
+              .split(',')
+              .map((r) => r.trim())
+              .filter(Boolean)
+          : ['global'],
       isSnapshotEnabled: response.data.type === 1,
       forkInfo: response.data.ForkInfo
         ? {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive read-only field on bucket metadata with simple string parsing and a safe default.
> 
> **Overview**
> **`getBucketInfo`** now exposes bucket placement as a **`regions`** string array on **`BucketInfoResponse`**, parsed from the API’s **`object_regions`** field (comma-separated, trimmed). Missing or empty values default to **`['global']`**, matching how updates represent global vs regional storage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afbaeb42d6f44e8f9d591b871b47993c6c340f84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->