### PR TITLE
feat(storage): add setBucketType, enableSnapshot, and disableSnapshot

### DIFF
--- a/.changeset/set-bucket-type.md
+++ b/.changeset/set-bucket-type.md
@@ -1,0 +1,18 @@
+---
+'@tigrisdata/storage': minor
+---
+
+Add `setBucketType`, `enableSnapshot`, and `disableSnapshot` to change a bucket's type (regular vs snapshot) after creation.
+
+- `setBucketType(bucketName, type, options?)` sets the bucket type to `BucketTypes.Regular` or `BucketTypes.Snapshot`.
+- `enableSnapshot(bucketName, options?)` switches a bucket to a snapshot bucket.
+- `disableSnapshot(bucketName, options?)` switches it back to a regular bucket. It is rejected with an error when the bucket still has dependent forks, since a snapshot parent cannot become regular while forks depend on it.
+
+Also exports the `BucketTypes` enum and the `SetBucketTypeOptions` / `BucketSnapshotOptions` option types.
+
+```ts
+import { setBucketType, BucketTypes, enableSnapshot } from '@tigrisdata/storage';
+
+await setBucketType('my-bucket', BucketTypes.Snapshot);
+await enableSnapshot('my-bucket');
+```

--- a/packages/storage/src/lib/bucket/set/type.ts
+++ b/packages/storage/src/lib/bucket/set/type.ts
@@ -1,0 +1,52 @@
+import type { TigrisStorageConfig, TigrisStorageResponse } from '../../types';
+import { getBucketInfo } from '../info';
+import type { UpdateBucketResponse } from '../types';
+import { setBucketSettings } from './set';
+
+export enum BucketTypes {
+  Regular = 0,
+  Snapshot = 1,
+}
+
+export type SetBucketTypeOptions = {
+  config?: Omit<TigrisStorageConfig, 'bucket'>;
+};
+
+export async function setBucketType(
+  bucketName: string,
+  type: BucketTypes,
+  options?: SetBucketTypeOptions
+): Promise<TigrisStorageResponse<UpdateBucketResponse, Error>> {
+  return setBucketSettings(bucketName, {
+    body: { type },
+    config: options?.config,
+  });
+}
+
+export type BucketSnapshotOptions = {
+  config?: Omit<TigrisStorageConfig, 'bucket'>;
+};
+
+export async function enableSnapshot(
+  bucketName: string,
+  options?: BucketSnapshotOptions
+): Promise<TigrisStorageResponse<UpdateBucketResponse, Error>> {
+  return setBucketType(bucketName, BucketTypes.Snapshot, options);
+}
+
+export async function disableSnapshot(
+  bucketName: string,
+  options?: BucketSnapshotOptions
+): Promise<TigrisStorageResponse<UpdateBucketResponse, Error>> {
+  const { data } = await getBucketInfo(bucketName, options);
+
+  if (data?.forkInfo?.hasChildren === true) {
+    return {
+      error: new Error(
+        'Bucket type cannot be changed from Snapshot to Regular while it has dependent forks'
+      ),
+    };
+  }
+
+  return setBucketType(bucketName, BucketTypes.Regular, options);
+}

