### PR TITLE
feat(storage): support allowObjectAcl and enableDirectoryListing on createBucket

### DIFF
--- a/.changeset/create-bucket-acl-and-listing.md
+++ b/.changeset/create-bucket-acl-and-listing.md
@@ -1,0 +1,18 @@
+---
+'@tigrisdata/storage': minor
+---
+
+Support the `allowObjectAcl` and `enableDirectoryListing` options in `createBucket`.
+
+- `allowObjectAcl: true` applies the object ACL setting via a follow-up `updateBucket` call once the bucket exists (the S3 `CreateBucket` command can't carry it). If the bucket is created but the ACL update fails — whether it returns an error or throws — the returned error makes the partial state explicit.
+- `enableDirectoryListing: true` enables object listing for the bucket at creation time (relevant for public buckets). It defaults to `false` (listing disabled).
+
+```ts
+import { createBucket } from '@tigrisdata/storage';
+
+await createBucket('my-bucket', { allowObjectAcl: true });
+await createBucket('my-listable-bucket', {
+  access: 'public',
+  enableDirectoryListing: true,
+});
+```

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -506,8 +506,10 @@ createBucket(bucketName: string, options?: CreateBucketOptions): Promise<TigrisS
 | **Parameter**        | **Required** | **Values**                                                                                                                                                               |
 | -------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | access               | No           | `public` or `private`. If set to public, objects in this bucket will be publicly readable. Default value is `private`                                                    |
+| allowObjectAcl       | No           | Whether to allow per-object ACL settings. When `true`, it is applied with a follow-up request after the bucket is created. Default is `false`                            |
 | defaultTier          | No           | `STANDARD`, `STANDARD_IA`, `GLACIER` or `GLACIER_IR`. This is default object tier for all objects uploaded to it. Default is `STANDARD`                                  |
 | enableSnapshot       | No           | Enable snapshot functionality for the bucket. Default is `false`. Please note only the Standard storage tier is supported for snapshot-enabled buckets                   |
+| enableDirectoryListing | No         | Whether the bucket's objects can be listed by unauthenticated clients (relevant for public buckets). Default is `false` (listing disabled)                               |
 | locations            | No           | Bucket location configuration. See [Locations](#bucket-locations) below. Default is **global**.                                                                          |
 | sourceBucketName     | No           | The name of the source bucket to fork from.                                                                                                                              |
 | sourceBucketSnapshot | No           | The snapshot version of the source bucket to fork from.                                                                                                                  |
@@ -581,6 +583,35 @@ if (result.error) {
   console.error('Error creating forked bucket:', result.error);
 } else {
   console.log('Forked bucket created:', result.data);
+}
+```
+
+#### Create a bucket that allows per-object ACLs
+
+```ts
+const result = await createBucket('my-acl-bucket', {
+  allowObjectAcl: true,
+});
+
+if (result.error) {
+  console.error('Error creating bucket:', result.error);
+} else {
+  console.log('Bucket created with per-object ACLs allowed:', result.data);
+}
+```
+
+#### Create a bucket with directory listing enabled
+
+```ts
+const result = await createBucket('my-listable-bucket', {
+  access: 'public',
+  enableDirectoryListing: true,
+});
+
+if (result.error) {
+  console.error('Error creating bucket:', result.error);
+} else {
+  console.log('Bucket created with directory listing enabled:', result.data);
 }
 ```
 

--- a/packages/storage/src/lib/bucket/create.ts
+++ b/packages/storage/src/lib/bucket/create.ts
@@ -1,9 +1,10 @@
 import { CreateBucketCommand } from '@aws-sdk/client-s3';
 import type { HttpRequest } from '@aws-sdk/types';
-import { TigrisHeaders } from '@shared/index';
+import { TigrisHeaders, toError } from '@shared/index';
 import { createTigrisClient } from '../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
 import type { BucketLocations, StorageClass } from './types';
+import { updateBucket } from './update';
 import { validateLocationValues } from './utils/regions';
 
 export type CreateBucketOptions = {
@@ -13,6 +14,8 @@ export type CreateBucketOptions = {
   access?: 'public' | 'private';
   defaultTier?: StorageClass;
   locations?: BucketLocations;
+  enableDirectoryListing?: boolean;
+  allowObjectAcl?: boolean;
   config?: Omit<TigrisStorageConfig, 'bucket'>;
 };
 
@@ -72,6 +75,11 @@ export async function createBucket(
       // Disable directory listing by default
       req.headers[TigrisHeaders.ACL_LIST_OBJECTS] = 'false';
 
+      if (options?.enableDirectoryListing !== undefined) {
+        req.headers[TigrisHeaders.ACL_LIST_OBJECTS] =
+          options.enableDirectoryListing === true ? 'true' : 'false';
+      }
+
       // Set storage class
       if (options?.defaultTier) {
         req.headers[TigrisHeaders.STORAGE_CLASS] = options.defaultTier;
@@ -120,7 +128,33 @@ export async function createBucket(
   try {
     return tigrisClient
       .send(command)
-      .then(() => {
+      .then(async () => {
+        // Object ACL settings can't be set on the S3 CreateBucket command,
+        // so when they're requested we apply them with a follow-up
+        // updateBucket PATCH once the bucket exists.
+        if (options?.allowObjectAcl === true) {
+          try {
+            const { error: updateError } = await updateBucket(bucketName, {
+              allowObjectAcl: true,
+              config: options?.config,
+            });
+
+            if (updateError) {
+              throw updateError;
+            }
+          } catch (updateError) {
+            // updateBucket can either return an error or throw (e.g. a
+            // network failure in the underlying request). Funnel both into
+            // the same partial-failure message so a created-but-not-updated
+            // bucket isn't misreported as a creation failure.
+            return {
+              error: new Error(
+                `Bucket created but failed to set object ACL settings: ${toError(updateError).message}`
+              ),
+            };
+          }
+        }
+
         return {
           data: {
             isSnapshotEnabled: !!options?.enableSnapshot,
@@ -135,7 +169,9 @@ export async function createBucket(
         };
       })
       .catch((error) => {
-        return { error: new Error(`Unable to create bucket ${error.message}`) };
+        return {
+          error: new Error(`Unable to create bucket ${error.message}`),
+        };
       });
   } catch {
     return { error: new Error('Unable to create bucket') };

--- a/packages/storage/src/test/bucket-create.integration.test.ts
+++ b/packages/storage/src/test/bucket-create.integration.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { createBucket } from '../lib/bucket/create';
+import { getBucketInfo } from '../lib/bucket/info';
 import { listBuckets } from '../lib/bucket/list';
 import { removeBucket } from '../lib/bucket/remove';
 import { config } from '../lib/config';
@@ -12,6 +13,11 @@ const testBucket = (suffix: string) =>
 
 describe.skipIf(skipTests)('createBucket Integration Tests', () => {
   const bucketsToCleanup: string[] = [];
+
+  // allowObjectAcl is applied with a follow-up updateBucket PATCH after the
+  // bucket is created, so round-trip assertions poll getBucketInfo until the
+  // change propagates rather than reading once.
+  const POLL = { timeout: 15000, interval: 1000 };
 
   afterEach(async () => {
     for (const bucket of bucketsToCleanup) {
@@ -135,6 +141,43 @@ describe.skipIf(skipTests)('createBucket Integration Tests', () => {
     expect(result.error).toBeUndefined();
     expect(result.data).toBeDefined();
     expect(result.data?.isSnapshotEnabled).toBe(true);
+  });
+
+  // ── Object ACL ──
+
+  it('should create a bucket with object ACL allowed and round-trip via getBucketInfo', async () => {
+    const name = testBucket('acl');
+    bucketsToCleanup.push(name);
+
+    const result = await createBucket(name, {
+      allowObjectAcl: true,
+      config,
+    });
+
+    expect(
+      result.error,
+      `create with allowObjectAcl failed: ${result.error?.message}`
+    ).toBeUndefined();
+    expect(result.data).toBeDefined();
+
+    await expect
+      .poll(async () => {
+        const info = await getBucketInfo(name, { config });
+        return info.data?.settings.allowObjectAcl;
+      }, POLL)
+      .toBe(true);
+  });
+
+  it('should default object ACL to disabled when allowObjectAcl is omitted', async () => {
+    const name = testBucket('no-acl');
+    bucketsToCleanup.push(name);
+
+    const result = await createBucket(name, { config });
+    expect(result.error).toBeUndefined();
+
+    const info = await getBucketInfo(name, { config });
+    expect(info.error).toBeUndefined();
+    expect(info.data?.settings.allowObjectAcl).toBe(false);
   });
 
   // ── Validation errors ──


### PR DESCRIPTION
## Summary

Wires up two previously-unused `createBucket` options in `@tigrisdata/storage`:

### `allowObjectAcl`
When `allowObjectAcl: true` is passed, the object ACL setting is applied with a follow-up `updateBucket` PATCH once the bucket exists — the S3 `CreateBucket` command can't carry ACL settings, so they must be set separately.

```ts
await createBucket('my-bucket', { allowObjectAcl: true });
```

- Only fires when explicitly `true`; omitting it (or `false`) leaves the bucket default (object ACLs disabled) and issues no extra request.
- **Partial-failure handling**: if the bucket is created but the ACL step fails — whether `updateBucket` returns an error **or throws** (e.g. a network error in the underlying request) — the returned error makes the partial state explicit (`Bucket created but failed to set object ACL settings: …`) rather than the misleading `Unable to create bucket …`. The throw path is funneled through `toError` into the same message. No rollback/delete is attempted.

### `enableDirectoryListing`
When `enableDirectoryListing: true` is passed, object listing is enabled for the bucket at creation time (relevant for public buckets). Defaults to `false` (listing disabled).

```ts
await createBucket('my-listable-bucket', {
  access: 'public',
  enableDirectoryListing: true,
});
```

## Tests

Adds integration tests to `bucket-create.integration.test.ts`:
- `allowObjectAcl: true` round-trips — polls `getBucketInfo` until `settings.allowObjectAcl === true` (eventually consistent, like the soft-delete tests).
- omitting `allowObjectAcl` leaves `settings.allowObjectAcl === false`.

Directory-listing behavior is covered by the existing public-bucket test (unauthenticated `ListObjects` returns `403` when listing is disabled). Ran the full file against the live gateway: **10/10 passing**.

## Docs & release

- README: documents both options in the `createBucket` options table, with usage examples.
- Changeset bumps `@tigrisdata/storage` (minor).

## Review notes

- Addresses the Cursor/Greptile finding that a thrown `updateBucket` would escape to the outer `.catch` and misreport the partial state — now wrapped in try/catch inside the `.then`.
- `enableDirectoryListing` keeps "enable" polarity (consistent with `createBucket`'s `enableSnapshot`); `updateBucket`'s `disableDirectoryListing` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)