### PR TITLE
feat(storage): typed BucketLocations on getBucketInfo response

### DIFF
--- a/.changeset/bucket-info-locations.md
+++ b/.changeset/bucket-info-locations.md
@@ -1,0 +1,9 @@
+---
+'@tigrisdata/storage': minor
+---
+
+Add `BucketInfoResponse.locations: BucketLocations` to `getBucketInfo` — a structured discriminated-union view of the bucket's region configuration that aligns with the `BucketLocations` type used by `createBucket` and `updateBucket`. Distinguishes `global` / `multi` / `single` / `dual` configurations.
+
+The legacy `BucketInfoResponse.regions: string[]` field is now deprecated; use `locations` instead. `regions` will be removed in the next major version.
+
+Note on single-vs-dual readback: the wire format stores a single region identically for `{ type: 'single' }` and `{ type: 'dual', values: <one> }`. Parsing prefers `single` for one-value cases — the underlying region selection is unchanged, only the type tag differs.

--- a/packages/storage/src/lib/bucket/info.ts
+++ b/packages/storage/src/lib/bucket/info.ts
@@ -3,19 +3,28 @@ import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
 import type {
   BucketCorsRule,
   BucketLifecycleRule,
+  BucketLocations,
   BucketMigration,
   BucketNotification,
   BucketTtl,
   StorageClass,
 } from './types';
 import type { GetBucketInfoApiResponseBody } from './utils/api';
+import { parseBucketLocations } from './utils/regions';
 
 export type GetBucketInfoOptions = {
   config?: TigrisStorageConfig;
 };
 
 export type BucketInfoResponse = {
+  /**
+   * @deprecated Use `locations` instead — it carries the same data with
+   * a structured `BucketLocations` shape that distinguishes `global` /
+   * `multi` / `single` / `dual`. `regions` will be removed in the next
+   * major version.
+   */
   regions: string[];
+  locations: BucketLocations;
   isSnapshotEnabled: boolean;
   forkInfo:
     | {
@@ -126,6 +135,7 @@ export async function getBucketInfo(
         };
       }) ?? [];
 
