### PR TITLE
feat(storage): byte-range reads and optional metadata wrapper on get

### DIFF
--- a/.changeset/get-byte-range.md
+++ b/.changeset/get-byte-range.md
@@ -1,0 +1,13 @@
+---
+'@tigrisdata/storage': minor
+---
+
+Add byte-range support to `get` via a new `range?: { start: number; end?: number }` option. Both bounds are inclusive and 0-based, matching HTTP `Range: bytes=start-end` semantics. Omit `end` to read from `start` to the end of the object. The returned body (string, File, or stream) is the partial content only.
+
+```ts
+const { data } = await get('large.bin', 'stream', {
+  range: { start: 0, end: 1023 }, // first 1 KiB
+});
+```
+
+Invalid ranges (e.g. `end < start`, negative `start`) are rejected client-side before the request is sent. A range that falls entirely outside the object returns an error from the gateway (HTTP 416).

--- a/.changeset/get-byte-range.md
+++ b/.changeset/get-byte-range.md
@@ -6,7 +6,7 @@ Extend `get` with byte-range reads and an opt-in metadata wrapper.
 
 **Byte ranges** via `range?: { start: number; end?: number }` — inclusive, 0-based, matching HTTP `Range: bytes=start-end`. Omit `end` to read from `start` to the end of the object. Invalid ranges are rejected client-side; a range outside the object returns an error from the gateway (HTTP 416).
 
-**Metadata wrapper** via `includeMetadata?: boolean` — when `true`, `get` returns `{ body, metadata }` instead of the bare body. `metadata` carries the object's `etag`, `contentType`, `contentDisposition`, `modified`, `size`, `userMetadata` (the `x-amz-meta-*` map), and `contentRange` (when `range` is used). All read from the same S3 response — no extra round-trip versus calling `head` separately. Existing callers without `includeMetadata` are unaffected (the overload narrows on the literal `true`).
+**Metadata wrapper** via `includeMetadata?: boolean` — when `true`, `get` returns `{ body, metadata }` instead of the bare body. `metadata` carries the object's `etag`, `contentType`, `contentDisposition`, `modified`, `size` (body bytes), `totalSize` (full object size — derived from `Content-Range` on range reads), `userMetadata` (the `x-amz-meta-*` map), and `contentRange` (when `range` is used). All read from the same S3 response — no extra round-trip versus calling `head` separately. Existing callers without `includeMetadata` are unaffected (the overload narrows on the literal `true`).
 
 ```ts
 // Bare body (existing behavior)

--- a/.changeset/get-byte-range.md
+++ b/.changeset/get-byte-range.md
@@ -2,12 +2,25 @@
 '@tigrisdata/storage': minor
 ---
 
-Add byte-range support to `get` via a new `range?: { start: number; end?: number }` option. Both bounds are inclusive and 0-based, matching HTTP `Range: bytes=start-end` semantics. Omit `end` to read from `start` to the end of the object. The returned body (string, File, or stream) is the partial content only.
+Extend `get` with byte-range reads and an opt-in metadata wrapper.
+
+**Byte ranges** via `range?: { start: number; end?: number }` — inclusive, 0-based, matching HTTP `Range: bytes=start-end`. Omit `end` to read from `start` to the end of the object. Invalid ranges are rejected client-side; a range outside the object returns an error from the gateway (HTTP 416).
+
+**Metadata wrapper** via `includeMetadata?: boolean` — when `true`, `get` returns `{ body, metadata }` instead of the bare body. `metadata` carries the object's `etag`, `contentType`, `contentDisposition`, `modified`, `size`, `userMetadata` (the `x-amz-meta-*` map), and `contentRange` (when `range` is used). All read from the same S3 response — no extra round-trip versus calling `head` separately. Existing callers without `includeMetadata` are unaffected (the overload narrows on the literal `true`).
 
 ```ts
