### PR TITLE
chore(repo): downgrade pnpm to 10.34.3 and pin renovate off 10.34.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Tigris monorepo for storage SDK",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.34.4",
+  "packageManager": "pnpm@10.34.3",
   "scripts": {
     "build": "pnpm -r --if-present run build",
     "dev": "pnpm -r --if-present run dev",

--- a/renovate.json
+++ b/renovate.json
@@ -87,9 +87,10 @@
       "groupName": "github-actions"
     },
     {
-      "description": "Group pnpm bumps (packageManager field + workflows)",
+      "description": "Group pnpm bumps (packageManager field + workflows); skip 10.34.4, which we rolled back from",
       "matchPackageNames": ["pnpm"],
-      "groupName": "pnpm"
+      "groupName": "pnpm",
+      "allowedVersions": "<10.34.4 || >10.34.4"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Roll the `packageManager` field back from `pnpm@10.34.4` to `pnpm@10.34.3`.
- Add `"allowedVersions": "<10.34.4 || >10.34.4"` to the renovate `pnpm` rule so renovate won't re-propose the version we just backed out of, while staying open to later releases (10.34.5+, 10.35.x, …).

## Why

`10.34.4` was rolled back. Without the renovate constraint, the pnpm group rule would immediately reopen a bump straight back to `10.34.4`.

## Notes

- `packageManager` is the single source of truth for the pnpm version — both CI workflows use `pnpm/action-setup@v6` with no `version:` input, so they pick this up automatically. No workflow changes needed.
- The lockfile is unaffected by a patch-level pnpm change; `pnpm-lock.yaml` is untouched.
- Repo tooling only — no changeset (nothing ships to npm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Repo tooling only (pnpm version + Renovate config); no application or published package behavior changes.
> 
> **Overview**
> Rolls back the monorepo **`packageManager`** from `pnpm@10.34.4` to **`pnpm@10.34.3`** after that patch was reverted locally. CI already uses `pnpm/action-setup@v6` without a pinned `version`, so this field is the only lever needed to align installs.
> 
> Updates the Renovate **pnpm** group rule with **`allowedVersions": "<10.34.4 || >10.34.4"`** so automation won’t immediately reopen a bump to the backed-out release, while still allowing `10.34.5+` and later lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 538ebf8fc3daab9ddb4ccf6f19f6da99b8dc6bcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->