### PR TITLE
perf(storage): resolve listForks server-side and add pagination

### DIFF
--- a/.changeset/list-forks-server-side.md
+++ b/.changeset/list-forks-server-side.md
@@ -1,0 +1,16 @@
+---
+'@tigrisdata/storage': minor
+---
+
+Rework `listForks` to resolve forks server-side and add pagination.
+
+`listForks` now lists a source bucket's forks with a single fork-scoped `ListBuckets` request (via the `X-Tigris-Fork` header) instead of paging the entire bucket listing and filtering by parent client-side. This avoids scanning every bucket in the account.
+
+- Forks are now returned as `BucketFork` (`{ name, creationDate }`), replacing `ForkedBucket`.
+- `ListForksOptions` accepts `limit` and `paginationToken`, and `ListForksResponse` returns a `paginationToken`, so callers can page through forks.
+
+```ts
+const { data } = await listForks('source-bucket', { limit: 50 });
+// data.forks: { name: string; creationDate: Date }[]
+// data.paginationToken?: string — pass back via options to fetch the next page
+```

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/packages/storage/src/lib/bucket/forks.ts
+++ b/packages/storage/src/lib/bucket/forks.ts
@@ -1,14 +1,24 @@
+import { ListBucketsCommand } from '@aws-sdk/client-s3';
+import type { HttpRequest } from '@aws-sdk/types';
+import { TigrisHeaders } from '@shared/index';
 import { config } from '../config';
+import { createTigrisClient } from '../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
-import { fetchBucketListing } from './listing';
-import type { ForkedBucket } from './types';
 
 export type ListForksOptions = {
   config?: TigrisStorageConfig;
+  paginationToken?: string;
+  limit?: number;
+};
+
+export type BucketFork = {
+  name: string;
+  creationDate: Date;
 };
 
 export type ListForksResponse = {
-  forks: ForkedBucket[];
+  forks: BucketFork[];
+  paginationToken?: string;
 };
 
 export async function listForks(
@@ -33,37 +43,48 @@ export async function listForks(
     return { error: new Error('Source bucket name is required') };
   }
 
-  const forks: ForkedBucket[] = [];
-  let paginationToken: string | undefined;
+  const { data: tigrisClient, error } = createTigrisClient(
+    options?.config,
+    true
+  );
 
-  do {
-    const { data, error } = await fetchBucketListing({
-      flags: { includeForkInfo: true },
-      paginationToken,
-      config: options?.config,
-    });
+  if (error) {
+    return { error };
+  }
 
-    if (error) {
-      return { error };
-    }
+  const command = new ListBucketsCommand({
+    ContinuationToken: options?.paginationToken,
+    MaxBuckets: options?.limit,
+  });
+  command.middlewareStack.add(
+    (next) => async (args) => {
+      (args.request as HttpRequest).headers[TigrisHeaders.FORK] = sourceBucket;
+      return next(args);
+    },
+    { step: 'build' }
+  );
 
-    for (const bucket of data.buckets) {
-      const parent = bucket.forkInfo?.parents.find(
-        (p) => p.bucketName === sourceBucket
-      );
-      if (parent) {
-        forks.push({
-          name: bucket.name,
-          creationDate: bucket.creationDate,
-          forkCreatedAt: parent.forkCreatedAt,
-          snapshot: parent.snapshot,
-          snapshotCreatedAt: parent.snapshotCreatedAt,
-        });
-      }
-    }
-
-    paginationToken = data.paginationToken;
-  } while (paginationToken);
-
-  return { data: { forks } };
+  try {
+    return tigrisClient
+      .send(command)
+      .then((res) => {
+        return {
+          data: {
+            forks:
+              res.Buckets?.map((bucket) => ({
+                name: bucket.Name!,
+                creationDate: new Date(bucket.CreationDate!),
+              })) ?? [],
+            paginationToken: res.ContinuationToken,
+          },
+        };
+      })
+      .catch((error) => {
+        return {
+          error: new Error(`Unable to list bucket forks: ${error.message}`),
+        };
+      });
+  } catch {
+    return { error: new Error('Unable to list bucket forks') };
+  }
 }

--- a/packages/storage/src/lib/bucket/types.ts
+++ b/packages/storage/src/lib/bucket/types.ts
@@ -219,14 +219,6 @@ export type BucketOwner = {
   id: string;
 };
 
