### PR TITLE
fix(cli): build workspace deps before compiling standalone binaries

### DIFF
--- a/.changeset/fix-cli-binary-release.md
+++ b/.changeset/fix-cli-binary-release.md
@@ -1,0 +1,5 @@
+---
+"@tigrisdata/cli": patch
+---
+
+Fix the release pipeline so the standalone binaries and Homebrew formula are actually built and published. The `build-binaries` job installed dependencies but never built the workspace packages, so the binary `tsc` could not resolve `@tigrisdata/iam` / `@tigrisdata/storage` types and failed before any assets were uploaded (3.4.2 shipped to npm but without binaries).

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -140,6 +140,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # build:binary type-checks against @tigrisdata/iam and @tigrisdata/storage,
+      # so their dist/*.d.ts must exist first. This job is separate from the
+      # release job, so build the workspace packages here too.
+      - name: Build workspace packages
+        run: pnpm -r --if-present run build
+
       - name: Build binaries for all platforms
         run: pnpm --filter @tigrisdata/cli run build:binary
 


### PR DESCRIPTION
## Summary

Fixes the `build-binaries` release job, which failed on the first live CLI release ([run](https://github.com/tigrisdata/storage/actions/runs/29580538375)).

`build:binary` runs `tsc -p tsconfig.binary.json`, which type-checks against `@tigrisdata/iam` and `@tigrisdata/storage`. The job installed dependencies but **never built the workspace packages**, so those `dist/*.d.ts` didn't exist and `tsc` failed with `Cannot find module '@tigrisdata/iam'` (plus cascading implicit-`any` errors) before any assets were built or uploaded.

The `release` job worked because it runs `pnpm -r run build`; `build-binaries` is a separate runner that skipped it. Fix: add a **"Build workspace packages"** step before `build:binary`.

## Impact of the failure (3.4.2)
- ✅ npm `@tigrisdata/cli@3.4.2` published and `latest` — that channel is unaffected.
- ❌ GitHub release `@tigrisdata/cli@3.4.2` has no binary assets.
- ⏭️ Homebrew update skipped (needs `build-binaries`).

3.4.2 binaries are being **backfilled manually**; this PR ensures future releases build them automatically.

## Verification
- Locally, with workspace deps built + registry generated, `tsc -p tsconfig.binary.json` passes cleanly (the `@tigrisdata/iam` / `@tigrisdata/storage` errors and the cascading implicit-`any` errors are gone).
- Workflow YAML parses; diff is +6 lines in the job plus a changeset.

## Changeset
Includes a `patch` changeset for `@tigrisdata/cli` so merging cuts a release (3.4.3) that exercises the fixed binary + Homebrew pipeline end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to the release workflow plus a changeset; no runtime or application logic changes.
> 
> **Overview**
> Fixes the **`build-binaries`** GitHub Actions job so standalone CLI binaries and Homebrew updates can succeed on release.
> 
> The job now runs **`pnpm -r --if-present run build`** after install and before **`build:binary`**. That mirrors what the main **`release`** job already does and ensures **`@tigrisdata/iam`** and **`@tigrisdata/storage`** have **`dist/*.d.ts`** when **`tsc -p tsconfig.binary.json`** runs on a separate runner.
> 
> Without this step, binary compilation failed with missing workspace module types, so GitHub release assets and the Homebrew pipeline were skipped (e.g. 3.4.2 on npm only). A **patch** changeset for **`@tigrisdata/cli`** is included for the next release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df2ab82025e7ebaef3346a75832e70c00a167e3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->