### PR TITLE
feat(storage): add mergeFork and rebaseFork

### DIFF
--- a/.changeset/fork-merge-and-rebase.md
+++ b/.changeset/fork-merge-and-rebase.md
@@ -1,0 +1,17 @@
+---
+'@tigrisdata/storage': minor
+---
+
+Add `mergeFork` and `rebaseFork` for managing bucket forks.
+
+- `mergeFork(forkName, sourceBucketName, options?)` merges a fork's changes back into its parent source bucket. The gateway requires the merge source to be a direct fork of the target, so the request targets the source bucket and names the fork as the merge source. Pass `forkSnapshot` to merge from a specific snapshot of the fork.
+- `rebaseFork(forkName, options?)` re-bases a fork onto the latest state of its source bucket.
+
+Both return the resulting `snapshotVersion` (read from the `X-Tigris-Snapshot-Version` response header).
+
+```ts
+const { data } = await mergeFork('my-fork', 'source-bucket');
+// data.snapshotVersion: string
+
+await rebaseFork('my-fork');
+```

--- a/packages/storage/src/lib/bucket/forks.ts
+++ b/packages/storage/src/lib/bucket/forks.ts
@@ -1,4 +1,6 @@
+import { handleError, TigrisHeaders } from '@shared/index';
 import { config } from '../config';
+import { createStorageClient } from '../http-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
 import { listForksLegacy } from './_fork';
 import { fetchBucketListing } from './listing';
@@ -89,4 +91,118 @@ export async function listForks(
       paginationToken: data.paginationToken,
     },
   };
+}
+
+export type MergeForkOptions = {
+  /**
+   * Merge from a specific snapshot of the fork (the merge source) rather than
+   * its current state. Maps to `X-Tigris-Merge-Source-Bucket-Snapshot`.
+   */
+  forkSnapshot?: string;
+  config?: TigrisStorageConfig;
+};
+
+export type MergeForkResponse = {
+  snapshotVersion: string;
+};
+
+export async function mergeFork(
+  forkName: string,
+  sourceBucketName: string,
+  options?: MergeForkOptions
+): Promise<TigrisStorageResponse<MergeForkResponse, Error>> {
+  if (!forkName || !sourceBucketName) {
+    return {
+      error: new Error('Fork name and source bucket name are required'),
+    };
+  }
+
+  const { data: storageHttpClient, error: storageHttpClientError } =
+    createStorageClient(options?.config);
+
+  if (storageHttpClientError) {
+    return { error: storageHttpClientError };
+  }
+
+  try {
+    // The gateway merges a fork back into its parent: the request targets the
+    // parent (`sourceBucketName`) and names the fork as the merge source. The
+    // merge source must be a direct fork of the target, otherwise the gateway
+    // returns `400 InvalidArgument`.
+    const response = await storageHttpClient.request<unknown, unknown>({
+      method: 'PUT',
+      path: `/${sourceBucketName}`,
+      headers: {
+        [TigrisHeaders.FORK_MERGE_SOURCE_BUCKET]: forkName,
+        ...(options?.forkSnapshot
+          ? {
+              [TigrisHeaders.FORK_MERGE_SOURCE_BUCKET_SNAPSHOT]:
+                options?.forkSnapshot,
+            }
+          : {}),
+      },
+    });
+
+    if (response.error) {
+      return { error: response.error };
+    }
+
+    return {
+      data: {
+        snapshotVersion:
+          response.headers.get(TigrisHeaders.SNAPSHOT_VERSION) ?? '',
+      },
+    };
+  } catch (error) {
+    return handleError(error as Error);
+  }
+}
+
+export type RebaseForkOptions = {
+  config?: TigrisStorageConfig;
+};
+
+export type RebaseForkResponse = {
+  snapshotVersion: string;
+};
+
+export async function rebaseFork(
+  forkName: string,
+  options?: RebaseForkOptions
+): Promise<TigrisStorageResponse<RebaseForkResponse, Error>> {
+  if (!forkName) {
+    return {
+      error: new Error('Fork name is required'),
+    };
+  }
+
+  const { data: storageHttpClient, error: storageHttpClientError } =
+    createStorageClient(options?.config);
+
+  if (storageHttpClientError) {
+    return { error: storageHttpClientError };
+  }
+
+  try {
+    const response = await storageHttpClient.request<unknown, unknown>({
+      method: 'PUT',
+      path: `/${forkName}`,
+      headers: {
+        [TigrisHeaders.REBASE]: 'true',
+      },
+    });
+
+    if (response.error) {
+      return { error: response.error };
+    }
+
+    return {
+      data: {
+        snapshotVersion:
+          response.headers.get(TigrisHeaders.SNAPSHOT_VERSION) ?? '',
+      },
+    };
+  } catch (error) {
+    return handleError(error as Error);
+  }
 }