-export type ForkedBucket = {
-  name: string;
-  creationDate: Date;
-  forkCreatedAt: Date;
-  snapshot: string;
-  snapshotCreatedAt: Date;
-};
-
 export type BucketsStats = {
   activeBuckets: number;
   totalObjects: number;

--- a/packages/storage/src/server.ts
+++ b/packages/storage/src/server.ts
@@ -5,6 +5,7 @@ export {
   createBucket,
 } from './lib/bucket/create';
 export {
+  type BucketFork,
   type ListForksOptions,
   type ListForksResponse,
   listForks,
@@ -68,7 +69,6 @@ export type {
   BucketTtl,
   BucketType,
   BucketVisibility,
-  ForkedBucket,
   NotificationEvent,
   NotificationEventName,
   NotificationResponse,

--- a/packages/storage/src/test/integration.test.ts
+++ b/packages/storage/src/test/integration.test.ts
@@ -683,6 +683,10 @@ describe.skipIf(skipTests)('Tigris Storage Integration Tests', () => {
       });
       expect(b.error).toBeUndefined();
       bucketsToCleanup.push(forkB);
+
+      // Bucket listing is eventually consistent; give the gateway a moment to
+      // surface the freshly created forks before the assertions run.
+      await new Promise((resolve) => setTimeout(resolve, 10_000));
     });
 
     afterAll(async () => {
@@ -719,10 +723,8 @@ describe.skipIf(skipTests)('Tigris Storage Integration Tests', () => {
 
       const fork = result.data?.forks.find((f) => f.name === forkA);
       expect(fork).toBeDefined();
+      expect(typeof fork?.name).toBe('string');
       expect(fork?.creationDate).toBeInstanceOf(Date);
-      expect(fork?.forkCreatedAt).toBeInstanceOf(Date);
-      expect(fork?.snapshotCreatedAt).toBeInstanceOf(Date);
-      expect(typeof fork?.snapshot).toBe('string');
     });
 
     it('should return an empty list when the source has no forks', async () => {
@@ -730,6 +732,37 @@ describe.skipIf(skipTests)('Tigris Storage Integration Tests', () => {
 
       expect(result.error).toBeUndefined();
       expect(result.data?.forks).toEqual([]);
+    });
+
+    it('should paginate forks using limit and paginationToken', async () => {
+      const collected: string[] = [];
+      let paginationToken: string | undefined;
+      let pages = 0;
+
+      do {
+        const page = await listForks(sourceBucket, {
+          config,
+          limit: 1,
+          paginationToken,
+        });
+
+        expect(page.error).toBeUndefined();
+        expect(page.data).toBeDefined();
+        // Each page must honour the requested limit.
+        expect(page.data?.forks.length).toBeLessThanOrEqual(1);
+
+        for (const fork of page.data?.forks ?? []) {
+          collected.push(fork.name);
+        }
+
+        paginationToken = page.data?.paginationToken;
+        pages += 1;
+      } while (paginationToken && pages < 10);
+
+      // With two forks and a page size of one, enumerating every fork
+      // requires following the pagination token across multiple pages.
+      expect(collected).toContain(forkA);
+      expect(collected).toContain(forkB);
     });
   });
 


### PR DESCRIPTION
## Summary

Reworks `listForks` to resolve a source bucket's forks **server-side** and adds pagination.

Previously `listForks` paged the entire bucket listing (`fetchBucketListing` with `includeForkInfo`) and filtered client-side for buckets whose parents included the source — scanning every bucket in the account. It now issues a single fork-scoped `ListBuckets` request via the `X-Tigris-Fork` header, so the gateway returns only the forks of the given source.

## Changes

- **Server-side resolution** — one `ListBuckets` call scoped by the `X-Tigris-Fork` header instead of a full-listing scan + client-side filter.
- **Pagination** — `ListForksOptions` now accepts `limit` and `paginationToken`; `ListForksResponse` returns a `paginationToken` for fetching the next page.
- **Return shape** — forks are returned as `BucketFork` (`{ name, creationDate }`), replacing `ForkedBucket`. Exports updated in `server.ts`.

```ts
const { data } = await listForks('source-bucket', { limit: 50 });
// data.forks: { name: string; creationDate: Date }[]
// data.paginationToken?: string — pass back via options for the next page
```

## Tests

Updated the `listForks` integration suite for the new shape and added coverage for `limit` / `paginationToken` paging.

## Changeset

Added (`minor`) — see `.changeset/list-forks-server-side.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Minor semver breaking change drops fork snapshot metadata from `listForks` results; behavior now depends on the fork-scoped ListBuckets API.
> 
> **Overview**
> **`listForks`** now uses a fork-scoped **`ListBuckets`** call with the **`X-Tigris-Fork`** header so the gateway returns only forks of the source bucket, instead of paging the full account bucket list with **`includeForkInfo`** and filtering client-side.
> 
> Callers can pass **`limit`** and **`paginationToken`** on **`ListForksOptions`**; **`ListForksResponse`** exposes **`paginationToken`** for the next page. Fork entries are **`BucketFork`** (`name`, **`creationDate`** only). The richer **`ForkedBucket`** type and its per-parent snapshot fields are removed from public exports.
> 
> Integration tests match the slimmer shape, add pagination coverage, and wait briefly after creating forks for listing consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c16e6f2158c4f7bd916ee219f33e9c6ad9f21538. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->