### PR TITLE
fix(shared): resolve config on demand without mutating process.env

### DIFF
--- a/.changeset/scoped-env-loading.md
+++ b/.changeset/scoped-env-loading.md
@@ -1,0 +1,8 @@
+---
+'@tigrisdata/storage': patch
+'@tigrisdata/iam': patch
+---
+
+Stop mutating the global `process.env` when loading configuration. Previously, importing the server entry ran `dotenv.config()` as an import-time side effect, loading the consuming app's entire `.env` (including unrelated keys) into `process.env`.
+
+Configuration is now resolved on demand, per operation, directly from the environment: the SDK parses `.env` into a private object (never touching `process.env`), keeps only `TIGRIS_`-prefixed keys, and prefers explicitly-set `process.env` values. Importing the SDK no longer has side effects, and apps that manage their own environment are no longer overridden.

--- a/packages/iam/src/lib/config.ts
+++ b/packages/iam/src/lib/config.ts
@@ -1,4 +1,4 @@
-import { isNode, loadEnv } from '@shared/index';
+import { getEnvVar, isNode } from '@shared/index';
 import type { TigrisIAMConfig } from './types';
 
 export const DEFAULT_ENDPOINTS = {
@@ -6,24 +6,28 @@ export const DEFAULT_ENDPOINTS = {
   mgmt: 'https://mgmt.storageapi.dev',
 };
 
-function loadIAMConfig(): TigrisIAMConfig {
-  loadEnv();
-
+/**
+ * Resolve the Tigris IAM configuration from the environment, on demand.
+ *
+ * Reads only `TIGRIS_`-prefixed variables — from `process.env`, falling back to
+ * a private parse of `.env` — and never mutates `process.env`. There is no
+ * module-level config and importing this module has no side effects: each
+ * operation calls `getConfig()` when it needs the current configuration.
+ */
+export function getConfig(): TigrisIAMConfig {
   const config: TigrisIAMConfig = {
     iamEndpoint: DEFAULT_ENDPOINTS.iam,
     mgmtEndpoint: DEFAULT_ENDPOINTS.mgmt,
   };
 
   if (isNode()) {
-    config.iamEndpoint = process.env.TIGRIS_IAM_ENDPOINT;
-    config.mgmtEndpoint = process.env.TIGRIS_MGMT_ENDPOINT;
-    config.sessionToken = process.env.TIGRIS_SESSION_TOKEN;
-    config.organizationId = process.env.TIGRIS_ORGANIZATION_ID;
-    config.accessKeyId = process.env.TIGRIS_STORAGE_ACCESS_KEY_ID;
-    config.secretAccessKey = process.env.TIGRIS_STORAGE_SECRET_ACCESS_KEY;
+    config.iamEndpoint = getEnvVar('TIGRIS_IAM_ENDPOINT');
+    config.mgmtEndpoint = getEnvVar('TIGRIS_MGMT_ENDPOINT');
+    config.sessionToken = getEnvVar('TIGRIS_SESSION_TOKEN');
+    config.organizationId = getEnvVar('TIGRIS_ORGANIZATION_ID');
+    config.accessKeyId = getEnvVar('TIGRIS_STORAGE_ACCESS_KEY_ID');
+    config.secretAccessKey = getEnvVar('TIGRIS_STORAGE_SECRET_ACCESS_KEY');
   }
 
   return config;
 }
-
-export const config: TigrisIAMConfig = loadIAMConfig();

--- a/packages/iam/src/lib/http-client.ts
+++ b/packages/iam/src/lib/http-client.ts
@@ -1,5 +1,5 @@
 import { createTigrisHttpClient, type TigrisHttpClient } from '@shared/index';
-import { config, DEFAULT_ENDPOINTS } from './config';
+import { DEFAULT_ENDPOINTS, getConfig } from './config';
 import type { TigrisIAMConfig, TigrisIAMResponse } from './types';
 
 export const IAM_ENDPOINTS = {
@@ -38,17 +38,22 @@ export const IAM_ENDPOINTS = {
 };
 
 function getIAMEndpoint(options?: TigrisIAMConfig): string {
-  return options?.iamEndpoint ?? config.iamEndpoint ?? DEFAULT_ENDPOINTS.iam;
+  return (
+    options?.iamEndpoint ?? getConfig().iamEndpoint ?? DEFAULT_ENDPOINTS.iam
+  );
 }
 
 function getManagementEndpoint(options?: TigrisIAMConfig): string {
-  return options?.mgmtEndpoint ?? config.mgmtEndpoint ?? DEFAULT_ENDPOINTS.mgmt;
+  return (
+    options?.mgmtEndpoint ?? getConfig().mgmtEndpoint ?? DEFAULT_ENDPOINTS.mgmt
+  );
 }
 
 export function createIAMClient(
   options?: TigrisIAMConfig,
   isManagement?: boolean
 ): TigrisIAMResponse<TigrisHttpClient, Error> {
+  const config = getConfig();
   const sessionToken = options?.sessionToken ?? config.sessionToken;
   const organizationId = options?.organizationId ?? config.organizationId;
   const accessKeyId = options?.accessKeyId ?? config.accessKeyId;

--- a/packages/storage/src/lib/bucket/snapshot.ts
+++ b/packages/storage/src/lib/bucket/snapshot.ts
@@ -5,7 +5,7 @@ import {
 } from '@aws-sdk/client-s3';
 import type { HttpRequest, HttpResponse } from '@aws-sdk/types';
 import { TigrisHeaders } from '@shared/index';
-import { config } from '../config';
+import { getConfig } from '../config';
 import { createTigrisClient } from '../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
 
@@ -37,6 +37,7 @@ export async function listBucketSnapshots(
   sourceBucketName?: string | ListBucketSnapshotsOptions,
   options?: ListBucketSnapshotsOptions
 ): Promise<TigrisStorageResponse<ListBucketSnapshotsResponse, Error>> {
+  const config = getConfig();
   if (typeof sourceBucketName === 'object') {
     options = sourceBucketName;
     sourceBucketName = undefined;
@@ -116,6 +117,7 @@ export async function createBucketSnapshot(
   sourceBucketName?: string | CreateBucketSnapshotOptions,
   options?: CreateBucketSnapshotOptions
 ): Promise<TigrisStorageResponse<CreateBucketSnapshotResponse, Error>> {
+  const config = getConfig();
   if (typeof sourceBucketName === 'object') {
     options = sourceBucketName;
     sourceBucketName = undefined;

--- a/packages/storage/src/lib/config.ts
+++ b/packages/storage/src/lib/config.ts
@@ -1,7 +1,7 @@
 import {
   missingConfigError as baseMissingConfigError,
+  getEnvVar,
   isNode,
-  loadEnv,
 } from '@shared/index';
 import type { TigrisStorageConfig } from './types';
 
@@ -17,24 +17,29 @@ const configMap: Partial<Record<keyof TigrisStorageConfig, string>> = {
 export const missingConfigError = (key: string) =>
   baseMissingConfigError(key, configMap[key as keyof TigrisStorageConfig]);
 
-function loadStorageConfig(): TigrisStorageConfig {
-  loadEnv();
-
+/**
+ * Resolve the Tigris storage configuration from the environment, on demand.
+ *
+ * Reads only `TIGRIS_`-prefixed variables — from `process.env`, falling back to
+ * a private parse of `.env` — and never mutates `process.env`. There is no
+ * module-level config and importing this module has no side effects: each
+ * operation calls `getConfig()` when it needs the current configuration.
+ */
+export function getConfig(): TigrisStorageConfig {
   const config: TigrisStorageConfig = {
     endpoint: 'https://t3.storage.dev',
   };
 
   if (isNode()) {
-    config.bucket = process.env.TIGRIS_STORAGE_BUCKET ?? '';
-    config.accessKeyId = process.env.TIGRIS_STORAGE_ACCESS_KEY_ID ?? '';
-    config.secretAccessKey = process.env.TIGRIS_STORAGE_SECRET_ACCESS_KEY ?? '';
+    config.bucket = getEnvVar('TIGRIS_STORAGE_BUCKET') ?? '';
+    config.accessKeyId = getEnvVar('TIGRIS_STORAGE_ACCESS_KEY_ID') ?? '';
+    config.secretAccessKey =
+      getEnvVar('TIGRIS_STORAGE_SECRET_ACCESS_KEY') ?? '';
     config.endpoint =
-      process.env.TIGRIS_STORAGE_ENDPOINT ?? 'https://t3.storage.dev';
-    config.sessionToken = process.env.TIGRIS_SESSION_TOKEN;
-    config.organizationId = process.env.TIGRIS_ORGANIZATION_ID;
+      getEnvVar('TIGRIS_STORAGE_ENDPOINT') ?? 'https://t3.storage.dev';
+    config.sessionToken = getEnvVar('TIGRIS_SESSION_TOKEN');
+    config.organizationId = getEnvVar('TIGRIS_ORGANIZATION_ID');
   }
 
   return config;
 }
-
-export const config: TigrisStorageConfig = loadStorageConfig();

--- a/packages/storage/src/lib/fork/_legacy.ts
+++ b/packages/storage/src/lib/fork/_legacy.ts
@@ -4,7 +4,7 @@
  */
 
 import { fetchBucketListing } from '../bucket/listing';
-import { config } from '../config';
+import { getConfig } from '../config';
 import type { TigrisStorageResponse } from '../types';
 import type { BucketFork, ListForksOptions, ListForksResponse } from './list';
 
@@ -19,6 +19,7 @@ export async function listForksLegacy(
   sourceBucketName?: string | ListForksOptions,
   options?: ListForksOptions
 ): Promise<TigrisStorageResponse<ListForksResponse, Error>> {
+  const config = getConfig();
   if (typeof sourceBucketName === 'object') {
     options = sourceBucketName;
     sourceBucketName = undefined;

--- a/packages/storage/src/lib/fork/list.ts
+++ b/packages/storage/src/lib/fork/list.ts
@@ -1,6 +1,6 @@
 import { fetchBucketListing } from '../bucket/listing';
 import type { Bucket } from '../bucket/types';
-import { config } from '../config';
+import { getConfig } from '../config';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
 import { listForksLegacy } from './_legacy';
 
@@ -46,6 +46,7 @@ export async function listForks(
   sourceBucketName?: string | ListForksOptions,
   options?: ListForksOptions
 ): Promise<TigrisStorageResponse<ListForksResponse, Error>> {
+  const config = getConfig();
   if (typeof sourceBucketName === 'object') {
     options = sourceBucketName;
     sourceBucketName = undefined;

--- a/packages/storage/src/lib/http-client.ts
+++ b/packages/storage/src/lib/http-client.ts
@@ -1,14 +1,15 @@
 import { createTigrisHttpClient, type TigrisHttpClient } from '@shared/index';
-import { config } from './config';
+import { getConfig } from './config';
 import type { TigrisStorageConfig, TigrisStorageResponse } from './types';
 
 function getStorageEndpoint(options?: TigrisStorageConfig): string {
-  return options?.endpoint ?? config.endpoint ?? 'https://t3.storage.dev';
+  return options?.endpoint ?? getConfig().endpoint ?? 'https://t3.storage.dev';
 }
 
 export function createStorageClient(
   options?: TigrisStorageConfig
 ): TigrisStorageResponse<TigrisHttpClient, Error> {
+  const config = getConfig();
   const sessionToken = options?.sessionToken ?? config.sessionToken;
   const organizationId = options?.organizationId ?? config.organizationId;
   const accessKeyId = options?.accessKeyId ?? config.accessKeyId;

--- a/packages/storage/src/lib/object/bundle.ts
+++ b/packages/storage/src/lib/object/bundle.ts
@@ -1,5 +1,5 @@
 import { TigrisHeaders, toError } from '@shared/index';
-import { config, missingConfigError } from '../config';
+import { getConfig, missingConfigError } from '../config';
 import { createStorageClient } from '../http-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
 
@@ -50,6 +50,7 @@ export async function bundle(
   keys: string[],
   options?: BundleOptions
 ): Promise<TigrisStorageResponse<BundleResponse, Error>> {
+  const config = getConfig();
   const bucket = options?.config?.bucket ?? config.bucket;
 
   if (!bucket) {

--- a/packages/storage/src/lib/object/copy.ts
+++ b/packages/storage/src/lib/object/copy.ts
@@ -1,6 +1,6 @@
 import { TigrisHeaders } from '@shared/headers';
 import { encodeObjectKey, handleError } from '@shared/utils';
-import { config, missingConfigError } from '../config';
+import { getConfig, missingConfigError } from '../config';
 import { createStorageClient } from '../http-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
 
@@ -31,6 +31,7 @@ export async function copyOrMove(
   rename: boolean,
   options?: CopyOptions
 ): Promise<TigrisStorageResponse<CopyResponse, Error>> {
+  const config = getConfig();
   if (!src || !dest) {
     return { error: new Error('src and dest are required') };
   }

--- a/packages/storage/src/lib/object/get.ts
+++ b/packages/storage/src/lib/object/get.ts
@@ -1,7 +1,7 @@
 import { GetObjectCommand } from '@aws-sdk/client-s3';
 import type { HttpRequest } from '@aws-sdk/types';
 import { handleError, TigrisHeaders } from '@shared/index';
-import { config } from '../config';
+import { getConfig } from '../config';
 import { createTigrisClient } from '../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
 
@@ -136,6 +136,7 @@ export async function get(
     Error
   >
 > {
+  const config = getConfig();
   const { data: tigrisClient, error } = createTigrisClient(options?.config);
 
   if (error) {

--- a/packages/storage/src/lib/object/head.ts
+++ b/packages/storage/src/lib/object/head.ts
@@ -2,7 +2,7 @@ import { HeadObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import type { HttpRequest } from '@aws-sdk/types';
 import { TigrisHeaders } from '@shared/index';
-import { config } from '../config';
+import { getConfig } from '../config';
 import { createTigrisClient } from '../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
 
@@ -27,6 +27,7 @@ export async function head(
   path: string,
   options?: HeadOptions
 ): Promise<TigrisStorageResponse<HeadResponse | undefined, Error>> {
+  const config = getConfig();
   const { data: tigrisClient, error } = createTigrisClient(options?.config);
 
   if (error) {

--- a/packages/storage/src/lib/object/list-versions.ts
+++ b/packages/storage/src/lib/object/list-versions.ts
@@ -1,6 +1,6 @@
 import { ListObjectVersionsCommand } from '@aws-sdk/client-s3';
 import { handleError } from '@shared/utils';
-import { config, missingConfigError } from '../config';
+import { getConfig, missingConfigError } from '../config';
 import { createTigrisClient } from '../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
 
@@ -44,6 +44,7 @@ export type ListVersionsResponse = {
 export async function listVersions(
   options?: ListVersionsOptions
 ): Promise<TigrisStorageResponse<ListVersionsResponse, Error>> {
+  const config = getConfig();
   if (!options?.config?.bucket && !config.bucket) {
     return missingConfigError('bucket');
   }

--- a/packages/storage/src/lib/object/list.ts
+++ b/packages/storage/src/lib/object/list.ts
@@ -1,7 +1,7 @@
 import { ListObjectsV2Command } from '@aws-sdk/client-s3';
 import type { HttpRequest } from '@aws-sdk/types';
 import { TigrisHeaders } from '@shared/index';
-import { config, missingConfigError } from '../config';
+import { getConfig, missingConfigError } from '../config';
 import { createTigrisClient } from '../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
 
@@ -33,6 +33,7 @@ export type ListResponse = {
 export async function list(
   options?: ListOptions
 ): Promise<TigrisStorageResponse<ListResponse, Error>> {
+  const config = getConfig();
   if (!options?.config?.bucket && !config.bucket) {
     return missingConfigError('bucket');
   }

--- a/packages/storage/src/lib/object/migrate.ts
+++ b/packages/storage/src/lib/object/migrate.ts
@@ -1,7 +1,7 @@
 import { HeadObjectCommand } from '@aws-sdk/client-s3';
 import type { HttpRequest, HttpResponse } from '@aws-sdk/types';
 import { handleError, TigrisHeaders } from '@shared/index';
-import { config } from '../config';
+import { getConfig } from '../config';
 import { createTigrisClient } from '../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
 
@@ -13,6 +13,7 @@ export async function migrate(
   path: string,
   options?: MigrateOptions
 ): Promise<TigrisStorageResponse<void, Error>> {
+  const config = getConfig();
   const { data: tigrisClient, error } = createTigrisClient(options?.config);
 
   if (error) {
@@ -54,6 +55,7 @@ export async function isMigrated(
   path: string,
   options?: MigrateOptions
 ): Promise<TigrisStorageResponse<boolean, Error>> {
+  const config = getConfig();
   const { data: tigrisClient, error } = createTigrisClient(options?.config);
 
   if (error) {

--- a/packages/storage/src/lib/object/multipart.ts
+++ b/packages/storage/src/lib/object/multipart.ts
@@ -5,7 +5,7 @@ import {
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { toError } from '@shared/utils';
-import { config } from '../config';
+import { getConfig } from '../config';
 import { createTigrisClient } from '../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
 import { getPresignedUrl } from './presigned-url';
@@ -22,6 +22,7 @@ export async function initMultipartUpload(
   path: string,
   options?: InitMultipartUploadOptions
 ): Promise<TigrisStorageResponse<InitMultipartUploadResponse, Error>> {
+  const config = getConfig();
   const { data: tigrisClient, error } = createTigrisClient(options?.config);
 
   if (error) {
@@ -69,6 +70,7 @@ export async function getPartsPresignedUrls(
   uploadId: string,
   options?: GetPartsPresignedUrlsOptions
 ): Promise<TigrisStorageResponse<GetPartsPresignedUrlsResponse, Error>> {
+  const config = getConfig();
   const { data: tigrisClient, error } = createTigrisClient(options?.config);
 
   if (error) {
@@ -121,6 +123,7 @@ export async function completeMultipartUpload(
   partIds: Array<{ [key: number]: string }>,
   options?: CompleteMultipartUploadOptions
 ): Promise<TigrisStorageResponse<CompleteMultipartUploadResponse, Error>> {
+  const config = getConfig();
   const { data: tigrisClient, error } = createTigrisClient(options?.config);
 
   if (error) {

--- a/packages/storage/src/lib/object/presigned-url.ts
+++ b/packages/storage/src/lib/object/presigned-url.ts
@@ -1,4 +1,4 @@
-import { config, missingConfigError } from '../config';
+import { getConfig, missingConfigError } from '../config';
 import { createStorageClient } from '../http-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
 import { listVersions } from './list-versions';
@@ -54,6 +54,7 @@ export async function getPresignedUrl(
   path: string,
   options: GetPresignedUrlOptions
 ): Promise<TigrisStorageResponse<GetPresignedUrlResponse, Error>> {
+  const config = getConfig();
   const { data: client, error } = createStorageClient(options?.config);
 
   if (error) {

--- a/packages/storage/src/lib/object/put.ts
+++ b/packages/storage/src/lib/object/put.ts
@@ -2,7 +2,7 @@ import { GetObjectCommand } from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { toError } from '@shared/utils';
-import { config } from '../config';
+import { getConfig } from '../config';
 import { createTigrisClient } from '../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
 import { addRandomSuffix } from '../utils';
@@ -49,6 +49,7 @@ export async function put(
   body: string | ReadableStream | Blob | Buffer,
   options?: PutOptions
 ): Promise<TigrisStorageResponse<PutResponse, Error>> {
+  const config = getConfig();
   const { data: tigrisClient, error } = createTigrisClient(options?.config);
 
   if (error) {

--- a/packages/storage/src/lib/object/remove.ts
+++ b/packages/storage/src/lib/object/remove.ts
@@ -1,6 +1,6 @@
 import { DeleteObjectCommand } from '@aws-sdk/client-s3';
 import { handleError } from '@shared/utils';
-import { config } from '../config';
+import { getConfig } from '../config';
 import { createTigrisClient } from '../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
 
@@ -13,6 +13,7 @@ export async function remove(
   path: string,
   options?: RemoveOptions
 ): Promise<TigrisStorageResponse<void, Error>> {
+  const config = getConfig();
   const { data: tigrisClient, error } = createTigrisClient(options?.config);
 
   if (error) {

--- a/packages/storage/src/lib/object/restore.ts
+++ b/packages/storage/src/lib/object/restore.ts
@@ -1,7 +1,7 @@
 import { HeadObjectCommand, RestoreObjectCommand } from '@aws-sdk/client-s3';
 import type { HttpResponse } from '@aws-sdk/types';
 import { handleError, TigrisHeaders } from '@shared/index';
-import { config } from '../config';
+import { getConfig } from '../config';
 import { createTigrisClient } from '../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
 
@@ -30,6 +30,7 @@ export async function restoreObject(
   path: string,
   options?: RestoreObjectOptions
 ): Promise<TigrisStorageResponse<RestoreObjectResponse, Error>> {
+  const config = getConfig();
   const { data: tigrisClient, error } = createTigrisClient(options?.config);
 
   if (error) {
@@ -96,6 +97,7 @@ export async function getRestoreInfo(
   path: string,
   options?: GetRestoreInfoOptions
 ): Promise<TigrisStorageResponse<RestoreInfo | undefined, Error>> {
+  const config = getConfig();
   const { data: tigrisClient, error } = createTigrisClient(options?.config);
 
   if (error) {

--- a/packages/storage/src/lib/object/set/access.ts
+++ b/packages/storage/src/lib/object/set/access.ts
@@ -1,6 +1,6 @@
 import { PutObjectAclCommand } from '@aws-sdk/client-s3';
 import { handleError } from '@shared/utils';
-import { config, missingConfigError } from '../../config';
+import { getConfig, missingConfigError } from '../../config';
 import { createTigrisClient } from '../../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../../types';
 
@@ -17,6 +17,7 @@ export async function setObjectAccess(
   path: string,
   options: SetObjectAccessOptions
 ): Promise<TigrisStorageResponse<SetObjectAccessResponse, Error>> {
+  const config = getConfig();
   if (!options?.access) {
     return { error: new Error('No access option provided') };
   }

--- a/packages/storage/src/lib/object/signed-upload-url.ts
+++ b/packages/storage/src/lib/object/signed-upload-url.ts
@@ -6,7 +6,7 @@ import {
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { TigrisHeaders } from '@shared/headers';
 import { handleError } from '@shared/utils';
-import { config, missingConfigError } from '../config';
+import { getConfig, missingConfigError } from '../config';
 import { createTigrisClient } from '../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
 import type { SignedUploadUrlResponse } from '../upload/shared';
@@ -64,6 +64,7 @@ export async function getSignedUploadUrl(
   key: string,
   options?: GetSignedUploadUrlOptions
 ): Promise<TigrisStorageResponse<SignedUploadUrlResponse, Error>> {
+  const config = getConfig();
   const bucket = options?.config?.bucket ?? config.bucket;
   if (!bucket) return missingConfigError('bucket');
 

--- a/packages/storage/src/lib/object/update.ts
+++ b/packages/storage/src/lib/object/update.ts
@@ -1,7 +1,7 @@
 import { PutObjectAclCommand } from '@aws-sdk/client-s3';
 import { TigrisHeaders } from '@shared/headers';
 import { encodeObjectKey, handleError } from '@shared/utils';
-import { config, missingConfigError } from '../config';
+import { getConfig, missingConfigError } from '../config';
 import { createStorageClient } from '../http-client';
 import { createTigrisClient } from '../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
@@ -25,6 +25,7 @@ export async function updateObject(
   path: string,
   options?: UpdateObjectOptions
 ): Promise<TigrisStorageResponse<UpdateObjectResponse, Error>> {
+  const config = getConfig();
   if (!options?.key && !options?.access) {
     return { error: new Error('No update options provided') };
   }

--- a/packages/storage/src/lib/tigris-client.ts
+++ b/packages/storage/src/lib/tigris-client.ts
@@ -1,7 +1,7 @@
 import { S3Client } from '@aws-sdk/client-s3';
 import type { HttpRequest } from '@aws-sdk/types';
 import { TigrisHeaders } from '@shared/index';
-import { config, missingConfigError } from './config';
+import { getConfig, missingConfigError } from './config';
 import type { TigrisStorageConfig, TigrisStorageResponse } from './types';
 
 const cachedClients = new Map<string, S3Client>();
@@ -10,6 +10,7 @@ export function createTigrisClient(
   options?: TigrisStorageConfig,
   skipBucketCheck: boolean | undefined = false
 ): TigrisStorageResponse<S3Client, Error> {
+  const config = getConfig();
   const accessKeyId = options?.accessKeyId ?? config.accessKeyId;
   const secretAccessKey = options?.secretAccessKey ?? config.secretAccessKey;
   const endpoint = options?.endpoint ?? config.endpoint;

--- a/packages/storage/src/test/bucket-create.integration.test.ts
+++ b/packages/storage/src/test/bucket-create.integration.test.ts
@@ -3,10 +3,12 @@ import { createBucket } from '../lib/bucket/create';
 import { getBucketInfo } from '../lib/bucket/info';
 import { listBuckets } from '../lib/bucket/list';
 import { removeBucket } from '../lib/bucket/remove';
-import { config } from '../lib/config';
+import { getConfig } from '../lib/config';
 import { shouldSkipIntegrationTests } from './setup';
 
 const skipTests = shouldSkipIntegrationTests();
+
+const config = getConfig();
 
 const testBucket = (suffix: string) =>
   `test-create-${suffix}-${Date.now()}`.toLowerCase();

--- a/packages/storage/src/test/bucket-listing.integration.test.ts
+++ b/packages/storage/src/test/bucket-listing.integration.test.ts
@@ -2,10 +2,12 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { createBucket } from '../lib/bucket/create';
 import { listBuckets } from '../lib/bucket/list';
 import { removeBucket } from '../lib/bucket/remove';
-import { config } from '../lib/config';
+import { getConfig } from '../lib/config';
 import { shouldSkipIntegrationTests } from './setup';
 
 const skipTests = shouldSkipIntegrationTests();
+
+const config = getConfig();
 
 // Pagination regression coverage for the listing endpoint: the gateway expects
 // `max-buckets` / `continuation-token` query params and returns the next page

--- a/packages/storage/src/test/bucket-type.integration.test.ts
+++ b/packages/storage/src/test/bucket-type.integration.test.ts
@@ -8,10 +8,12 @@ import {
   enableSnapshot,
   setBucketType,
 } from '../lib/bucket/set/type';
-import { config } from '../lib/config';
+import { getConfig } from '../lib/config';
 import { shouldSkipIntegrationTests } from './setup';
 
 const skipTests = shouldSkipIntegrationTests();
+
+const config = getConfig();
 
 const testBucket = (suffix: string) =>
   `test-snap-${suffix}-${Date.now()}`.toLowerCase();

--- a/packages/storage/src/test/config.test.ts
+++ b/packages/storage/src/test/config.test.ts
@@ -1,0 +1,83 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// Path to the actual shared config source. It only depends on `dotenv`, so it
+// runs standalone under Node's type stripping — no bundler/alias needed.
+const sharedConfig = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../../../shared/config.ts'
+);
+
+/**
+ * Runs a probe in a fresh Node process whose cwd is `dir` (so `.env`
+ * resolution is isolated from the test runner's own environment), and returns
+ * the JSON the probe prints.
+ */
+function runProbe(dir: string): {
+  bucket: string | null;
+  leakedTigris: string | null;
+  leakedUnrelated: string | null;
+} {
+  const probe = join(dir, 'probe.mjs');
+  writeFileSync(
+    probe,
+    `import { getEnvVar } from ${JSON.stringify(sharedConfig)};
+     process.stdout.write(JSON.stringify({
+       bucket: getEnvVar('TIGRIS_STORAGE_BUCKET') ?? null,
+       leakedTigris: process.env.TIGRIS_STORAGE_BUCKET ?? null,
+       leakedUnrelated: process.env.UNRELATED_SECRET ?? null,
+     }));`
+  );
+  // Strip any TIGRIS_/probe vars the test runner already has in its
+  // environment (it injects the repo `.env`) so the child only sees what the
+  // temp `.env` provides — otherwise inheritance would mask the behavior.
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('TIGRIS_') || key === 'UNRELATED_SECRET') {
+      delete env[key];
+    }
+  }
+
+  return JSON.parse(
+    execFileSync(process.execPath, [probe], { cwd: dir, encoding: 'utf8', env })
+  );
+}
+
+describe('config env loading', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'tigris-env-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('reads TIGRIS_ vars from .env without mutating process.env', () => {
+    writeFileSync(
+      join(dir, '.env'),
+      'TIGRIS_STORAGE_BUCKET=from-dotenv\nUNRELATED_SECRET=leak-me\n'
+    );
+
+    const out = runProbe(dir);
+
+    // The value is available to the SDK via getEnvVar...
+    expect(out.bucket).toBe('from-dotenv');
+    // ...but nothing from .env reaches the global process.env: neither the
+    // TIGRIS_ key nor the unrelated secret leaks to the rest of the process.
+    expect(out.leakedTigris).toBeNull();
+    expect(out.leakedUnrelated).toBeNull();
+  });
+
+  it('resolves to undefined when there is no .env', () => {
+    const out = runProbe(dir);
+
+    expect(out.bucket).toBeNull();
+    expect(out.leakedUnrelated).toBeNull();
+  });
+});

--- a/packages/storage/src/test/fork-merge-rebase.integration.test.ts
+++ b/packages/storage/src/test/fork-merge-rebase.integration.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { createBucket } from '../lib/bucket/create';
 import { removeBucket } from '../lib/bucket/remove';
-import { config } from '../lib/config';
+import { getConfig } from '../lib/config';
 import { mergeFork } from '../lib/fork/merge';
 import { rebaseFork } from '../lib/fork/rebase';
 import { get } from '../lib/object/get';
@@ -9,6 +9,8 @@ import { put } from '../lib/object/put';
 import { shouldSkipIntegrationTests } from './setup';
 
 const skipTests = shouldSkipIntegrationTests();
+
+const config = getConfig();
 
 // Target a specific bucket (a source or one of its forks) by overriding the
 // bucket on the shared config.

--- a/packages/storage/src/test/integration.test.ts
+++ b/packages/storage/src/test/integration.test.ts
@@ -18,7 +18,7 @@ import {
   listBucketSnapshots,
 } from '../lib/bucket/snapshot';
 import { updateBucket } from '../lib/bucket/update';
-import { config } from '../lib/config';
+import { getConfig } from '../lib/config';
 import { listForks } from '../lib/fork/list';
 import { copy } from '../lib/object/copy';
 import { get } from '../lib/object/get';
@@ -32,6 +32,8 @@ import { getSignedUploadUrl } from '../lib/object/signed-upload-url';
 import { shouldSkipIntegrationTests } from './setup';
 
 const skipTests = shouldSkipIntegrationTests();
+
+const config = getConfig();
 
 describe.skipIf(skipTests)('Tigris Storage Integration Tests', () => {
   const testFileName = `test-${Date.now()}.txt`;

--- a/packages/storage/src/test/object-versions.integration.test.ts
+++ b/packages/storage/src/test/object-versions.integration.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { createBucket } from '../lib/bucket/create';
 import { removeBucket } from '../lib/bucket/remove';
 import { createBucketSnapshot } from '../lib/bucket/snapshot';
-import { config } from '../lib/config';
+import { getConfig } from '../lib/config';
 import { get } from '../lib/object/get';
 import { head } from '../lib/object/head';
 import { listVersions } from '../lib/object/list-versions';
@@ -12,6 +12,8 @@ import { remove } from '../lib/object/remove';
 import { shouldSkipIntegrationTests } from './setup';
 
 const skipTests = shouldSkipIntegrationTests();
+
+const config = getConfig();
 
 describe.skipIf(skipTests)('Object versioning Integration Tests', () => {
   const bucket = `test-versions-${Date.now()}`.toLowerCase();

--- a/packages/storage/src/test/restore.integration.test.ts
+++ b/packages/storage/src/test/restore.integration.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { createBucket } from '../lib/bucket/create';
 import { removeBucket } from '../lib/bucket/remove';
-import { config } from '../lib/config';
+import { getConfig } from '../lib/config';
 import { put } from '../lib/object/put';
 import {
   getRestoreInfo,
@@ -11,6 +11,8 @@ import {
 import { shouldSkipIntegrationTests } from './setup';
 
 const skipTests = shouldSkipIntegrationTests();
+
+const config = getConfig();
 
 const testBucket = (suffix: string) =>
   `test-restore-${suffix}-${Date.now()}`.toLowerCase();

--- a/packages/storage/src/test/setup.ts
+++ b/packages/storage/src/test/setup.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll } from 'vitest';
-import { config } from '../lib/config';
+import { getConfig } from '../lib/config';
 import { list } from '../lib/object/list';
 import { remove } from '../lib/object/remove';
 
@@ -14,6 +14,7 @@ afterAll(async () => {
 });
 
 async function cleanupTestFiles() {
+  const config = getConfig();
   try {
     const result = await list({ config });
 

--- a/packages/storage/src/test/setup.ts
+++ b/packages/storage/src/test/setup.ts
@@ -1,3 +1,4 @@
+import { getEnvVar } from '@shared/index';
 import { afterAll, beforeAll } from 'vitest';
 import { getConfig } from '../lib/config';
 import { list } from '../lib/object/list';
@@ -43,7 +44,9 @@ export function shouldSkipIntegrationTests(): boolean {
     'TIGRIS_STORAGE_SECRET_ACCESS_KEY',
   ];
 
-  const missing = requiredEnvVars.filter((envVar) => !process.env[envVar]);
+  // Resolve through the SDK's own env resolution (process.env + private .env),
+  // so the skip decision matches what getConfig() will actually resolve.
+  const missing = requiredEnvVars.filter((envVar) => !getEnvVar(envVar));
 
   if (missing.length > 0) {
     console.warn(

--- a/shared/config.ts
+++ b/shared/config.ts
@@ -8,10 +8,43 @@ export function isNode(): boolean {
   );
 }
 
-export function loadEnv(): void {
-  if (isNode()) {
-    dotenv.config({ quiet: true });
+let cachedDotenv: Record<string, string> | undefined;
+
+/**
+ * Parse the consumer's `.env` file into a private, memoized object, keeping
+ * only `TIGRIS_`-prefixed keys.
+ *
+ * `dotenv`'s `processEnv` option redirects its writes to the throwaway object
+ * we hand it, so the global `process.env` is never mutated. Importing or using
+ * the SDK therefore cannot leak a consumer's `.env` — including unrelated
+ * secrets in it — into the process environment. Returns `{}` outside Node or
+ * when there is no readable `.env`.
+ */
+function readDotenv(): Record<string, string> {
+  if (!isNode()) {
+    return {};
   }
+  if (cachedDotenv) {
+    return cachedDotenv;
+  }
+
+  const parsed = dotenv.config({ quiet: true, processEnv: {} }).parsed ?? {};
+  cachedDotenv = Object.fromEntries(
+    Object.entries(parsed).filter(([key]) => key.startsWith('TIGRIS_'))
+  );
+  return cachedDotenv;
+}
+
+/**
+ * Resolve a single Tigris env var at call time. An explicitly-set `process.env`
+ * value wins (matching dotenv's non-override behavior); otherwise fall back to
+ * the value parsed from `.env`. Never writes to `process.env`.
+ */
+export function getEnvVar(key: string): string | undefined {
+  if (!isNode()) {
+    return undefined;
+  }
+  return process.env[key] ?? readDotenv()[key];
 }
 
 export const missingConfigError = (key: string, envVar?: string) => ({

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -1,4 +1,4 @@
-export { isNode, loadEnv, missingConfigError } from './config';
+export { getEnvVar, isNode, missingConfigError } from './config';
 export { TigrisHeaders } from './headers';
 export {
   type CreateHttpClientOptions,


### PR DESCRIPTION
Closes #181

## Problem

Importing the server entry of `@tigrisdata/storage` (and `@tigrisdata/iam`) ran `dotenv.config()` as an **import-time side effect**. That loaded the consuming app's entire `.env` — including keys unrelated to Tigris — into the global `process.env`, silently overriding apps that manage their own environment (or deliberately don't).

## Change

Remove the module-level exported `config` singleton in both packages. Configuration is now resolved **on demand** via a `getConfig()` function that each operation (`get`, `put`, `createStorageClient`, …) calls when it needs the current config.

Env resolution (`shared/config.ts`):
- Parses `.env` into a **private object** — never mutates `process.env`.
- Keeps **only `TIGRIS_`-prefixed** keys.
- Prefers explicitly-set `process.env` values (same non-override precedence dotenv itself uses).
- Memoized, so `.env` is parsed at most once.

Result: importing the SDK has **no side effects**, and nothing from a consumer's `.env` leaks into `process.env`.

## Compatibility

All existing dotenv usage keeps working, because `getConfig()` reads `process.env` first and only falls back to its private `.env` parse:

| Consumer setup | Works? |
|---|---|
| Loads their own `.env` (`dotenv/config`, framework, custom path, `override`, expand) | ✅ identical — read from `process.env` |
| Real env vars only (Docker/CI/shell) | ✅ identical |
| Has `.env` with `TIGRIS_*`, doesn't load dotenv | ✅ SDK supplies them privately, env stays clean |

The one intended behavior change: the SDK no longer loads a consumer's **non-Tigris** `.env` keys into `process.env` — which is the bug in #181.

## Scope

- **Core:** `shared/config.ts` (`getEnvVar`), `shared/index.ts`, `storage`/`iam` `lib/config.ts` (`getConfig`)
- **21 lib consumers** (20 storage + 1 iam) updated to call `getConfig()`
- **9 test files** updated (`setup.ts` + 8 integration suites)
- **New `config.test.ts`** — regression guard: `.env` reaches the SDK but never leaks to `process.env`

Note: the `config` singleton was internal only (never exported from the package entry), so there is no public API change — hence a **patch** changeset for both packages.

## Testing

- `pnpm biome check` — clean
- `pnpm --filter @tigrisdata/storage --filter @tigrisdata/iam build` — passes incl. `.d.ts`
- Storage suite: **209 passed, 3 skipped** — integration tests drive every refactored consumer against the live gateway
- New `config.test.ts` verifies the no-pollution / TIGRIS-only guarantees in an isolated subprocess

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential and endpoint resolution across all storage/IAM operations; behavior change is intentional (no global `.env` pollution) but misconfigured apps that relied on non-`TIGRIS_` keys in `process.env` from SDK import would no longer see them.
> 
> **Overview**
> Fixes import-time side effects where `@tigrisdata/storage` and `@tigrisdata/iam` called `dotenv.config()` and loaded the host app’s full `.env` into global `process.env`.
> 
> **Shared env resolution** replaces `loadEnv` with `getEnvVar`: `.env` is parsed once into a private cache (via `dotenv`’s `processEnv: {}`), only **`TIGRIS_`** keys are kept, and **`process.env` is never written**. Explicit `process.env` values still win over `.env`, matching prior dotenv precedence.
> 
> **Package config** drops the module-level `config` singleton in storage and IAM in favor of **`getConfig()`** called when clients and operations need settings. Storage and IAM HTTP/S3 entry points and object/bucket/fork helpers were updated accordingly; integration tests call `getConfig()` at module scope or in setup, and **`shouldSkipIntegrationTests`** uses `getEnvVar` so skip logic matches runtime resolution.
> 
> Adds **`config.test.ts`** (subprocess probe) to assert Tigris vars are readable from `.env` without leaking into `process.env`, plus a patch changeset for both packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d4b5c87fc699ada3cf92dc807f6ef640a2eb432. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->