--- a/packages/storage/src/server.ts
+++ b/packages/storage/src/server.ts
@@ -10,6 +10,12 @@ export {
   type ListForksOptions,
   type ListForksResponse,
   listForks,
+  type MergeForkOptions,
+  type MergeForkResponse,
+  mergeFork,
+  type RebaseForkOptions,
+  type RebaseForkResponse,
+  rebaseFork,
 } from './lib/bucket/forks';
 export {
   type BucketInfoResponse,

--- a/packages/storage/src/test/fork-merge-rebase.integration.test.ts
+++ b/packages/storage/src/test/fork-merge-rebase.integration.test.ts
@@ -1,0 +1,222 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createBucket } from '../lib/bucket/create';
+import { mergeFork, rebaseFork } from '../lib/bucket/forks';
+import { removeBucket } from '../lib/bucket/remove';
+import { createBucketSnapshot } from '../lib/bucket/snapshot';
+import { config } from '../lib/config';
+import { get } from '../lib/object/get';
+import { put } from '../lib/object/put';
+import { shouldSkipIntegrationTests } from './setup';
+
+const skipTests = shouldSkipIntegrationTests();
+
+// Target a specific bucket (a source or one of its forks) by overriding the
+// bucket on the shared config.
+const bucketConfig = (bucket: string) => ({ ...config, bucket });
+
+// Bucket creation and fork relationships are eventually consistent; give the
+// gateway a moment before exercising merge/rebase against a fresh fork.
+const waitForConsistency = (ms = 10_000) =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+describe.skipIf(skipTests)('mergeFork integration', () => {
+  const ts = Date.now();
+  const sourceBucket = `test-merge-src-${ts}`.toLowerCase();
+  const forkBucket = `test-merge-fork-${ts}`.toLowerCase();
+  const snapshotForkBucket = `test-merge-fork-snap-${ts}`.toLowerCase();
+  const bucketsToCleanup: string[] = [];
+
+  beforeAll(async () => {
+    const src = await createBucket(sourceBucket, {
+      enableSnapshot: true,
+      config,
+    });
+    expect(
+      src.error,
+      `source bucket create failed: ${src.error?.message}`
+    ).toBeUndefined();
+    bucketsToCleanup.push(sourceBucket);
+
+    // Seed the source with an object that exists before either fork is made.
+    const seed = await put('base.txt', 'base', {
+      config: bucketConfig(sourceBucket),
+    });
+    expect(seed.error).toBeUndefined();
+
+    const fork = await createBucket(forkBucket, {
+      sourceBucketName: sourceBucket,
+      config,
+    });
+    expect(
+      fork.error,
+      `fork create failed: ${fork.error?.message}`
+    ).toBeUndefined();
+    bucketsToCleanup.push(forkBucket);
+
+    const snapFork = await createBucket(snapshotForkBucket, {
+      sourceBucketName: sourceBucket,
+      config,
+    });
+    expect(snapFork.error).toBeUndefined();
+    bucketsToCleanup.push(snapshotForkBucket);
+
+    await waitForConsistency();
+  }, 60_000);
+
+  afterAll(async () => {
+    // Remove forks before the parent so the source bucket can be deleted.
+    const order = [forkBucket, snapshotForkBucket, sourceBucket].filter((b) =>
+      bucketsToCleanup.includes(b)
+    );
+    for (const bucket of order) {
+      await removeBucket(bucket, { force: true, config });
+    }
+  });
+
+  it('merges a fork back into its source and returns a snapshot version', async () => {
+    // A change made on the fork after it diverged from the source.
+    const change = await put('fork-only.txt', 'made in fork', {
+      config: bucketConfig(forkBucket),
+    });
+    expect(change.error).toBeUndefined();
+
+    const result = await mergeFork(forkBucket, sourceBucket, { config });
+
+    expect(
+      result.error,
+      `merge failed: ${result.error?.message}`
+    ).toBeUndefined();
+    expect(result.data).toBeDefined();
+    // The gateway reports the resulting snapshot via response header.
+    expect(typeof result.data?.snapshotVersion).toBe('string');
+    expect(result.data?.snapshotVersion).not.toBe('');
+
+    // The fork's object should now be present in the source bucket.
+    await waitForConsistency(5_000);
+    const merged = await get('fork-only.txt', 'string', {
+      config: bucketConfig(sourceBucket),
+    });
+    expect(merged.error).toBeUndefined();
+    expect(merged.data).toBe('made in fork');
+  }, 60_000);
+
+  it('merges from a specific fork snapshot', async () => {
+    const change = await put('snap-fork-only.txt', 'snapshot content', {
+      config: bucketConfig(snapshotForkBucket),
+    });
+    expect(change.error).toBeUndefined();
+
+    // The optional snapshot scopes the merge to a snapshot of the *fork*
+    // (the merge source), not of the parent bucket.
+    const snap = await createBucketSnapshot(snapshotForkBucket, { config });
+    expect(snap.error).toBeUndefined();
+    const version = snap.data?.snapshotVersion as string;
+    expect(version).toBeTruthy();
+
+    const result = await mergeFork(snapshotForkBucket, sourceBucket, {
+      forkSnapshot: version,
+      config,
+    });
+
+    expect(
+      result.error,
+      `snapshot merge failed: ${result.error?.message}`
+    ).toBeUndefined();
+    expect(result.data?.snapshotVersion).not.toBe('');
+  }, 60_000);
+
+  // ── Validation errors (no network) ──
+
+  it('returns an error when forkName is missing', async () => {
+    const result = await mergeFork('', sourceBucket, { config });
+    expect(result.error).toBeDefined();
+    expect(result.error?.message).toBe(
+      'Fork name and source bucket name are required'
+    );
+  });
+
+  it('returns an error when sourceBucketName is missing', async () => {
+    const result = await mergeFork(forkBucket, '', { config });
+    expect(result.error).toBeDefined();
+    expect(result.error?.message).toBe(
+      'Fork name and source bucket name are required'
+    );
+  });
+
+  it('returns an error when the merge source is not a fork of the target', async () => {
+    // Two unrelated buckets — neither is a fork of the other.
+    const result = await mergeFork(sourceBucket, forkBucket, { config });
+    expect(result.error).toBeDefined();
+  }, 30_000);
+});
+
+describe.skipIf(skipTests)('rebaseFork integration', () => {
+  const ts = Date.now();
+  const sourceBucket = `test-rebase-src-${ts}`.toLowerCase();
+  const forkBucket = `test-rebase-fork-${ts}`.toLowerCase();
+  const bucketsToCleanup: string[] = [];
+
+  beforeAll(async () => {
+    const src = await createBucket(sourceBucket, {
+      enableSnapshot: true,
+      config,
+    });
+    expect(src.error).toBeUndefined();
+    bucketsToCleanup.push(sourceBucket);
+
+    const seed = await put('base.txt', 'base', {
+      config: bucketConfig(sourceBucket),
+    });
+    expect(seed.error).toBeUndefined();
+
+    const fork = await createBucket(forkBucket, {
+      sourceBucketName: sourceBucket,
+      config,
+    });
+    expect(fork.error).toBeUndefined();
+    bucketsToCleanup.push(forkBucket);
+
+    await waitForConsistency();
+  }, 60_000);
+
+  afterAll(async () => {
+    const order = [forkBucket, sourceBucket].filter((b) =>
+      bucketsToCleanup.includes(b)
+    );
+    for (const bucket of order) {
+      await removeBucket(bucket, { force: true, config });
+    }
+  });
+
+  it('rebases a fork onto its source and returns a snapshot version', async () => {
+    // Advance the source after the fork was created.
+    const change = await put('rebased.txt', 'from source', {
+      config: bucketConfig(sourceBucket),
+    });
+    expect(change.error).toBeUndefined();
+
+    const result = await rebaseFork(forkBucket, { config });
+
+    expect(
+      result.error,
+      `rebase failed: ${result.error?.message}`
+    ).toBeUndefined();
+    expect(result.data).toBeDefined();
+    expect(typeof result.data?.snapshotVersion).toBe('string');
+    expect(result.data?.snapshotVersion).not.toBe('');
+
+    // The source's new object should now be visible in the rebased fork.
+    await waitForConsistency(5_000);
+    const rebased = await get('rebased.txt', 'string', {
+      config: bucketConfig(forkBucket),
+    });
+    expect(rebased.error).toBeUndefined();
+    expect(rebased.data).toBe('from source');
+  }, 60_000);
+
+  it('returns an error when forkName is missing', async () => {
+    const result = await rebaseFork('', { config });
+    expect(result.error).toBeDefined();
+    expect(result.error?.message).toBe('Fork name is required');
+  });
+});

