### PR TITLE
feat(storage): add restoreObject and getRestoreInfo

### DIFF
--- a/.changeset/restore-object.md
+++ b/.changeset/restore-object.md
@@ -1,0 +1,19 @@
+---
+'@tigrisdata/storage': minor
+---
+
+Add `restoreObject` and `getRestoreInfo` for working with archived objects.
+
+- `restoreObject(path, options?)` restores an archived object (e.g. one in the `GLACIER` tier) back into an actively-readable copy for a number of `days` (defaults to `1`).
+- `getRestoreInfo(path, options?)` reports an object's restore state from its `HEAD` headers as a `RestoreInfo` (`{ status, expiresAt? }`), using the `RestoreStatus` enum (`Archived`, `InProgress`, `Restored`). It resolves to `undefined` when there is no restore information — for a non-archived object or one that does not exist.
+
+```ts
+import { restoreObject, getRestoreInfo, RestoreStatus } from '@tigrisdata/storage';
+
+await restoreObject('archived.bin', { days: 3 });
+
+const { data } = await getRestoreInfo('archived.bin');
+if (data?.status === RestoreStatus.InProgress) {
+  // restore underway
+}
+```

--- a/packages/storage/src/lib/object/restore.ts
+++ b/packages/storage/src/lib/object/restore.ts
@@ -1,0 +1,169 @@
+import { HeadObjectCommand, RestoreObjectCommand } from '@aws-sdk/client-s3';
+import type { HttpResponse } from '@aws-sdk/types';
+import { handleError, TigrisHeaders } from '@shared/index';
+import { config } from '../config';
+import { createTigrisClient } from '../tigris-client';
+import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
+
+export type RestoreObjectOptions = {
+  /**
+   * How many days the restored (active) copy stays available before it
+   * reverts to its archived tier. Defaults to `1`.
+   */
+  days?: number;
+  /**
+   * Restore a specific object version instead of the current one.
+   */
+  versionId?: string;
+  config?: TigrisStorageConfig;
+};
+
+export type RestoreObjectResponse = {
+  path: string;
+};
+
+/**
+ * Restore an archived object (e.g. one stored in the `GLACIER` tier) back into
+ * an actively-readable copy for a number of days.
+ */
+export async function restoreObject(
+  path: string,
+  options?: RestoreObjectOptions
+): Promise<TigrisStorageResponse<RestoreObjectResponse, Error>> {
+  const { data: tigrisClient, error } = createTigrisClient(options?.config);
+
+  if (error) {
+    return { error };
+  }
+
+  const restore = new RestoreObjectCommand({
+    Bucket: options?.config?.bucket ?? config.bucket,
+    Key: path,
+    VersionId: options?.versionId,
+    RestoreRequest: {
+      Days: options?.days ?? 1,
+    },
+  });
+
+  try {
+    return tigrisClient
+      .send(restore)
+      .then(() => {
+        return {
+          data: {
+            path,
+          },
+        };
+      })
+      .catch(handleError);
+  } catch (error) {
+    return handleError(error as Error);
+  }
+}
+
+export enum RestoreStatus {
+  /** A restore has been requested and is still being processed. */
+  InProgress = 'in-progress',
+  /** The object has been restored and is currently readable. */
+  Restored = 'restored',
+  /** The object is archived (e.g. `GLACIER`) and has not been restored. */
+  Archived = 'archived',
+}
+
+export type RestoreInfo = {
+  status: RestoreStatus;
+  /**
+   * When the restored copy expires and reverts to its archived tier. Only set
+   * when `status` is `RestoreStatus.Restored`.
+   */
+  expiresAt?: Date;
+};
+
+export type GetRestoreInfoOptions = {
+  /** Inspect a specific object version instead of the current one. */
+  versionId?: string;
+  config?: TigrisStorageConfig;
+};
+
+/**
+ * Read an archived object's restore state from its `HEAD` response headers.
+ *
+ * Resolves to `undefined` when there is no restore information to report — for
+ * example, an object in a standard (non-archived) tier, or one that does not
+ * exist.
+ */
+export async function getRestoreInfo(
+  path: string,
+  options?: GetRestoreInfoOptions
+): Promise<TigrisStorageResponse<RestoreInfo | undefined, Error>> {
+  const { data: tigrisClient, error } = createTigrisClient(options?.config);
+
+  if (error) {
+    return { error };
+  }
+
+  const head = new HeadObjectCommand({
+    Bucket: options?.config?.bucket ?? config.bucket,
+    Key: path,
+    VersionId: options?.versionId,
+  });
+
+  let responseHeaders: Record<string, string> = {};
+
+  // Restore state is conveyed via response headers (x-amz-restore /
+  // x-amz-storage-class), which aren't part of the parsed HeadObject output,
+  // so capture the raw headers in the deserialize step.
+  head.middlewareStack.add(
+    (next) => async (args) => {
+      const result = await next(args);
+      responseHeaders = (result.response as HttpResponse).headers;
+      return result;
+    },
+    {
+      step: 'deserialize',
+    }
+  );
+
+  try {
+    return tigrisClient
+      .send(head)
+      .then(() => {
+        return { data: determineRestoreStatus(responseHeaders) };
+      })
+      .catch((error) => {
+        // A missing object simply has no restore information to report.
+        if (error?.name === 'NotFound') {
+          return { data: undefined };
+        }
+        return handleError(error as Error);
+      });
+  } catch (error) {
+    return handleError(error as Error);
+  }
+}
+
+function determineRestoreStatus(
+  headers: Record<string, string>
+): RestoreInfo | undefined {
+  // Response header names arrive lowercased, so match the constants the same way.
+  const restoreHeader = headers[TigrisHeaders.RESTORE.toLowerCase()];
+  if (restoreHeader) {
+    // The object has restore metadata: a restore is ongoing, or has completed
+    // and the active copy has an expiry date.
+    const isOngoing = restoreHeader.includes('ongoing-request="true"');
+    const expiryMatch = restoreHeader.match(/expiry-date="([^"]+)"/);
+
+    return {
+      status: isOngoing ? RestoreStatus.InProgress : RestoreStatus.Restored,
+      expiresAt: expiryMatch ? new Date(expiryMatch[1]) : undefined,
+    };
+  }
+
+  // No restore metadata, but the object is archived and can be restored.
+  if (headers[TigrisHeaders.STORAGE_CLASS.toLowerCase()] === 'GLACIER') {
+    return { status: RestoreStatus.Archived };
+  }
+
+  // Object isn't archived (e.g. standard storage) — no restore info.
+  return undefined;
+}

