### PR TITLE
docs(repo): document agent-shell and cli packages and apps directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,11 +63,19 @@ Located in the root `packages/` directory as a pnpm workspace (`pnpm-workspace.y
   - Built with TypeScript, uses AWS SDK v3 for S3 compatibility
   - Exports both server and client modules
 - **`@tigrisdata/iam`** ([packages/iam](packages/iam)) — IAM SDK
+- **`@tigrisdata/cli`** ([packages/cli](packages/cli)) — Command line interface for Tigris object storage (depends on `@tigrisdata/storage` and `@tigrisdata/iam`)
 - **`@tigrisdata/agent-kit`** ([packages/agent-kit](packages/agent-kit)) — Composition library for AI agents (depends on `@tigrisdata/storage` and `@tigrisdata/iam`)
 - **`@tigrisdata/keyv-tigris`** ([packages/keyv-tigris](packages/keyv-tigris)) — Keyv adapter (depends on `@tigrisdata/storage`)
 - **`@tigrisdata/react`** ([packages/react](packages/react)) — React components (depends on `@tigrisdata/storage`)
+- **`@tigrisdata/agent-shell`** ([packages/agent-shell](packages/agent-shell)) — A virtual bash environment for AI agents, backed by Tigris object storage (depends on `@tigrisdata/storage`)
 
 Cross-package deps use the `workspace:^` protocol; pnpm rewrites them to real ranges at publish time.
+
+### Apps
+
+Non-published apps live in `apps/` (part of the pnpm workspace via the `apps/*` glob) and are marked `private: true` so Changesets never publishes them:
+
+- **`agent-shell-playground`** ([apps/agent-shell-playground](apps/agent-shell-playground)) — Vite playground for `@tigrisdata/agent-shell`, deployed to Fly.io via the `deploy-agent-shell-playground.yml` workflow
 
 Shared code lives in [`shared/`](shared) and is imported via the `@shared/*` TS path alias and the matching tsup esbuild alias. It is bundled into each package at build time and is not published as its own package.
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,17 @@ This monorepo contains multiple JavaScript/TypeScript packages for Tigris object
 
 - [`@tigrisdata/storage`](./packages/storage) - Tigris Storage SDK
 - [`@tigrisdata/iam`](./packages/iam) - Tigris IAM SDK
+- [`@tigrisdata/cli`](./packages/cli) - Command line interface for Tigris object storage
 - [`@tigrisdata/agent-kit`](./packages/agent-kit) - Composed workflows for AI agents (sandboxes, workspaces, checkpoints, coordination)
 - [`@tigrisdata/keyv-tigris`](./packages/keyv-tigris) - Tigris adapter for [Keyv](https://keyv.org/)
 - [`@tigrisdata/react`](./packages/react) - Ready to use React Components and Hooks
+- [`@tigrisdata/agent-shell`](./packages/agent-shell) - A virtual bash environment for AI agents, backed by Tigris object storage
+
+### Apps
+
+Non-published apps live in [`apps/`](./apps):
+
+- [`agent-shell-playground`](./apps/agent-shell-playground) - Vite playground for `@tigrisdata/agent-shell`
 
 ## Go SDK
 


### PR DESCRIPTION
## Summary

Documents the newly-imported `@tigrisdata/cli` and `@tigrisdata/agent-shell` packages and the `apps/` directory in the two top-level docs.

- **`AGENTS.md`** — adds `@tigrisdata/cli` and `@tigrisdata/agent-shell` to the package list and a new **Apps** section describing `agent-shell-playground` (private, deployed to Fly.io).
- **`README.md`** — mirrors the same additions in the package list and an **Apps** section.

## Why

The `cli` and `agent-shell` packages and the `agent-shell-playground` app were imported into the monorepo but weren't reflected in the structure docs. This brings the docs in line with the current workspace layout.

## Notes

- Docs-only change to root files — nothing publishes to npm, so no changeset is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to root markdown files with no code, build, or release impact.
> 
> **Overview**
> Brings **AGENTS.md** and **README.md** in line with the current monorepo layout after importing agent-shell.
> 
> Both files now list **`@tigrisdata/agent-shell`** (and **`@tigrisdata/cli`** where it was missing) in the JavaScript/TypeScript package inventory. **AGENTS.md** also adds an **Apps** section that explains `apps/` as private workspace members excluded from Changesets, and documents **`agent-shell-playground`** with its Fly.io deploy workflow. **README.md** adds a shorter **Apps** section pointing at the same playground.
> 
> Docs-only; no runtime or publish behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25962dda15a789243306848bd48b003cc0b99dfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