--- a/shared/headers.ts
+++ b/shared/headers.ts
@@ -15,6 +15,7 @@ export enum TigrisHeaders {
   READ_SOURCE = 'X-Tigris-Read-Source',
 
   REGIONS = 'X-Tigris-Regions',
+
   SNAPSHOT = 'X-Tigris-Snapshot',
   FORK = 'X-Tigris-Fork',
   SNAPSHOT_VERSION = 'X-Tigris-Snapshot-Version',
@@ -22,6 +23,11 @@ export enum TigrisHeaders {
   HAS_FORKS = 'X-Tigris-Is-Fork-Parent',
   FORK_SOURCE_BUCKET = 'X-Tigris-Fork-Source-Bucket',
   FORK_SOURCE_BUCKET_SNAPSHOT = 'X-Tigris-Fork-Source-Bucket-Snapshot',
+
+  FORK_MERGE_SOURCE_BUCKET = 'X-Tigris-Merge-Source-Bucket',
+  FORK_MERGE_SOURCE_BUCKET_SNAPSHOT = 'X-Tigris-Merge-Source-Bucket-Snapshot',
+
+  REBASE = 'X-Tigris-Rebase',
 
   RENAME = 'X-Tigris-Rename',
   COPY_SOURCE = 'X-Amz-Copy-Source',


### PR DESCRIPTION
## Summary

Adds two fork-management operations to `@tigrisdata/storage`:

- **`mergeFork(forkName, sourceBucketName, options?)`** — merges a fork's changes back into its parent source bucket. The gateway requires the merge source to be a *direct fork* of the target, so the request targets the source bucket (`PUT /{source}`) and names the fork via `X-Tigris-Merge-Source-Bucket`. Pass `forkSnapshot` to merge from a specific snapshot of the fork.
- **`rebaseFork(forkName, options?)`** — re-bases a fork onto the latest state of its source bucket (`X-Tigris-Rebase: true`).

Both return the resulting `snapshotVersion`, read from the `X-Tigris-Snapshot-Version` response header, and are exported from `server.ts`.

```ts
const { data } = await mergeFork('my-fork', 'source-bucket');
// data.snapshotVersion: string

// Merge from a specific snapshot of the fork
await mergeFork('my-fork', 'source-bucket', { forkSnapshot });

await rebaseFork('my-fork');
```

## Notes / fixes during review

- **Merge direction**: the gateway rejects `PUT /{fork}` + `Merge-Source-Bucket: source` with `400 InvalidArgument` ("merge source must be a direct fork of target"). The correct shape is target = source, merge-source = fork — verified live (the fork's object lands in the source bucket after merge).
- **`snapshotVersion`** comes back in the `X-Tigris-Snapshot-Version` response header (the body is empty), matching `createBucketSnapshot`.
- **Option naming**: the merge snapshot option is `forkSnapshot` (it maps to `X-Tigris-Merge-Source-Bucket-Snapshot`, which the gateway treats as a snapshot *of the fork* / merge source — not the parent). Distinct from `createBucket`'s `sourceBucketSnapshot`, which really is a snapshot of the source/parent.
- New headers added to `shared/headers.ts`: `X-Tigris-Merge-Source-Bucket`, `X-Tigris-Merge-Source-Bucket-Snapshot`, `X-Tigris-Rebase`.

## Testing

`packages/storage/src/test/fork-merge-rebase.integration.test.ts` (7 tests, all passing against the live gateway):
- merge transfers fork data into the source + returns a snapshot version
- merge from a specific fork snapshot
- rebase pulls source changes into the fork + returns a snapshot version
- validation errors (missing fork/source names, non-fork merge source)

`tsc` and `biome check` are clean. A `minor` changeset is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New bucket-mutating gateway operations can change parent/fork data; behavior depends on correct merge direction and fork relationships, though the surface is additive with integration coverage.
> 
> **Overview**
> Adds **`mergeFork`** and **`rebaseFork`** to `@tigrisdata/storage` for bucket fork lifecycle: merge applies a direct fork’s changes into its parent; rebase updates a fork from the parent’s latest state. Both are exported from `server.ts` with a **minor** changeset.
> 
> **`mergeFork(forkName, sourceBucketName, options?)`** issues `PUT /{sourceBucketName}` with `X-Tigris-Merge-Source-Bucket` set to the fork (gateway expects target = parent, merge source = fork). Optional **`forkSnapshot`** sends `X-Tigris-Merge-Source-Bucket-Snapshot` to merge from a specific fork snapshot.
> 
> **`rebaseFork(forkName, options?)`** issues `PUT /{forkName}` with `X-Tigris-Rebase: true`. Each operation returns **`snapshotVersion`** from `X-Tigris-Snapshot-Version`, aligned with snapshot APIs. Client-side validation covers missing names; gateway errors surface for invalid merge relationships.
> 
> Shared **`TigrisHeaders`** gains merge and rebase constants. Integration tests cover happy paths, snapshot-scoped merge, validation, and live gateway behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afe33ea8a92f641292df530e7ee441addc1e27d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->