--- a/packages/storage/src/server.ts
+++ b/packages/storage/src/server.ts
@@ -133,6 +133,15 @@ export {
 export { type PutOptions, type PutResponse, put } from './lib/object/put';
 export { type RemoveOptions, remove } from './lib/object/remove';
 export {
+  type GetRestoreInfoOptions,
+  getRestoreInfo,
+  type RestoreInfo,
+  type RestoreObjectOptions,
+  type RestoreObjectResponse,
+  RestoreStatus,
+  restoreObject,
+} from './lib/object/restore';
+export {
   type SetObjectAccessOptions,
   type SetObjectAccessResponse,
   setObjectAccess,

--- a/packages/storage/src/test/restore.integration.test.ts
+++ b/packages/storage/src/test/restore.integration.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createBucket } from '../lib/bucket/create';
+import { removeBucket } from '../lib/bucket/remove';
+import { config } from '../lib/config';
+import { put } from '../lib/object/put';
+import {
+  getRestoreInfo,
+  RestoreStatus,
+  restoreObject,
+} from '../lib/object/restore';
+import { shouldSkipIntegrationTests } from './setup';
+
+const skipTests = shouldSkipIntegrationTests();
+
+const testBucket = (suffix: string) =>
+  `test-restore-${suffix}-${Date.now()}`.toLowerCase();
+
+describe.skipIf(skipTests)('restoreObject Integration Tests', () => {
+  const bucketsToCleanup: string[] = [];
+
+  // Archiving and restore are asynchronous, so poll the restore status until
+  // it reaches the expected state rather than reading once.
+  const POLL = { timeout: 30000, interval: 2000 };
+
+  afterEach(async () => {
+    for (const bucket of bucketsToCleanup) {
+      await removeBucket(bucket, { force: true, config });
+    }
+    bucketsToCleanup.length = 0;
+  });
+
+  it('should restore an archived object and report it in progress', async () => {
+    const bucket = testBucket('glacier');
+    bucketsToCleanup.push(bucket);
+    const bucketConfig = { ...config, bucket };
+
+    // Archive bucket: objects uploaded to it default to the GLACIER tier.
+    const created = await createBucket(bucket, {
+      defaultTier: 'GLACIER',
+      config,
+    });
+    expect(
+      created.error,
+      `create bucket failed: ${created.error?.message}`
+    ).toBeUndefined();
+
+    // Upload a 1-byte object; it inherits the bucket's GLACIER default.
+    const key = `archived-${Date.now()}.txt`;
+    const uploaded = await put(key, 'a', { config: bucketConfig });
+    expect(
+      uploaded.error,
+      `put failed: ${uploaded.error?.message}`
+    ).toBeUndefined();
+    expect(uploaded.data?.size).toBe(1);
+
+    // Before any restore, the archived object should report as Archived.
+    await expect
+      .poll(async () => {
+        const info = await getRestoreInfo(key, { config: bucketConfig });
+        return info.data?.status;
+      }, POLL)
+      .toBe(RestoreStatus.Archived);
+
+    // Initiate the restore.
+    const restored = await restoreObject(key, { config: bucketConfig });
+    expect(
+      restored.error,
+      `restore failed: ${restored.error?.message}`
+    ).toBeUndefined();
+    expect(restored.data?.path).toBe(key);
+
+    // The object should now report a restore in progress.
+    await expect
+      .poll(async () => {
+        const info = await getRestoreInfo(key, { config: bucketConfig });
+        return info.data?.status;
+      }, POLL)
+      .toBe(RestoreStatus.InProgress);
+  });
+
+  it('should report no restore info for non-archived and missing objects', async () => {
+    const bucket = testBucket('standard');
+    bucketsToCleanup.push(bucket);
+    const bucketConfig = { ...config, bucket };
+
+    // A standard (non-archived) bucket.
+    const created = await createBucket(bucket, { config });
+    expect(
+      created.error,
+      `create bucket failed: ${created.error?.message}`
+    ).toBeUndefined();
+
+    // A missing object has no restore information.
+    const missing = await getRestoreInfo(`missing-${Date.now()}.txt`, {
+      config: bucketConfig,
+    });
+    expect(missing.error).toBeUndefined();
+    expect(missing.data).toBeUndefined();
+
+    // A non-archived object also has no restore information.
+    const key = `standard-${Date.now()}.txt`;
+    const uploaded = await put(key, 'a', { config: bucketConfig });
+    expect(
+      uploaded.error,
+      `put failed: ${uploaded.error?.message}`
+    ).toBeUndefined();
+
+    const info = await getRestoreInfo(key, { config: bucketConfig });
+    expect(info.error).toBeUndefined();
+    expect(info.data).toBeUndefined();
+  });
+
+  it('should accept a restore request for a non-archived object', async () => {
+    const bucket = testBucket('non-archived');
+    bucketsToCleanup.push(bucket);
+    const bucketConfig = { ...config, bucket };
+
+    const created = await createBucket(bucket, { config });
+    expect(
+      created.error,
+      `create bucket failed: ${created.error?.message}`
+    ).toBeUndefined();
+
+    const key = `standard-${Date.now()}.txt`;
+    const uploaded = await put(key, 'a', { config: bucketConfig });
+    expect(
+      uploaded.error,
+      `put failed: ${uploaded.error?.message}`
+    ).toBeUndefined();
+
+    // Unlike AWS S3 (which rejects with InvalidObjectState), the Tigris
+    // gateway accepts a restore request for a non-archived object without
+    // error.
+    const restored = await restoreObject(key, { config: bucketConfig });
+    expect(restored.error).toBeUndefined();
+    expect(restored.data?.path).toBe(key);
+  });
+});

--- a/shared/headers.ts
+++ b/shared/headers.ts
@@ -5,6 +5,7 @@ export enum TigrisHeaders {
   SESSION_TOKEN = 'x-amz-security-token',
   NAMESPACE = 'X-Tigris-Namespace',
   STORAGE_CLASS = 'X-Amz-Storage-Class',
+  RESTORE = 'X-Amz-Restore',
   /** Prefix for user metadata headers; concatenate with a key, e.g. `${TigrisHeaders.META_PREFIX}author`. */
   META_PREFIX = 'x-amz-meta-',
 


### PR DESCRIPTION
## Summary

Adds support for working with archived objects in `@tigrisdata/storage`.

### `restoreObject`
```ts
restoreObject(path: string, options?: RestoreObjectOptions): Promise<TigrisStorageResponse<RestoreObjectResponse, Error>>
```
Restores an archived object (e.g. one in the `GLACIER` tier) back into an actively-readable copy via `RestoreObjectCommand`.
- **`RestoreObjectOptions`**: `days?` (lifetime of the restored copy, default `1`), `versionId?`, `config?`.
- **`RestoreObjectResponse`**: `{ path }`.

### `getRestoreInfo`
```ts
getRestoreInfo(path: string, options?: GetRestoreInfoOptions): Promise<TigrisStorageResponse<RestoreInfo | undefined, Error>>
```
Reports an object's restore state by reading the `HEAD` response headers (`x-amz-restore` / `x-amz-storage-class`) via a deserialize-step middleware (same pattern as `isMigrated`).
- **`RestoreInfo`**: `{ status: RestoreStatus; expiresAt?: Date }`.
- **`RestoreStatus`** enum: `Archived`, `InProgress`, `Restored`.
- Resolves to **`undefined`** when there's no restore info — a non-archived object, or one that doesn't exist (missing keys are mapped to `undefined`, consistent with `head`).

```ts
import { restoreObject, getRestoreInfo, RestoreStatus } from '@tigrisdata/storage';

await restoreObject('archived.bin', { days: 3 });

const { data } = await getRestoreInfo('archived.bin');
if (data?.status === RestoreStatus.InProgress) {
  // restore underway
}
```

## Tests

Integration tests (`restore.integration.test.ts`), run against the live gateway — **3/3 passing**:
1. **Archive → restore → in progress**: GLACIER bucket → 1-byte upload → `getRestoreInfo` is `Archived` → `restoreObject` → `getRestoreInfo` polls to `InProgress`.
2. **No restore info**: non-archived object and missing key both yield `undefined`.
3. **Non-archived restore is accepted**: documents that Tigris accepts a restore request for a non-archived object **without error** (unlike AWS S3, which rejects with `InvalidObjectState`).

## Notes

- Exported from `server.ts` only (credentialed server op, like `remove`) — not the browser `client` entry.
- Gateway behavior captured during testing: Tigris **accepts** restores on non-archived objects (HTTP 202) rather than erroring. The "restore completes → `Restored`" path isn't covered by an integration test because restore latency is unbounded.

## Release

Includes a changeset bumping `@tigrisdata/storage` (minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive storage helpers with isolated logic and integration coverage; no changes to auth or existing object read/write paths beyond new optional calls.
> 
> **Overview**
> **`@tigrisdata/storage`** gains **archived-object restore** support on the server entry only: **`restoreObject`** issues S3 **`RestoreObjectCommand`** (optional **`days`**, **`versionId`**, **`config`**) and returns **`{ path }`**; **`getRestoreInfo`** HEADs the object, captures **`x-amz-restore`** / storage-class via deserialize middleware (same idea as other header-based helpers), and returns **`RestoreInfo`** with **`RestoreStatus`** (`Archived`, `InProgress`, `Restored`) and optional **`expiresAt`**, or **`undefined`** for standard-tier objects and missing keys (**`NotFound`** is not surfaced as an error).
> 
> Shared **`TigrisHeaders.RESTORE`** is added for header parsing. Exports are wired through **`server.ts`**. A **minor changeset** documents the API, and **integration tests** cover GLACIER archive → restore → in-progress polling, undefined restore info for standard/missing objects, and Tigris accepting restore on non-archived objects (unlike S3).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7611fa51261d2da3850ab226556dd1283c5d8a2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->