### PR TITLE
feat(iam): add createTeam, editTeam, and listTeams

### DIFF
--- a/.changeset/iam-teams.md
+++ b/.changeset/iam-teams.md
@@ -1,0 +1,25 @@
+---
+'@tigrisdata/iam': minor
+---
+
+Add `createTeam`, `editTeam`, and `listTeams` for managing teams within an organization.
+
+- `createTeam(team, options?)` creates a team from a `CreateTeamInput` (`name` required, optional `description` and `members`) and returns the new `teamId`.
+- `editTeam(teamId, team, options?)` applies a partial update (`Partial<CreateTeamInput>`); it errors with `No fields to update` when no fields are provided.
+- `listTeams(options?)` returns the organization's teams, each mapped to a `Team` (`id`, `name`, `description`, `members`, `createdAt`, `updatedAt`).
+
+Also exports the `CreateTeamInput`, `CreateTeamOptions`, `CreateTeamResponse`, `EditTeamOptions`, `EditTeamResponse`, `ListTeamsOptions`, `ListTeamsResponse`, and `Team` types.
+
+```ts
+import { createTeam, editTeam, listTeams } from '@tigrisdata/iam';
+
+const { data } = await createTeam({
+  name: 'engineering',
+  description: 'Engineering team',
+  members: ['user@example.com'],
+});
+
+await editTeam(data.teamId, { name: 'engineering-renamed' });
+
+const { data: teams } = await listTeams();
+```

--- a/packages/iam/src/index.ts
+++ b/packages/iam/src/index.ts
@@ -65,6 +65,23 @@ export type {
   PolicyDocument,
   PolicyStatement,
 } from './lib/policy/types';