+    const locations = parseBucketLocations(response.data.object_regions);
     const data: BucketInfoResponse = {
       regions:
         response.data.object_regions && response.data.object_regions !== ''
@@ -134,6 +144,7 @@ export async function getBucketInfo(
               .map((r) => r.trim())
               .filter(Boolean)
           : ['global'],
+      locations,
       isSnapshotEnabled: response.data.type === 1,
       forkInfo: response.data.ForkInfo
         ? {

--- a/packages/storage/src/lib/bucket/info.ts
+++ b/packages/storage/src/lib/bucket/info.ts
@@ -22,6 +22,11 @@ export type BucketInfoResponse = {
    * a structured `BucketLocations` shape that distinguishes `global` /
    * `multi` / `single` / `dual`. `regions` will be removed in the next
    * major version.
+   *
+   * Note: for region codes the SDK does not recognize, `regions` passes
+   * the raw value through (e.g. `['mars']`) while `locations` falls back
+   * defensively to `{ type: 'global' }`. The two fields can therefore
+   * disagree when the gateway returns a region code newer than the SDK.
    */
   regions: string[];
   locations: BucketLocations;

--- a/packages/storage/src/lib/bucket/utils/regions.test.ts
+++ b/packages/storage/src/lib/bucket/utils/regions.test.ts
@@ -45,4 +45,12 @@ describe('parseBucketLocations', () => {
     expect(parseBucketLocations('mars')).toEqual({ type: 'global' });
     expect(parseBucketLocations('ams,mars')).toEqual({ type: 'global' });
   });
+
+  it('falls back to global for multiple multi-region values', () => {
+    // `usa` and `eur` are valid as a single `multi` value but not combinable
+    // — multi-region codes aren't in `singleOrDualRegions`, so the dual
+    // branch rejects them. Documents the fallback rather than asserting
+    // a different semantic for unsupported combinations.
+    expect(parseBucketLocations('usa,eur')).toEqual({ type: 'global' });
+  });
 });

--- a/packages/storage/src/lib/bucket/utils/regions.test.ts
+++ b/packages/storage/src/lib/bucket/utils/regions.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { parseBucketLocations } from './regions';
+
+describe('parseBucketLocations', () => {
+  it('returns global for empty, undefined, or whitespace-only input', () => {
+    expect(parseBucketLocations(undefined)).toEqual({ type: 'global' });
+    expect(parseBucketLocations('')).toEqual({ type: 'global' });
+    expect(parseBucketLocations(',')).toEqual({ type: 'global' });
+    expect(parseBucketLocations(' , ')).toEqual({ type: 'global' });
+  });
+
+  it('returns multi for a single multi-region value', () => {
+    expect(parseBucketLocations('usa')).toEqual({
+      type: 'multi',
+      values: 'usa',
+    });
+    expect(parseBucketLocations('eur')).toEqual({
+      type: 'multi',
+      values: 'eur',
+    });
+  });
+
+  it('returns single for a single value from singleOrDualRegions', () => {
+    // Single is preferred over dual when one value is present; the wire
+    // form is ambiguous and `single` is the more natural reading.
+    expect(parseBucketLocations('ams')).toEqual({
+      type: 'single',
+      values: 'ams',
+    });
+  });
+
+  it('returns dual for multiple values from singleOrDualRegions', () => {
+    expect(parseBucketLocations('ams,fra')).toEqual({
+      type: 'dual',
+      values: ['ams', 'fra'],
+    });
+    // Tolerates whitespace.
+    expect(parseBucketLocations('ams, fra ,iad')).toEqual({
+      type: 'dual',
+      values: ['ams', 'fra', 'iad'],
+    });
+  });
+
+  it('falls back to global for unrecognized values', () => {
+    expect(parseBucketLocations('mars')).toEqual({ type: 'global' });
+    expect(parseBucketLocations('ams,mars')).toEqual({ type: 'global' });
+  });
+});

--- a/packages/storage/src/lib/bucket/utils/regions.ts
+++ b/packages/storage/src/lib/bucket/utils/regions.ts
@@ -1,8 +1,65 @@
 import {
+  type BucketLocationDualOrSingle,
+  type BucketLocationMulti,
   type BucketLocations,
   multiRegions,
   singleOrDualRegions,
 } from '../types';
+
+/**
+ * Map the wire `object_regions` string (comma-separated region codes)
+ * back to a `BucketLocations` value.
+ *
+ * Note on the single-vs-dual ambiguity: when the wire carries exactly
+ * one value from `singleOrDualRegions`, both `{ type: 'single' }` and
+ * `{ type: 'dual', values: <one> }` are valid representations — the
+ * server stores the same string for both. This function prefers
+ * `single`, which is the more common and natural reading. Callers who
+ * originally created the bucket with a one-value `dual` config will
+ * read back as `single`; the underlying region selection is unchanged.
+ *
+ * Unrecognized values fall back to `{ type: 'global' }` so a future
+ * server-side region addition doesn't crash the SDK on read.
+ */
+export function parseBucketLocations(
+  objectRegions: string | undefined
+): BucketLocations {
+  if (!objectRegions || objectRegions === '') {
+    return { type: 'global' };
+  }
+
+  const values = objectRegions
+    .split(',')
+    .map((r) => r.trim())
+    .filter(Boolean);
+
+  if (values.length === 0) {
+    return { type: 'global' };
+  }
+
+  if (values.length === 1) {
+    const v = values[0];
+    if ((multiRegions as readonly string[]).includes(v)) {
+      return { type: 'multi', values: v as BucketLocationMulti };
+    }
+    if ((singleOrDualRegions as readonly string[]).includes(v)) {
+      return { type: 'single', values: v as BucketLocationDualOrSingle };
+    }
+    return { type: 'global' };
+  }
+
+  const allDualOrSingle = values.every((v) =>
+    (singleOrDualRegions as readonly string[]).includes(v)
+  );
+  if (allDualOrSingle) {
+    return {
+      type: 'dual',
+      values: values as BucketLocationDualOrSingle[],
+    };
+  }
+
+  return { type: 'global' };
+}
 
 export function validateLocationValues(
   locations: BucketLocations

--- a/packages/storage/src/lib/bucket/utils/regions.ts
+++ b/packages/storage/src/lib/bucket/utils/regions.ts
@@ -38,7 +38,9 @@ export function parseBucketLocations(
   }
 
   if (values.length === 1) {
-    const v = values[0];
+    // Non-null asserted: guarded by the `length === 1` check above, but
+    // marked explicitly so `noUncheckedIndexedAccess` would still compile.
+    const v = values[0]!;
     if ((multiRegions as readonly string[]).includes(v)) {
       return { type: 'multi', values: v as BucketLocationMulti };
     }


### PR DESCRIPTION
## Summary

- Adds `BucketInfoResponse.locations: BucketLocations` to `getBucketInfo`, parsing the wire `object_regions` string into the structured discriminated union used by `createBucket` / `updateBucket` (`global` / `multi` / `single` / `dual`).
- Marks the existing `BucketInfoResponse.regions: string[]` as `@deprecated`; both fields are populated for one major version. `regions` will be removed in the next major.
- New helper `parseBucketLocations(objectRegions?)` lives next to the existing `validateLocationValues` in `utils/regions.ts`.
- Minor (non-breaking) changeset on `@tigrisdata/storage`.

## Mapping rules

| Wire `object_regions` | `locations` |
|---|---|
| empty / undefined / whitespace-only | `{ type: 'global' }` |
| one value in `multiRegions` (`usa`/`eur`) | `{ type: 'multi', values: <v> }` |
| one value in `singleOrDualRegions` | `{ type: 'single', values: <v> }` |
| multiple values in `singleOrDualRegions` | `{ type: 'dual', values: [...] }` |
| anything unrecognized | `{ type: 'global' }` (defensive fallback) |

### Single-vs-dual ambiguity

`BucketLocations` lets `dual` carry one or many region values, but the wire stores a single region identically for `{ type: 'single' }` and `{ type: 'dual', values: <one> }`. The parser prefers `single` on read — the underlying region selection is unchanged; only the type tag may differ from what the caller originally configured. Documented inline.

## Test plan

- [x] `pnpm --filter @tigrisdata/storage build` — clean
- [x] `pnpm --filter @tigrisdata/storage test` — 170/170 pass (5 new unit tests in `regions.test.ts` covering global, multi, single, dual, fallback)
- [ ] Manually verify the `locations` field on an existing multi-region bucket via the live gateway — not done; please confirm before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SDK surface with legacy `regions` retained; parsing behavior is covered by new unit tests and does not change write paths.
> 
> **Overview**
> **`getBucketInfo`** now exposes **`locations: BucketLocations`**, parsing the gateway’s comma-separated `object_regions` wire string into the same discriminated union used by create/update (`global`, `multi`, `single`, `dual`). A new **`parseBucketLocations`** helper in `utils/regions.ts` implements the mapping, with defensive **`global`** fallback for unknown or unsupported combinations and **`single`** preferred when one `singleOrDualRegions` code is present (wire ambiguity vs one-value `dual`).
> 
> The existing **`regions: string[]`** field remains populated but is **`@deprecated`** in favor of `locations`; docs note that unknown region codes can still appear in `regions` while `locations` falls back to `global`. A **minor** changeset documents the addition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7685c9a5e32f3d24b23cfcd45e32e5f7aeefc60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->