--- a/packages/storage/src/lib/bucket/utils/api.ts
+++ b/packages/storage/src/lib/bucket/utils/api.ts
@@ -72,6 +72,7 @@ type BucketApiSettings = {
   object_notifications?: BucketApiNotifications;
   soft_delete?: { enabled: true; retention_days: number } | { enabled: false };
   additional_http_headers?: { 'X-Content-Type-Options': 'nosniff' } | null;
+  type?: 0 | 1;
 };
 
 export type GetBucketInfoApiResponseBody = BucketApiSettings & {
@@ -86,7 +87,6 @@ export type GetBucketInfoApiResponseBody = BucketApiSettings & {
   };
   name: string;
   storage_class: StorageClass;
-  type?: 1;
   tier_sizes: Record<string, number>;
   estimated_unique_rows?: number; // number of objects
   estimated_size?: number; // estimated size of the bucket in bytes

--- a/packages/storage/src/server.ts
+++ b/packages/storage/src/server.ts
@@ -45,6 +45,14 @@ export {
 } from './lib/bucket/set/notifications';
 export { type SetBucketTtlOptions, setBucketTtl } from './lib/bucket/set/ttl';
 export {
+  type BucketSnapshotOptions,
+  BucketTypes,
+  disableSnapshot,
+  enableSnapshot,
+  type SetBucketTypeOptions,
+  setBucketType,
+} from './lib/bucket/set/type';
+export {
   type BucketSnapshot,
   type CreateBucketSnapshotOptions,
   type CreateBucketSnapshotResponse,

--- a/packages/storage/src/test/bucket-listing.integration.test.ts
+++ b/packages/storage/src/test/bucket-listing.integration.test.ts
@@ -28,7 +28,7 @@ describe.skipIf(skipTests)('listBuckets pagination', () => {
     }
     // Bucket listing is eventually consistent.
     await new Promise((resolve) => setTimeout(resolve, 10_000));
-  }, 60_000);
+  });
 
   afterAll(async () => {
     for (const name of created) {

--- a/packages/storage/src/test/bucket-type.integration.test.ts
+++ b/packages/storage/src/test/bucket-type.integration.test.ts
@@ -1,0 +1,147 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import { createBucket } from '../lib/bucket/create';
+import { getBucketInfo } from '../lib/bucket/info';
+import { removeBucket } from '../lib/bucket/remove';
+import {
+  BucketTypes,
+  disableSnapshot,
+  enableSnapshot,
+  setBucketType,
+} from '../lib/bucket/set/type';
+import { config } from '../lib/config';
+import { shouldSkipIntegrationTests } from './setup';
+
+const skipTests = shouldSkipIntegrationTests();
+
+const testBucket = (suffix: string) =>
+  `test-snap-${suffix}-${Date.now()}`.toLowerCase();
+
+// Bucket type changes (and fork relationships) are eventually consistent, so
+// assertions poll getBucketInfo rather than reading once.
+const POLL = { timeout: 20_000, interval: 1000 };
+
+const isSnapshotEnabled = async (bucket: string) =>
+  (await getBucketInfo(bucket, { config })).data?.isSnapshotEnabled;
+
+describe.skipIf(skipTests)('setBucketType / enable-disable snapshot', () => {
+  const buckets: string[] = [];
+  const forks: string[] = [];
+
+  afterAll(async () => {
+    // Remove forks before their parents so the parent can be deleted.
+    for (const fork of forks) {
+      await removeBucket(fork, { force: true, config });
+    }
+    for (const bucket of buckets) {
+      await removeBucket(bucket, { force: true, config });
+    }
+  });
+
+  it('setBucketType(Snapshot) turns a regular bucket into a snapshot bucket', async () => {
+    const name = testBucket('type-snap');
+    buckets.push(name);
+
+    const created = await createBucket(name, { config });
+    expect(created.error).toBeUndefined();
+    expect(created.data?.isSnapshotEnabled).toBe(false);
+
+    const result = await setBucketType(name, BucketTypes.Snapshot, { config });
+    expect(
+      result.error,
+      `setBucketType failed: ${result.error?.message}`
+    ).toBeUndefined();
+    expect(result.data).toEqual({ bucket: name, updated: true });
+
+    await expect.poll(() => isSnapshotEnabled(name), POLL).toBe(true);
+  });
+
+  it('setBucketType(Regular) turns a snapshot bucket back to regular', async () => {
+    const name = testBucket('type-reg');
+    buckets.push(name);
+
+    const created = await createBucket(name, { enableSnapshot: true, config });
+    expect(created.error).toBeUndefined();
+    expect(created.data?.isSnapshotEnabled).toBe(true);
+
+    const result = await setBucketType(name, BucketTypes.Regular, { config });
+    expect(
+      result.error,
+      `setBucketType failed: ${result.error?.message}`
+    ).toBeUndefined();
+
+    await expect.poll(() => isSnapshotEnabled(name), POLL).toBe(false);
+  });
+
+  it('enableSnapshot converts a regular bucket into a snapshot bucket', async () => {
+    const name = testBucket('enable');
+    buckets.push(name);
+
+    await createBucket(name, { config });
+
+    const result = await enableSnapshot(name, { config });
+    expect(
+      result.error,
+      `enableSnapshot failed: ${result.error?.message}`
+    ).toBeUndefined();
+    expect(result.data).toEqual({ bucket: name, updated: true });
+
+    await expect.poll(() => isSnapshotEnabled(name), POLL).toBe(true);
+  });
+
+  it('disableSnapshot converts a snapshot bucket back to regular', async () => {
+    const name = testBucket('disable');
+    buckets.push(name);
+
+    await createBucket(name, { enableSnapshot: true, config });
+
+    const result = await disableSnapshot(name, { config });
+    expect(
+      result.error,
+      `disableSnapshot failed: ${result.error?.message}`
+    ).toBeUndefined();
+    expect(result.data).toEqual({ bucket: name, updated: true });
+
+    await expect.poll(() => isSnapshotEnabled(name), POLL).toBe(false);
+  });
+
+  it('disableSnapshot is rejected while the bucket has dependent forks', async () => {
+    const source = testBucket('src');
+    const fork = testBucket('fork');
+    buckets.push(source);
+    forks.push(fork);
+
+    const createdSource = await createBucket(source, {
+      enableSnapshot: true,
+      config,
+    });
+    expect(createdSource.error).toBeUndefined();
+
+    const createdFork = await createBucket(fork, {
+      sourceBucketName: source,
+      config,
+    });
+    expect(
+      createdFork.error,
+      `fork create failed: ${createdFork.error?.message}`
+    ).toBeUndefined();
+
+    // Wait until the parent reports the dependent fork so we exercise the
+    // guard rather than a not-yet-consistent read.
+    await expect
+      .poll(
+        async () =>
+          (await getBucketInfo(source, { config })).data?.forkInfo?.hasChildren,
+        { timeout: 30_000, interval: 2000 }
+      )
+      .toBe(true);
+
+    const result = await disableSnapshot(source, { config });
+    expect(result.error).toBeDefined();
+    expect(result.error?.message).toBe(
+      'Bucket type cannot be changed from Snapshot to Regular while it has dependent forks'
+    );
+
+    // The change must have been rejected, leaving it a snapshot bucket.
+    expect(await isSnapshotEnabled(source)).toBe(true);
+  });
+});

--- a/packages/storage/src/test/integration.test.ts
+++ b/packages/storage/src/test/integration.test.ts
@@ -651,6 +651,9 @@ describe.skipIf(skipTests)('Tigris Storage Integration Tests', () => {
     const forkA = `test-fork-a-${ts}`.toLowerCase();
     const forkB = `test-fork-b-${ts}`.toLowerCase();
     const bucketsToCleanup: string[] = [];
+    // Fork listing is eventually consistent and can lag, so tests poll for the
+    // forks to surface instead of reading once.
+    const POLL = { timeout: 45_000, interval: 2000 };
 
     beforeAll(async () => {
       const src = await createBucket(sourceBucket, {
@@ -683,10 +686,6 @@ describe.skipIf(skipTests)('Tigris Storage Integration Tests', () => {
       });
       expect(b.error).toBeUndefined();
       bucketsToCleanup.push(forkB);
-
-      // Bucket listing is eventually consistent; give the gateway a moment to
-      // surface the freshly created forks before the assertions run.
-      await new Promise((resolve) => setTimeout(resolve, 10_000));
     });
 
     afterAll(async () => {
@@ -700,31 +699,43 @@ describe.skipIf(skipTests)('Tigris Storage Integration Tests', () => {
     });
 
     it('should list all forks of a source bucket', async () => {
-      const result = await listForks(sourceBucket, { config });
-
-      expect(result.error).toBeUndefined();
-      expect(result.data).toBeDefined();
-
-      const names = result.data?.forks.map((f) => f.name) ?? [];
-      expect(names).toContain(forkA);
-      expect(names).toContain(forkB);
+      await expect
+        .poll(async () => {
+          const result = await listForks(sourceBucket, { config });
+          const names = result.data?.forks.map((f) => f.name) ?? [];
+          return names.includes(forkA) && names.includes(forkB);
+        }, POLL)
+        .toBe(true);
     });
 
     it('should not include buckets forked from a different source', async () => {
-      const result = await listForks(sourceBucket, { config });
-
-      const names = result.data?.forks.map((f) => f.name) ?? [];
-      expect(names).not.toContain(unrelatedBucket);
-      expect(names).not.toContain(sourceBucket);
+      await expect
+        .poll(async () => {
+          const result = await listForks(sourceBucket, { config });
+          const names = result.data?.forks.map((f) => f.name) ?? [];
+          // Wait for the forks to surface, then confirm the unrelated bucket
+          // and the source itself are absent.
+          return (
+            names.includes(forkA) &&
+            !names.includes(unrelatedBucket) &&
+            !names.includes(sourceBucket)
+          );
+        }, POLL)
+        .toBe(true);
     });
 
     it('should populate fork metadata for each returned bucket', async () => {
-      const result = await listForks(sourceBucket, { config });
-
-      const fork = result.data?.forks.find((f) => f.name === forkA);
-      expect(fork).toBeDefined();
-      expect(typeof fork?.name).toBe('string');
-      expect(fork?.creationDate).toBeInstanceOf(Date);
+      await expect
+        .poll(async () => {
+          const result = await listForks(sourceBucket, { config });
+          const fork = result.data?.forks.find((f) => f.name === forkA);
+          return (
+            fork !== undefined &&
+            typeof fork.name === 'string' &&
+            fork.creationDate instanceof Date
+          );
+        }, POLL)
+        .toBe(true);
     });
 
     // Skipped until the gateway update returns forkInfo for

--- a/packages/storage/vitest.config.ts
+++ b/packages/storage/vitest.config.ts
@@ -9,6 +9,11 @@ export default mergeConfig(
       include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
       exclude: ['node_modules', 'dist'],
       setupFiles: ['src/test/setup.ts'],
+      // Live-gateway integration tests poll eventually-consistent state, so they
+      // need a longer ceiling than the 30s base default. Configure it once here
+      // instead of overriding per-test.
+      testTimeout: 60_000,
+      hookTimeout: 60_000,
       // Integration tests run against a live, eventually-consistent gateway,
       // so a transient read-after-write/delete race or a slow request can fail
       // an otherwise-correct assertion. Retry to absorb those flakes instead of


### PR DESCRIPTION
## Summary

Adds the ability to change a bucket's type (regular ↔ snapshot) **after** creation.

- **`setBucketType(bucketName, type, options?)`** — sets the type to `BucketTypes.Regular` or `BucketTypes.Snapshot` via the bucket-settings `PATCH`.
- **`enableSnapshot(bucketName, options?)`** / **`disableSnapshot(bucketName, options?)`** — shorthands over `setBucketType`. `disableSnapshot` is rejected with an error when the bucket still has dependent forks (a snapshot parent can't become regular while forks depend on it).
- Exports the `BucketTypes` enum and the `SetBucketTypeOptions` / `BucketSnapshotOptions` option types from the server entry.

```ts
import { setBucketType, BucketTypes, enableSnapshot } from '@tigrisdata/storage';

await setBucketType('my-bucket', BucketTypes.Snapshot);
await enableSnapshot('my-bucket');
```

## Testing

`packages/storage/src/test/bucket-type.integration.test.ts` (5 tests, all passing against the live gateway):
- `setBucketType(Snapshot)` / `setBucketType(Regular)` both directions
- `enableSnapshot` / `disableSnapshot`
- `disableSnapshot` rejected while the bucket has dependent forks (waits for the parent to register the fork first)

Assertions poll `getBucketInfo` since bucket-type changes are eventually consistent.

## Notes

- The numeric `BucketTypes` enum is intentionally distinct from the existing string-union `BucketType` type (`'Regular' | 'Snapshot'`); both are exported and verified to coexist cleanly in the bundled `.d.ts`, and `BucketTypes` is confirmed to survive as a runtime value (not a type-only export).
- Replaced the per-test timeout overrides with a single storage-wide `testTimeout`/`hookTimeout: 60_000` in `vitest.config.ts` (the live-gateway polls need more than the 30s base default).
- A `minor` changeset is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bucket configuration and fork/snapshot semantics via PATCH; incorrect type handling could break fork workflows, though `disableSnapshot` adds an explicit guard for dependent forks.
> 
> **Overview**
> Adds **post-creation** bucket type switching in `@tigrisdata/storage`: **`setBucketType`**, **`enableSnapshot`**, and **`disableSnapshot`**, backed by the existing bucket-settings PATCH via `setBucketSettings` with a numeric **`BucketTypes`** enum (`Regular` / `Snapshot`). **`disableSnapshot`** checks **`getBucketInfo`** and returns a client error if **`forkInfo.hasChildren`** is true so snapshot parents with forks cannot revert to regular.
> 
> Bucket API typings now include **`type?: 0 | 1`** on shared settings (moved off the info-only response shape). The server entry re-exports the new APIs and option types; a **minor** changeset documents the release.
> 
> Integration coverage adds **`bucket-type.integration.test.ts`** (both directions, shorthand helpers, fork guard). **`listForks`** tests and storage **`vitest.config`** switch from fixed sleeps to **`expect.poll`** and a package-wide **60s** test/hook timeout for eventually consistent gateway behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d07872cb5fac2148c3834f18e1fc87368fad759. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->