-const { data } = await get('large.bin', 'stream', {
-  range: { start: 0, end: 1023 }, // first 1 KiB
-});
-```
+// Bare body (existing behavior)
+const { data } = await get('file.txt', 'string');
+// data: string
 
-Invalid ranges (e.g. `end < start`, negative `start`) are rejected client-side before the request is sent. A range that falls entirely outside the object returns an error from the gateway (HTTP 416).
+// Body + metadata
+const { data } = await get('file.txt', 'string', { includeMetadata: true });
+// data: { body: string, metadata: { etag, modified, size, userMetadata, ... } }
+
+// Range + metadata together
+const { data } = await get('large.bin', 'stream', {
+  range: { start: 0, end: 1023 },
+  includeMetadata: true,
+});
+// data.metadata.contentRange === "bytes 0-1023/<total>"
+```

--- a/packages/storage/src/lib/object/get.ts
+++ b/packages/storage/src/lib/object/get.ts
@@ -11,6 +11,13 @@ export type GetOptions = {
   contentType?: string;
   encoding?: string;
   /**
+   * When true, `get` returns `{ body, metadata }` instead of the bare
+   * body, surfacing the object's etag, content metadata, user metadata,
+   * and (when `range` is used) `Content-Range` — all read from the same
+   * S3 response, no extra round-trip.
+   */
+  includeMetadata?: boolean;
+  /**
    * Byte range to read. Both bounds are inclusive and 0-based, matching
    * the HTTP `Range: bytes=…` semantics. Omit `end` to read from `start`
    * to the end of the object. A range that falls entirely outside the
@@ -20,6 +27,23 @@ export type GetOptions = {
   range?: { start: number; end?: number };
   snapshotVersion?: string;
   versionId?: string;
+};
+
+export type GetMetadata = {
+  contentDisposition: string;
+  contentType: string;
+  etag: string;
+  modified: Date;
+  size: number;
+  /** User metadata baked into the object via `x-amz-meta-*`. */
+  userMetadata: Record<string, string>;
+  /** Populated when `range` was used; e.g. `"bytes 0-99/1024"`. */
+  contentRange?: string;
+};
+
+export type GetResponseWithMetadata<T> = {
+  body: T;
+  metadata: GetMetadata;
 };
 
 function formatRange(range: NonNullable<GetOptions['range']>): string | Error {
@@ -40,6 +64,27 @@ function formatRange(range: NonNullable<GetOptions['range']>): string | Error {
 
 export type GetResponse = string | File | ReadableStream;
 
+// Wrapped overloads first so TS resolves the literal `includeMetadata: true`
+// before falling through to the bare branch.
+export async function get(
+  path: string,
+  format: 'string',
+  options: GetOptions & { includeMetadata: true }
+): Promise<TigrisStorageResponse<GetResponseWithMetadata<string>, Error>>;
+export async function get(
+  path: string,
+  format: 'file',
+  options: GetOptions & { includeMetadata: true }
+): Promise<TigrisStorageResponse<GetResponseWithMetadata<File>, Error>>;
+export async function get(
+  path: string,
+  format: 'stream',
+  options: GetOptions & { includeMetadata: true }
+): Promise<
+  TigrisStorageResponse<GetResponseWithMetadata<ReadableStream>, Error>
+>;
+// Bare overloads accept any GetOptions — including ones where the
+// `includeMetadata` flag is statically widened to `boolean | undefined`.
 export async function get(
   path: string,
   format: 'string',
@@ -59,7 +104,12 @@ export async function get(
   path: string,
   format: 'string' | 'file' | 'stream',
   options?: GetOptions
-): Promise<TigrisStorageResponse<GetResponse, Error>> {
+): Promise<
+  TigrisStorageResponse<
+    GetResponse | GetResponseWithMetadata<GetResponse>,
+    Error
+  >
+> {
   const { data: tigrisClient, error } = createTigrisClient(options?.config);
 
   if (error) {
@@ -115,23 +165,35 @@ export async function get(
           };
         }
 
+        let body: GetResponse;
         if (format === 'stream') {
-          return {
-            data: res.Body.transformToWebStream(),
-          };
+          body = res.Body.transformToWebStream();
+        } else if (format === 'file') {
+          const bytes = await res.Body.transformToByteArray();
+          body = new File([bytes as BlobPart], path, {
+            type: res.ContentType ?? options?.contentType ?? '',
+          });
+        } else {
+          body = await res.Body.transformToString(options?.encoding);
         }
 
-        if (format === 'file') {
-          const bytes = await res.Body.transformToByteArray();
-          return {
-            data: new File([bytes as BlobPart], path, {
-              type: res.ContentType ?? options?.contentType ?? '',
-            }),
-          };
+        if (!options?.includeMetadata) {
+          return { data: body };
         }
 
         return {
-          data: await res.Body.transformToString(options?.encoding),
+          data: {
+            body,
+            metadata: {
+              contentDisposition: res.ContentDisposition ?? '',
+              contentType: res.ContentType ?? '',
+              etag: res.ETag ?? '',
+              modified: res.LastModified ?? new Date(),
+              size: res.ContentLength ?? 0,
+              userMetadata: res.Metadata ?? {},
+              contentRange: res.ContentRange,
+            },
+          },
         };
       })
       .catch(handleError);

--- a/packages/storage/src/lib/object/get.ts
+++ b/packages/storage/src/lib/object/get.ts
@@ -10,9 +10,33 @@ export type GetOptions = {
   contentDisposition?: 'attachment' | 'inline';
   contentType?: string;
   encoding?: string;
+  /**
+   * Byte range to read. Both bounds are inclusive and 0-based, matching
+   * the HTTP `Range: bytes=…` semantics. Omit `end` to read from `start`
+   * to the end of the object. A range that falls entirely outside the
+   * object returns an error (HTTP 416). The returned body is the partial
+   * content only.
+   */
+  range?: { start: number; end?: number };
   snapshotVersion?: string;
   versionId?: string;
 };
+
+function formatRange(range: NonNullable<GetOptions['range']>): string | Error {
+  const { start, end } = range;
+  if (!Number.isInteger(start) || start < 0) {
+    return new Error('range.start must be a non-negative integer');
+  }
+  if (end !== undefined) {
+    if (!Number.isInteger(end) || end < start) {
+      return new Error(
+        'range.end must be an integer greater than or equal to range.start'
+      );
+    }
+    return `bytes=${start}-${end}`;
+  }
+  return `bytes=${start}-`;
+}
 
 export type GetResponse = string | File | ReadableStream;
 
@@ -42,10 +66,20 @@ export async function get(
     return { error };
   }
 
+  let rangeHeader: string | undefined;
+  if (options?.range) {
+    const formatted = formatRange(options.range);
+    if (formatted instanceof Error) {
+      return { error: formatted };
+    }
+    rangeHeader = formatted;
+  }
+
   const get = new GetObjectCommand({
     Bucket: options?.config?.bucket ?? config.bucket,
     Key: path,
     VersionId: options?.versionId,
+    Range: rangeHeader,
     ResponseContentType: options?.contentType ?? undefined,
     ResponseContentDisposition: options?.contentDisposition
       ? options.contentDisposition === 'attachment'

--- a/packages/storage/src/lib/object/get.ts
+++ b/packages/storage/src/lib/object/get.ts
@@ -34,12 +34,38 @@ export type GetMetadata = {
   contentType: string;
   etag: string;
   modified: Date;
+  /**
+   * Number of bytes in this response body. For a full read this equals
+   * the object size; for a range read this is the length of the partial
+   * content. See `totalSize` for the full object size on range reads.
+   */
   size: number;
+  /**
+   * Full object size in bytes. Always set for full reads (same as `size`);
+   * for range reads, parsed from `Content-Range` (`bytes start-end/total`).
+   * `undefined` if the gateway omits or malforms the header.
+   */
+  totalSize?: number;
   /** User metadata baked into the object via `x-amz-meta-*`. */
   userMetadata: Record<string, string>;
   /** Populated when `range` was used; e.g. `"bytes 0-99/1024"`. */
   contentRange?: string;
 };
+
+/**
+ * Parse the total-size suffix out of a `Content-Range: bytes start-end/total`
+ * value. Returns `undefined` when the header is missing or malformed (S3
+ * may return `*` for unknown length).
+ */
+function parseTotalSizeFromContentRange(
+  contentRange: string | undefined
+): number | undefined {
+  if (!contentRange) return undefined;
+  const match = /\/(\d+)\s*$/.exec(contentRange);
+  if (!match) return undefined;
+  const total = Number(match[1]);
+  return Number.isFinite(total) ? total : undefined;
+}
 
 export type GetResponseWithMetadata<T> = {
   body: T;
@@ -181,6 +207,10 @@ export async function get(
           return { data: body };
         }
 
+        const size = res.ContentLength ?? 0;
+        const totalSize = res.ContentRange
+          ? parseTotalSizeFromContentRange(res.ContentRange)
+          : size;
         return {
           data: {
             body,
@@ -189,7 +219,8 @@ export async function get(
               contentType: res.ContentType ?? '',
               etag: res.ETag ?? '',
               modified: res.LastModified ?? new Date(),
-              size: res.ContentLength ?? 0,
+              size,
+              totalSize,
               userMetadata: res.Metadata ?? {},
               contentRange: res.ContentRange,
             },

--- a/packages/storage/src/server.ts
+++ b/packages/storage/src/server.ts
@@ -77,7 +77,13 @@ export {
   bundle,
 } from './lib/object/bundle';
 export { type CopyOptions, type CopyResponse, copy } from './lib/object/copy';
-export { type GetOptions, type GetResponse, get } from './lib/object/get';
+export {
+  type GetMetadata,
+  type GetOptions,
+  type GetResponse,
+  type GetResponseWithMetadata,
+  get,
+} from './lib/object/get';
 export { type HeadOptions, type HeadResponse, head } from './lib/object/head';
 export {
   type ListItem,

--- a/packages/storage/src/test/integration.test.ts
+++ b/packages/storage/src/test/integration.test.ts
@@ -192,6 +192,42 @@ describe.skipIf(skipTests)('Tigris Storage Integration Tests', () => {
       expect(result.data).toBeUndefined();
       expect(result.error?.message).toMatch(/range\.end/);
     });
+
+    it('should return body + metadata when includeMetadata is true', async () => {
+      const metaFileName = `test-get-meta-${Date.now()}.txt`;
+      await put(metaFileName, testFileContent, {
+        config,
+        contentType: 'text/plain',
+        metadata: { Author: 'tigris' },
+      });
+
+      const result = await get(metaFileName, 'string', {
+        config,
+        includeMetadata: true,
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.data?.body).toBe(testFileContent);
+      expect(result.data?.metadata.contentType).toBe('text/plain');
+      expect(result.data?.metadata.size).toBe(testFileContent.length);
+      expect(result.data?.metadata.etag).toMatch(/^".+"$/);
+      expect(result.data?.metadata.modified).toBeInstanceOf(Date);
+      expect(result.data?.metadata.userMetadata).toEqual({ author: 'tigris' });
+      // Full reads don't get a Content-Range.
+      expect(result.data?.metadata.contentRange).toBeUndefined();
+
+      await remove(metaFileName, { config });
+    });
+
+    it('should expose contentRange when a range is used with includeMetadata', async () => {
+      const result = await get(testFileName, 'string', {
+        config,
+        includeMetadata: true,
+        range: { start: 0, end: 4 },
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.data?.body).toBe('Hello');
+      expect(result.data?.metadata.contentRange).toMatch(/^bytes 0-4\/\d+$/);
+    });
   });
 
   describe('head', () => {

--- a/packages/storage/src/test/integration.test.ts
+++ b/packages/storage/src/test/integration.test.ts
@@ -145,6 +145,53 @@ describe.skipIf(skipTests)('Tigris Storage Integration Tests', () => {
         expect(error).toBeDefined();
       }
     });
+
+    it('should read a byte range as string (start and end inclusive)', async () => {
+      // testFileContent = 'Hello, Tigris Storage!' (22 bytes)
+      const result = await get(testFileName, 'string', {
+        config,
+        range: { start: 0, end: 4 },
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.data).toBe('Hello');
+    });
+
+    it('should read a byte range as string (start through EOF)', async () => {
+      const result = await get(testFileName, 'string', {
+        config,
+        range: { start: 7 },
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.data).toBe('Tigris Storage!');
+    });
+
+    it('should read a byte range as a stream', async () => {
+      const result = await get(testFileName, 'stream', {
+        config,
+        range: { start: 0, end: 4 },
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.data).toBeInstanceOf(ReadableStream);
+
+      const reader = (result.data as ReadableStream).getReader();
+      const chunks: Uint8Array[] = [];
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        if (value) chunks.push(value);
+      }
+      const total = chunks.reduce((n, c) => n + c.byteLength, 0);
+      expect(total).toBe(5);
+    });
+
+    it('should reject an invalid range with a client-side error', async () => {
+      const result = await get(testFileName, 'string', {
+        config,
+        range: { start: 5, end: 2 },
+      });
+      expect(result.data).toBeUndefined();
+      expect(result.error?.message).toMatch(/range\.end/);
+    });
   });
 
   describe('head', () => {

--- a/packages/storage/src/test/integration.test.ts
+++ b/packages/storage/src/test/integration.test.ts
@@ -201,24 +201,29 @@ describe.skipIf(skipTests)('Tigris Storage Integration Tests', () => {
         metadata: { Author: 'tigris' },
       });
 
-      const result = await get(metaFileName, 'string', {
-        config,
-        includeMetadata: true,
-      });
-      expect(result.error).toBeUndefined();
-      expect(result.data?.body).toBe(testFileContent);
-      expect(result.data?.metadata.contentType).toBe('text/plain');
-      expect(result.data?.metadata.size).toBe(testFileContent.length);
-      expect(result.data?.metadata.etag).toMatch(/^".+"$/);
-      expect(result.data?.metadata.modified).toBeInstanceOf(Date);
-      expect(result.data?.metadata.userMetadata).toEqual({ author: 'tigris' });
-      // Full reads don't get a Content-Range.
-      expect(result.data?.metadata.contentRange).toBeUndefined();
-
-      await remove(metaFileName, { config });
+      try {
+        const result = await get(metaFileName, 'string', {
+          config,
+          includeMetadata: true,
+        });
+        expect(result.error).toBeUndefined();
+        expect(result.data?.body).toBe(testFileContent);
+        expect(result.data?.metadata.contentType).toBe('text/plain');
+        expect(result.data?.metadata.size).toBe(testFileContent.length);
+        // Full reads: totalSize matches size (no Content-Range header).
+        expect(result.data?.metadata.totalSize).toBe(testFileContent.length);
+        expect(result.data?.metadata.etag).toMatch(/^".+"$/);
+        expect(result.data?.metadata.modified).toBeInstanceOf(Date);
+        expect(result.data?.metadata.userMetadata).toEqual({
+          author: 'tigris',
+        });
+        expect(result.data?.metadata.contentRange).toBeUndefined();
+      } finally {
+        await remove(metaFileName, { config });
+      }
     });
 
-    it('should expose contentRange when a range is used with includeMetadata', async () => {
+    it('should expose contentRange and totalSize when range + includeMetadata are combined', async () => {
       const result = await get(testFileName, 'string', {
         config,
         includeMetadata: true,
@@ -226,6 +231,10 @@ describe.skipIf(skipTests)('Tigris Storage Integration Tests', () => {
       });
       expect(result.error).toBeUndefined();
       expect(result.data?.body).toBe('Hello');
+      // size is the partial body length…
+      expect(result.data?.metadata.size).toBe(5);
+      // …while totalSize is the full object size parsed from Content-Range.
+      expect(result.data?.metadata.totalSize).toBe(testFileContent.length);
       expect(result.data?.metadata.contentRange).toMatch(/^bytes 0-4\/\d+$/);
     });
   });


### PR DESCRIPTION
## Summary

Two additive options on `get`:

- **`range?: { start: number; end?: number }`** — inclusive, 0-based byte-range reads. Maps to HTTP `Range: bytes=start-end` (or `bytes=start-` when `end` is omitted). Invalid ranges (negative start, `end < start`, non-integer) are rejected client-side; ranges outside the object return HTTP 416 from the gateway.
- **`includeMetadata?: boolean`** — when `true`, `get` returns `{ body, metadata }` instead of the bare body. `metadata` carries `etag`, `contentType`, `contentDisposition`, `modified`, `size`, `userMetadata` (the `x-amz-meta-*` map), and `contentRange` (when `range` is used). All read from the same S3 response — no extra round-trip versus `head`.

## Examples

```ts
// Bare body — unchanged
const { data } = await get('file.txt', 'string');
// data: string

// Body + metadata
const { data } = await get('file.txt', 'string', { includeMetadata: true });
// data: { body: string, metadata: { etag, modified, size, userMetadata, ... } }

// Range + metadata
const { data } = await get('large.bin', 'stream', {
  range: { start: 0, end: 1023 },
  includeMetadata: true,
});
// data.metadata.contentRange === "bytes 0-1023/<total>"
```

## Non-breaking

`includeMetadata` could in principle break the existing return type. It doesn't, because the wrapped overloads are declared first and require literal `includeMetadata: true` — TS resolves them ahead of the bare overloads. The bare overloads accept any `GetOptions`, so existing callers (inline literals, variables typed as `GetOptions`, dynamic flags) all fall through to the bare branch and keep the existing `string | File | ReadableStream` return shape.

| Call | Picked overload | Return type |
|---|---|---|
| `get('f', 'string')` | bare | `string` |
| `get('f', 'string', { contentType: 'x' })` | bare | `string` |
| `get('f', 'string', { includeMetadata: false })` | bare | `string` |
| `get('f', 'string', { includeMetadata: true })` | wrapped | `{ body, metadata }` |
| `get('f', 'string', opts: GetOptions)` | bare | `string` |
| `get('f', 'string', { includeMetadata: someVar })` (dynamic) | bare | `string` *(soft caveat: runtime is wrapped if the flag resolves to `true`; users with dynamic flags should narrow themselves)* |

## Test plan

- [x] `pnpm --filter @tigrisdata/storage build` — clean
- [x] `pnpm --filter @tigrisdata/storage test` — 177/177 pass
- New integration tests against the real gateway:
  - [x] Byte-range as string (`{ start, end }`)
  - [x] Byte-range as string (`{ start }` through EOF)
  - [x] Byte-range as stream (asserts byte count)
  - [x] Invalid range rejected client-side with descriptive error
  - [x] `includeMetadata: true` returns body + metadata; user metadata round-trips via `x-amz-meta-*`
  - [x] `contentRange` populated when `range` and `includeMetadata` are combined

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API on object reads with overload-preserved types; behavior changes only when new options are used.
> 
> **Overview**
> **`get`** in `@tigrisdata/storage` gains two optional capabilities without changing default return shapes.
> 
> **Byte-range reads** use `range?: { start; end? }` (inclusive, 0-based), validated client-side and sent as S3 `Range`. Invalid ranges error locally; out-of-bounds ranges surface gateway **416**. Partial bodies work for `string`, `file`, and `stream`.
> 
> **Metadata wrapper** with `includeMetadata: true` returns `{ body, metadata }` from the same `GetObject` response—etag, content headers, `userMetadata`, partial `size` vs full `totalSize` (from `Content-Range` on range reads), and optional `contentRange`. TypeScript overloads keep bare `get` calls typed as before when the flag is not literally `true`.
> 
> Public exports add `GetMetadata` and `GetResponseWithMetadata`; integration tests cover ranges, validation, metadata, and combined range + metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1b91b15ac4fae2b1cff46f8c843ea5a92377762. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->