+export {
+  type CreateTeamInput,
+  type CreateTeamOptions,
+  type CreateTeamResponse,
+  createTeam,
+} from './lib/team/create';
+export {
+  type EditTeamOptions,
+  type EditTeamResponse,
+  editTeam,
+} from './lib/team/edit';
+export {
+  type ListTeamsOptions,
+  type ListTeamsResponse,
+  listTeams,
+  type Team,
+} from './lib/team/list';
 export { type InviteUserOptions, inviteUser } from './lib/users/invite';
 export {
   type ListUsersOptions,

--- a/packages/iam/src/lib/http-client.ts
+++ b/packages/iam/src/lib/http-client.ts
@@ -3,6 +3,8 @@ import { config, DEFAULT_ENDPOINTS } from './config';
 import type { TigrisIAMConfig, TigrisIAMResponse } from './types';
 
 export const IAM_ENDPOINTS = {
+  // Teams
+  teams: '/tigris-iam/teams',
   // Whoami
   whoami: '/users/whoami',
   // Users

--- a/packages/iam/src/lib/team/create.ts
+++ b/packages/iam/src/lib/team/create.ts
@@ -1,0 +1,71 @@
+import { createIAMClient, IAM_ENDPOINTS } from '../http-client';
+import type { TigrisIAMConfig, TigrisIAMResponse } from '../types';
+
+export type CreateTeamInput = {
+  name: string;
+  description?: string;
+  members?: string[];
+};
+
+export type CreateTeamOptions = {
+  config?: TigrisIAMConfig;
+};
+
+export type CreateTeamResponse = {
+  teamId: string;
+};
+
+type CreateTeamApiResponse = {
+  status: 'success' | 'error';
+  message?: string;
+  result: {
+    team_id: string;
+  };
+};
+
+export async function createTeam(
+  team: CreateTeamInput,
+  options?: CreateTeamOptions
+): Promise<TigrisIAMResponse<CreateTeamResponse, Error>> {
+  const { data: client, error: clientError } = createIAMClient(options?.config);
+
+  if (clientError || !client) {
+    return { error: clientError };
+  }
+
+  const { data, error } = await client.request<unknown, CreateTeamApiResponse>({
+    method: 'POST',
+    path: IAM_ENDPOINTS.teams,
+    body: {
+      name: team.name,
+      ...(team.description !== undefined && { description: team.description }),
+      ...(team.members && {
+        members: team.members.map((member) => ({
+          user_id: member,
+        })),
+      }),
+    },
+  });
+
+  if (error) {
+    return { error };
+  }
+
+  if (data.status === 'error') {
+    return {
+      error: new Error(data.message ?? 'Failed to create team'),
+    };
+  }
+
+  if (!data.result?.team_id) {
+    return {
+      error: new Error('Failed to create team'),
+    };
+  }
+
+  return {
+    data: {
+      teamId: data.result.team_id,
+    },
+  };
+}

--- a/packages/iam/src/lib/team/edit.ts
+++ b/packages/iam/src/lib/team/edit.ts
@@ -1,0 +1,65 @@
+import { createIAMClient, IAM_ENDPOINTS } from '../http-client';
+import type { TigrisIAMConfig, TigrisIAMResponse } from '../types';
+import type { CreateTeamInput } from './create';
+
+export type EditTeamOptions = {
+  config?: TigrisIAMConfig;
+};
+
+export type EditTeamResponse = {
+  teamId: string;
+};
+
+type EditTeamApiResponse = {
+  status: 'success' | 'error';
+  message?: string;
+  result: unknown;
+};
+
+export async function editTeam(
+  teamId: string,
+  team: Partial<CreateTeamInput>,
+  options?: EditTeamOptions
+): Promise<TigrisIAMResponse<EditTeamResponse, Error>> {
+  const { data: client, error: clientError } = createIAMClient(options?.config);
+
+  if (clientError || !client) {
+    return { error: clientError };
+  }
+
+  const body = {
+    ...(team?.name && { name: team.name }),
+    ...(team?.description !== undefined && { description: team.description }),
+    ...(team?.members && {
+      members: team.members.map((member) => ({ user_id: member })),
+    }),
+  };
+
+  if (Object.keys(body).length === 0) {
+    return {
+      error: new Error('No fields to update'),
+    };
+  }
+
+  const { data, error } = await client.request<unknown, EditTeamApiResponse>({
+    method: 'PATCH',
+    path: `${IAM_ENDPOINTS.teams}/${teamId}`,
+    body,
+  });
+
+  if (error) {
+    return { error };
+  }
+
+  if (data.status === 'error') {
+    return {
+      error: new Error(data.message ?? 'Failed to edit team'),
+    };
+  }
+
+  return {
+    data: {
+      teamId,
+    },
+  };
+}

--- a/packages/iam/src/lib/team/list.ts
+++ b/packages/iam/src/lib/team/list.ts
@@ -1,0 +1,75 @@
+import { createIAMClient, IAM_ENDPOINTS } from '../http-client';
+import type { TigrisIAMConfig, TigrisIAMResponse } from '../types';
+
+export type ListTeamsOptions = {
+  config?: TigrisIAMConfig;
+};
+
+export type ListTeamsResponse = {
+  teams: Team[];
+};
+
+export type Team = {
+  createdAt: Date;
+  description: string;
+  id: string;
+  members: string[];
+  name: string;
+  updatedAt: Date;
+};
+
+type ListTeamsApiResponse = {
+  status: 'success' | 'error';
+  message?: string;
+  result: {
+    teams: Array<{
+      created_at: string;
+      description: string;
+      id: string;
+      members: Array<{
+        user_id: string;
+      }>;
+      name: string;
+      updated_at: string;
+    }>;
+  };
+};
+
+export async function listTeams(
+  options?: ListTeamsOptions
+): Promise<TigrisIAMResponse<ListTeamsResponse, Error>> {
+  const { data: client, error } = createIAMClient(options?.config);
+
+  if (error || !client) {
+    return { error };
+  }
+
+  const response = await client.request<unknown, ListTeamsApiResponse>({
+    method: 'GET',
+    path: IAM_ENDPOINTS.teams,
+  });
+
+  if (response.error) {
+    return { error: response.error };
+  }
+
+  if (response.data.status === 'error') {
+    return {
+      error: new Error(response.data.message ?? 'Failed to list teams'),
+    };
+  }
+
+  return {
+    data: {
+      teams:
+        response.data.result?.teams?.map((team) => ({
+          createdAt: new Date(team.created_at),
+          description: team.description,
+          id: team.id,
+          members: team.members?.map((member) => member.user_id) ?? [],
+          name: team.name,
+          updatedAt: new Date(team.updated_at),
+        })) ?? [],
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Adds team management to `@tigrisdata/iam` for creating, editing, and listing teams within an organization.

- **`createTeam(team, options?)`** — creates a team from `CreateTeamInput` (`name` required, optional `description` and `members`) and returns the new `teamId`.
- **`editTeam(teamId, team, options?)`** — applies a partial update (`Partial<CreateTeamInput>`); errors with `No fields to update` when no fields are provided.
- **`listTeams(options?)`** — returns the organization's teams, each mapped to a `Team` (`id`, `name`, `description`, `members`, `createdAt`, `updatedAt`).

Adds the `/tigris-iam/teams` endpoint and exports the team functions plus their option/response/input types (`CreateTeamInput`, `CreateTeamOptions`, `CreateTeamResponse`, `EditTeamOptions`, `EditTeamResponse`, `ListTeamsOptions`, `ListTeamsResponse`, `Team`).

```ts
import { createTeam, editTeam, listTeams } from '@tigrisdata/iam';

const { data } = await createTeam({
  name: 'engineering',
  description: 'Engineering team',
  members: ['user@example.com'],
});

await editTeam(data.teamId, { name: 'engineering-renamed' });

const { data: teams } = await listTeams();
```

## Implementation notes

- All three functions follow the existing IAM conventions: `createIAMClient` auth/guard, HTTP-level error check **and** body-level `status === 'error'` check surfacing the API `message`.
- Request/response keys are mapped between the SDK's camelCase shape and the API's snake_case (`user_id`, `created_at`, …).
- `createTeam` / `editTeam` share a single `CreateTeamInput` type (edit uses `Partial<CreateTeamInput>`) for a symmetric API surface.

## Notes / follow-ups

- `deleteTeam` / `getTeam` are intentionally **not** in this PR — planned as a follow-up.
- Integration tests are deferred to a follow-up (the IAM package has no test infra yet).

## Release

Includes a changeset bumping `@tigrisdata/iam` (minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New IAM org membership APIs can affect access grouping if misused; behavior depends on the backend teams endpoint with no integration tests in this PR.
> 
> **Overview**
> Adds **organization team management** to `@tigrisdata/iam` via three new public APIs wired to `/tigris-iam/teams`.
> 
> **`createTeam`** POSTs a team (`name` plus optional `description` and `members`), maps members to `user_id` in the request body, and returns **`teamId`**. **`editTeam`** PATCHes `/{teamId}` with a partial `CreateTeamInput` and fails locally with **`No fields to update`** when the patch body would be empty. **`listTeams`** GETs all teams and normalizes API snake_case fields into the exported **`Team`** shape (including `Date` timestamps and member user IDs).
> 
> Package surface updates: new `lib/team/*` modules, **`IAM_ENDPOINTS.teams`**, re-exports from `index.ts`, and a **minor** changeset for `@tigrisdata/iam`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac5f42e95e6d5ee8d79cf247a5de13e4938af9ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->