### PR TITLE
test(repo): retry live-gateway integration suites to absorb flakes

### DIFF
--- a/packages/agent-kit/vitest.config.ts
+++ b/packages/agent-kit/vitest.config.ts
@@ -9,6 +9,11 @@ export default mergeConfig(
       include: ['test/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
       exclude: ['node_modules', 'dist'],
       setupFiles: ['test/setup.ts'],
+      // Integration tests run against a live, eventually-consistent gateway,
+      // so a transient read-after-write/delete race or a slow request can fail
+      // an otherwise-correct assertion. Retry to absorb those flakes instead of
+      // failing (and manually re-running) the whole CI job.
+      retry: 2,
       coverage: {
         provider: 'v8',
         reporter: ['text', 'json', 'html'],

--- a/packages/storage/vitest.config.ts
+++ b/packages/storage/vitest.config.ts
@@ -9,6 +9,12 @@ export default mergeConfig(
       include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
       exclude: ['node_modules', 'dist'],
       setupFiles: ['src/test/setup.ts'],
+      // Integration tests run against a live, eventually-consistent gateway,
+      // so a transient read-after-write/delete race or a slow request can fail
+      // an otherwise-correct assertion. Retry to absorb those flakes instead of
+      // failing (and manually re-running) the whole CI job. Deterministic unit
+      // failures still fail every attempt, so they are not masked.
+      retry: 2,
       coverage: {
         provider: 'v8',
         reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary

CI has been flaky lately, requiring manual re-runs to go green. Analyzing failed `Pull Request Checks` runs over the last ~2 months, the flakes all trace to the **live-gateway integration tests** in `storage` and `agent-kit`, which hit an eventually-consistent backend:

- **read-after-write** — `get > should retrieve file as stream`: a file `put` in `beforeEach` isn't always visible to the immediate `get` (`File not found`).
- **read-after-delete** — `agent-kit > should teardown forks cleanly`: `getBucketInfo` still succeeds briefly after teardown (`expected undefined to be defined`).
- **slow/stalled request** — `listForks` (×4) hung to the 30s test timeout (the custom HTTP client has no request timeout/retry).

None of these are product bugs; they're timing races against a live service. There is currently **no `retry`** configured, so a single transient blip fails the whole job.

## Change

Add `retry: 2` to the vitest configs of the two packages that run live-gateway integration tests (`packages/storage`, `packages/agent-kit`). Each test gets up to 3 attempts; a flake that clears on retry is reported as passed.

- Scoped to these two packages only — `iam`/`keyv-tigris`/`react` are unit-only and untouched.
- Deterministic failures still fail every attempt, so genuine regressions are **not** masked.

## Verification

- Confirmed config-level retry fires through `mergeConfig` (a deliberately flaky probe failed attempt 1, passed on retry → reported passed).
- Full suites green locally: storage **182/182**, agent-kit **11/11**.
- biome clean; test-config only, so no changeset (nothing ships to npm).

## Follow-ups (not in this PR)

Retry treats the symptom. Recommended next steps to fix the root causes:
- Poll the eventually-consistent reads with `expect.poll` (`get`, agent-kit teardown).
- Add a request timeout + small retry to the custom HTTP client (`shared/http-client.ts`) to fix the `listForks` hangs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Vitest config changes with no production or runtime behavior impact.
> 
> **Overview**
> Adds **`retry: 2`** to Vitest in **`packages/storage`** and **`packages/agent-kit`** so live-gateway integration tests get up to three runs per case, reducing CI flakes from eventual consistency (read-after-write/delete) and slow requests.
> 
> Comments in each config document the rationale; **`storage`** also notes that deterministic failures still fail on every attempt. Other packages’ Vitest configs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c15da35dcecb5a8e5eec0c14a5f854aa09f8f6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->