### PR TITLE
fix(cli): resolve buckets migrate stalls and overhaul progress display

### DIFF
--- a/.changeset/migrate-head-of-line-deadlock.md
+++ b/.changeset/migrate-head-of-line-deadlock.md
@@ -2,9 +2,20 @@
 "@tigrisdata/cli": patch
 ---
 
-Fix a deadlock in `tigris buckets migrate` that stalled large migrations. The
-drain step only polled the oldest in-flight objects, so a slow object at the
-head hid the completed objects behind it — their bytes were never freed, the
-in-flight budget stayed pinned at its cap, and the migration wedged (progress
-frozen with in-flight stuck at ~10 GB). It now polls a rotating window across
-the whole in-flight set, so completions are observed regardless of position.
+Fix a deadlock in `tigris buckets migrate` that stalled large migrations, and
+improve how large-file migrations look and behave.
+
+- **Deadlock fix:** the drain step only polled the oldest in-flight objects, so
+  a slow object at the head hid the completed objects behind it — their bytes
+  were never freed, the in-flight budget stayed pinned at its cap, and the
+  migration wedged (progress frozen with in-flight stuck at ~10 GB). It now
+  polls a rotating window across the whole in-flight set, so completions are
+  observed regardless of position.
+- **Smallest-first:** objects now migrate smallest-first, so progress climbs
+  quickly and large files finish at the end instead of stalling mid-run.
+- **Object-count cap:** in-flight is now bounded by object count as well as
+  bytes, keeping the poll set manageable on runs with millions of small files.
+- **Clearer progress:** the progress line now shows throughput (objects/s and
+  bytes/s), the in-flight object count, and — when a transfer has been running a
+  while — the oldest in-flight object (name, size, and how long it has been
+  pulling), so a slow large file is visibly attributed instead of looking stuck.

--- a/.changeset/migrate-head-of-line-deadlock.md
+++ b/.changeset/migrate-head-of-line-deadlock.md
@@ -3,7 +3,7 @@
 ---
 
 Fix a deadlock in `tigris buckets migrate` that stalled large migrations, and
-improve how large-file migrations look and behave.
+overhaul how migrations are paced and displayed.
 
 - **Deadlock fix:** the drain step only polled the oldest in-flight objects, so
   a slow object at the head hid the completed objects behind it — their bytes
@@ -11,11 +11,24 @@ improve how large-file migrations look and behave.
   migration wedged (progress frozen with in-flight stuck at ~10 GB). It now
   polls a rotating window across the whole in-flight set, so completions are
   observed regardless of position.
-- **Smallest-first:** objects now migrate smallest-first, so progress climbs
-  quickly and large files finish at the end instead of stalling mid-run.
-- **Object-count cap:** in-flight is now bounded by object count as well as
-  bytes, keeping the poll set manageable on runs with millions of small files.
-- **Clearer progress:** the progress line now shows throughput (objects/s and
-  bytes/s), the in-flight object count, and — when a transfer has been running a
-  while — the oldest in-flight object (name, size, and how long it has been
-  pulling), so a slow large file is visibly attributed instead of looking stuck.
+- **Smallest-first:** objects migrate smallest-first, so progress climbs quickly
+  and large files finish at the end instead of stalling mid-run.
+- **In-flight caps:** in-flight work is bounded by both object count and total
+  bytes, and the byte budget is enforced across the pending schedule batch, so a
+  large file can't be scheduled alongside a full batch and blow the budget.
+- **Poll backoff:** the `isMigrated` poll backs off (5s up to 30s) after sweeps
+  where nothing completed, and resets on the next completion, so an idle
+  migration stops hammering the gateway with status checks.
+- **Multi-line, live progress:** progress renders as a sticky multi-line block —
+  bucket and elapsed clock, file and byte percentages, and the file currently
+  being pulled (name, size, and how long it has been going) plus the in-flight
+  count. It redraws in place instead of duplicating lines on window resize, and
+  truncates each line to the terminal width so nothing wraps. There is no
+  throughput figure: confirmations are lumpy binary flips (the gateway does the
+  transfer), not a byte stream, so an "obj/s · MB/s" rate would misrepresent
+  progress.
+- **Responsive cancel:** Ctrl-C stops scheduling and polling and prints a
+  summary of what was confirmed; objects already scheduled remain queued for
+  migration server-side, so re-running resumes from there. It is felt
+  immediately (the poll wait is abortable rather than blocking until it
+  elapses), and a second Ctrl-C forces an immediate exit.

--- a/.changeset/migrate-head-of-line-deadlock.md
+++ b/.changeset/migrate-head-of-line-deadlock.md
@@ -1,0 +1,10 @@
+---
+"@tigrisdata/cli": patch
+---
+
+Fix a deadlock in `tigris buckets migrate` that stalled large migrations. The
+drain step only polled the oldest in-flight objects, so a slow object at the
+head hid the completed objects behind it — their bytes were never freed, the
+in-flight budget stayed pinned at its cap, and the migration wedged (progress
+frozen with in-flight stuck at ~10 GB). It now polls a rotating window across
+the whole in-flight set, so completions are observed regardless of position.

--- a/packages/cli/src/lib/buckets/migrate.ts
+++ b/packages/cli/src/lib/buckets/migrate.ts
@@ -109,6 +109,28 @@ export function atCapacity(state: MigrationState, itemSize: number): boolean {
   );
 }
 
+/**
+ * Whether the pending schedule batch should be flushed before adding `itemSize`.
+ * Flushing moves the batch's bytes into `inFlight` where the byte/object budget
+ * is actually enforced — without this, a batch that hasn't reached
+ * SCHEDULE_BATCH_SIZE (e.g. a run with only a couple of objects) is scheduled
+ * all at once at the end, blowing the in-flight budget and letting a huge file
+ * be scheduled alongside others instead of running on its own.
+ */
+export function shouldFlushBatch(
+  state: MigrationState,
+  batchLength: number,
+  batchBytes: number,
+  itemSize: number
+): boolean {
+  if (batchLength === 0) return false;
+  return (
+    batchLength >= SCHEDULE_BATCH_SIZE ||
+    state.inFlight.length + batchLength >= MAX_IN_FLIGHT_OBJECTS ||
+    state.inFlightBytes + batchBytes + itemSize > MAX_IN_FLIGHT_BYTES
+  );
+}
+
 /** The in-flight item that has been pulling longest, or null if none. */
 export function oldestInFlight(inFlight: InFlightItem[]): InFlightItem | null {
   let oldest: InFlightItem | null = null;
@@ -511,11 +533,22 @@ export default async function migrate(
     };
 
     let batch: MigrationItem[] = [];
+    let batchBytes = 0;
 
     for (const item of diff) {
       if (interrupted) break;
 
-      // Throttle: wait until capacity (object count and bytes) is available
+      // Flush the pending batch before it would exceed the in-flight budget (or
+      // fill a batch), so scheduled bytes are accounted and a large file isn't
+      // scheduled alongside a full batch.
+      if (shouldFlushBatch(state, batch.length, batchBytes, item.size)) {
+        await flushScheduleBatch(batch, state, config, bucket);
+        batch = [];
+        batchBytes = 0;
+        printProgress(state, bucket);
+      }
+
+      // Throttle: wait until in-flight capacity (object count and bytes) frees.
       while (atCapacity(state, item.size) && !interrupted) {
         await drainCompleted(state, config, bucket);
         printProgress(state, bucket);
@@ -524,12 +557,7 @@ export default async function migrate(
       if (interrupted) break;
 
       batch.push(item);
-
-      if (batch.length >= SCHEDULE_BATCH_SIZE) {
-        await flushScheduleBatch(batch, state, config, bucket);
-        batch = [];
-        printProgress(state, bucket);
-      }
+      batchBytes += item.size;
     }
 
     // Flush remaining batch

--- a/packages/cli/src/lib/buckets/migrate.ts
+++ b/packages/cli/src/lib/buckets/migrate.ts
@@ -27,8 +27,11 @@ const MAX_IN_FLIGHT_OBJECTS = 1000;
 /** Max concurrent migrate() or isMigrated() calls */
 const CONCURRENCY = 50;
 
-/** Seconds to wait between isMigrated polling rounds */
+/** Base wait between isMigrated polling rounds (grows with backoff). */
 const CHECK_INTERVAL_MS = 5_000;
+
+/** Upper bound on the isMigrated poll backoff. */
+const MAX_CHECK_INTERVAL_MS = 30_000;
 
 /** Batch size for scheduling migrate() calls before checking throttle */
 const SCHEDULE_BATCH_SIZE = 50;
@@ -36,14 +39,11 @@ const SCHEDULE_BATCH_SIZE = 50;
 /** Max consecutive isMigrated failures before marking item as failed */
 const MAX_CHECK_FAILURES = 3;
 
-/**
- * Surface the oldest in-flight object once it has been pulling this long, so a
- * slow/large transfer is visibly named instead of looking like a stall.
- */
-const SLOW_IN_FLIGHT_MS = 30_000;
+/** Spinner frames for the live progress indicator. */
+const SPINNER = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
-/** Window over which the displayed confirmed-object/byte rate is averaged. */
-const RATE_WINDOW_MS = 5_000;
+/** How often the progress line re-renders (spinner + clock) while polling. */
+const RENDER_INTERVAL_MS = 250;
 
 interface MigrationItem {
   name: string;
@@ -69,14 +69,10 @@ export interface MigrationState {
   drainOffset: number;
   /** In-flight items checked since the last completion (for backoff). */
   drainSweepMisses: number;
-  /** Rolling anchor for the displayed confirmed-object/byte rate. */
-  rate: {
-    anchorTime: number;
-    anchorConfirmed: number;
-    anchorBytes: number;
-    objPerSec: number;
-    bytesPerSec: number;
-  };
+  /** Current isMigrated poll backoff, grown after each empty full sweep. */
+  checkBackoffMs: number;
+  /** Current spinner frame index for the live progress indicator. */
+  spinnerFrame: number;
   errors: Array<{ name: string; error: string }>;
   startTime: number;
 }
@@ -140,6 +136,32 @@ export function oldestInFlight(inFlight: InFlightItem[]): InFlightItem | null {
     }
   }
   return oldest;
+}
+
+/**
+ * The activity segment of the progress line: the oldest in-flight object (the
+ * one scheduled-but-unconfirmed the longest), or a waiting indicator. The time
+ * shown is how long we have been *waiting* for that file since it was scheduled
+ * (`now - scheduledAt`), NOT an active-transfer time — the gateway exposes no
+ * per-object progress, so we can only report how long it has been in-flight.
+ * There is likewise no throughput figure: confirmations are lumpy binary flips
+ * of isMigrated (the gateway does the transfer), not a byte stream, so an
+ * "obj/s · MB/s" rate would misrepresent progress.
+ */
+export function activityLabel(
+  oldest: InFlightItem | null,
+  now: number,
+  maxNameLen = 40
+): string {
+  if (oldest) {
+    // Keep the tail of the key (the filename) when truncating.
+    const name =
+      oldest.name.length > maxNameLen
+        ? `…${oldest.name.slice(-Math.max(1, maxNameLen - 1))}`
+        : oldest.name;
+    return `migrating ${name} (${formatSize(oldest.size)}, waiting ${formatElapsed(now - oldest.scheduledAt)})`;
+  }
+  return 'waiting…';
 }
 
 // ---------------------------------------------------------------------------
@@ -210,7 +232,8 @@ class PaginatedCursor {
 async function discoverDiff(
   bucket: string,
   prefix: string | undefined,
-  config: Record<string, unknown>
+  config: Record<string, unknown>,
+  signal?: AbortSignal
 ): Promise<MigrationItem[]> {
   const shadow = new PaginatedCursor(bucket, 'shadow', prefix, config);
   const tigris = new PaginatedCursor(bucket, 'tigris', prefix, config);
@@ -221,6 +244,9 @@ async function discoverDiff(
   let tigrisItem = await tigris.current();
 
   while (shadowItem !== null) {
+    // Stop listing promptly on Ctrl-C instead of paging through the whole
+    // bucket first (which would look like a hang after the cancel).
+    if (signal?.aborted) break;
     if (tigrisItem === null) {
       // Tigris exhausted — all remaining shadow items need migration
       diff.push({ name: shadowItem.name, size: shadowItem.size });
@@ -254,8 +280,22 @@ async function discoverDiff(
 // Migration loop
 // ---------------------------------------------------------------------------
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    function onAbort() {
+      clearTimeout(timer);
+      resolve();
+    }
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
 }
 
 function formatElapsed(ms: number): string {
@@ -266,60 +306,68 @@ function formatElapsed(ms: number): string {
   return `${minutes}m ${seconds}s`;
 }
 
-/** Recompute the rolling confirmed rate once per RATE_WINDOW_MS. */
-function updateRate(state: MigrationState, now: number): void {
-  const dt = now - state.rate.anchorTime;
-  if (dt < RATE_WINDOW_MS) return;
-  state.rate.objPerSec =
-    ((state.confirmed - state.rate.anchorConfirmed) * 1000) / dt;
-  state.rate.bytesPerSec =
-    ((state.confirmedBytes - state.rate.anchorBytes) * 1000) / dt;
-  state.rate.anchorTime = now;
-  state.rate.anchorConfirmed = state.confirmed;
-  state.rate.anchorBytes = state.confirmedBytes;
+/**
+ * The multi-line progress block. Each line is kept to one row (the renderer
+ * truncates to the terminal width) so nothing wraps — wrapping is what let the
+ * old single-line `\r` redraw leave duplicated rows behind on Ctrl-C and resize.
+ */
+function progressLines(state: MigrationState, bucket: string): string[] {
+  const now = Date.now();
+  state.spinnerFrame = (state.spinnerFrame + 1) % SPINNER.length;
+  const spin = SPINNER[state.spinnerFrame];
+
+  const filePct =
+    state.total > 0 ? Math.floor((state.confirmed / state.total) * 100) : 0;
+  const bytePct =
+    state.totalBytes > 0
+      ? Math.floor((state.confirmedBytes / state.totalBytes) * 100)
+      : 0;
+  const elapsed = formatElapsed(now - state.startTime);
+  const oldest = oldestInFlight(state.inFlight);
+  const width = process.stderr.columns ?? 80;
+
+  return [
+    `${spin} Migrating ${bucket} · ${elapsed} elapsed`,
+    // File count climbs fast (smallest-first); the byte figure shows how much
+    // data has actually moved (the big files are last).
+    `  ${state.confirmed.toLocaleString()} / ${state.total.toLocaleString()} files (${filePct}%)` +
+      ` · ${formatSize(state.confirmedBytes)} / ${formatSize(state.totalBytes)} (${bytePct}%)`,
+    `  ${activityLabel(oldest, now, Math.max(20, width - 45))}` +
+      ` · in-flight ${state.inFlight.length.toLocaleString()} (${formatSize(state.inFlightBytes)})`,
+  ];
 }
 
-function printProgress(state: MigrationState, bucket: string): void {
+// Lines the sticky renderer last drew, so it can move the cursor up and clear
+// exactly that block before redrawing. A single `\r` can only rewrite one row,
+// which is why a wrapped or multi-line block used to duplicate itself.
+let renderedLines = 0;
+
+function renderProgress(state: MigrationState, bucket: string): void {
   if (!process.stderr.isTTY || globalThis.__TIGRIS_JSON_MODE) return;
-
-  const now = Date.now();
-  updateRate(state, now);
-
-  const pct =
-    state.total > 0 ? Math.floor((state.confirmed / state.total) * 100) : 0;
-
-  const parts = [
-    `Migrating ${bucket}: ${state.confirmed.toLocaleString()} / ${state.total.toLocaleString()} (${pct}%)`,
-    `${Math.round(state.rate.objPerSec).toLocaleString()} obj/s, ${formatSize(state.rate.bytesPerSec)}/s`,
-    `in-flight ${state.inFlight.length.toLocaleString()} (${formatSize(state.inFlightBytes)})`,
-    formatElapsed(now - state.startTime),
-  ];
-
-  // Name the oldest in-flight object once it has been pulling a while, so a
-  // slow/large transfer is visibly attributed instead of looking like a stall.
-  const oldest = oldestInFlight(state.inFlight);
-  if (oldest && now - oldest.scheduledAt >= SLOW_IN_FLIGHT_MS) {
-    const label =
-      oldest.name.length > 40 ? `…${oldest.name.slice(-39)}` : oldest.name;
-    parts.push(
-      `pulling ${label} (${formatSize(oldest.size)}, ${formatElapsed(now - oldest.scheduledAt)})`
-    );
-  }
-
-  const width = process.stderr.columns ?? 100;
-  let text = parts.join(' | ');
-  if (text.length > width) {
-    text = `${text.slice(0, width - 1)}…`;
-  }
-  process.stderr.write(
-    `\r${text}${' '.repeat(Math.max(0, width - text.length))}`
+  const width = process.stderr.columns ?? 80;
+  const lines = progressLines(state, bucket).map((line) =>
+    line.length > width ? `${line.slice(0, Math.max(1, width - 1))}…` : line
   );
+
+  let out = '';
+  if (renderedLines > 0) {
+    out += `\x1b[${renderedLines}A`; // up to the first line of the last block
+  }
+  out += '\x1b[0J'; // clear from the cursor to the end of the screen
+  out += `${lines.join('\n')}\n`;
+  renderedLines = lines.length;
+  process.stderr.write(out);
 }
 
 function clearProgress(): void {
   if (!process.stderr.isTTY || globalThis.__TIGRIS_JSON_MODE) return;
-  const width = process.stderr.columns ?? 100;
-  process.stderr.write(`\r${' '.repeat(width)}\r`);
+  if (renderedLines > 0) {
+    process.stderr.write(`\x1b[${renderedLines}A\x1b[0J`);
+    renderedLines = 0;
+    return;
+  }
+  // No sticky block yet — clear any partial single line (e.g. "Discovering…").
+  process.stderr.write('\r\x1b[K');
 }
 
 async function flushScheduleBatch(
@@ -363,7 +411,8 @@ async function flushScheduleBatch(
 export async function drainCompleted(
   state: MigrationState,
   config: Record<string, unknown>,
-  bucket: string
+  bucket: string,
+  signal?: AbortSignal
 ): Promise<void> {
   const n = state.inFlight.length;
   if (n === 0) return;
@@ -420,17 +469,23 @@ export async function drainCompleted(
       (item) => !completedKeys.has(item.name)
     );
     state.drainSweepMisses = 0;
+    state.checkBackoffMs = CHECK_INTERVAL_MS;
     return;
   }
 
   // No completions in this window: advance to the next one instead of sleeping
   // right away, so a slow head can't stall polling of the rest. Only back off
-  // once we've swept the whole in-flight set without a single completion —
-  // i.e. we are genuinely waiting on the gateway.
+  // once we've swept the whole in-flight set without a single completion — and
+  // grow the wait each time (up to MAX_CHECK_INTERVAL_MS) so a genuinely idle
+  // migration isn't hammering the gateway with HEADs every few seconds.
   state.drainSweepMisses += window.length;
   if (state.drainSweepMisses >= n) {
     state.drainSweepMisses = 0;
-    await sleep(CHECK_INTERVAL_MS);
+    await sleep(state.checkBackoffMs, signal);
+    state.checkBackoffMs = Math.min(
+      state.checkBackoffMs * 2,
+      MAX_CHECK_INTERVAL_MS
+    );
   }
 }
 
@@ -455,12 +510,39 @@ export default async function migrate(
 
   const config = await getStorageConfig();
 
-  // Handle SIGINT gracefully
+  // Handle SIGINT: the first Ctrl-C stops scheduling and polling, prints a
+  // summary of what has been confirmed, and exits. Objects already scheduled
+  // remain queued for migration server-side (the pull is the gateway's, not
+  // ours), so re-running migrate resumes from there. A second Ctrl-C
+  // force-quits. The
+  // AbortController wakes any in-progress poll backoff so the first Ctrl-C is
+  // felt immediately instead of after a sleep of up to MAX_CHECK_INTERVAL_MS.
   let interrupted = false;
+  let renderTimer: ReturnType<typeof setInterval> | undefined;
+  const abortController = new AbortController();
+  const stopRendering = () => {
+    if (renderTimer) {
+      clearInterval(renderTimer);
+      renderTimer = undefined;
+    }
+  };
   const sigintHandler = () => {
+    if (interrupted) {
+      process.exit(130);
+    }
     interrupted = true;
+    abortController.abort();
+    stopRendering();
+    clearProgress();
   };
   process.on('SIGINT', sigintHandler);
+  // On resize, clear the block at its current height so the next render tick
+  // repaints it at the new width. Just zeroing the height would append a fresh
+  // block under the old one (orphaning it) and desync clearProgress.
+  const resizeHandler = () => {
+    clearProgress();
+  };
+  process.stderr.on('resize', resizeHandler);
 
   try {
     // Phase 1: Discovery
@@ -470,13 +552,18 @@ export default async function migrate(
 
     let diff: MigrationItem[];
     try {
-      diff = await discoverDiff(bucket, prefix, config);
+      diff = await discoverDiff(bucket, prefix, config, abortController.signal);
     } catch (err) {
       clearProgress();
       failWithError(context, err);
     }
 
     clearProgress();
+
+    if (interrupted) {
+      console.error('\nCancelled.');
+      process.exit(1);
+    }
 
     if (diff.length === 0) {
       if (process.stderr.isTTY && !globalThis.__TIGRIS_JSON_MODE) {
@@ -521,16 +608,22 @@ export default async function migrate(
       inFlightBytes: 0,
       drainOffset: 0,
       drainSweepMisses: 0,
-      rate: {
-        anchorTime: now,
-        anchorConfirmed: 0,
-        anchorBytes: 0,
-        objPerSec: 0,
-        bytesPerSec: 0,
-      },
+      checkBackoffMs: CHECK_INTERVAL_MS,
+      spinnerFrame: 0,
       errors: [],
       startTime: now,
     };
+
+    // Re-render the progress block on a timer so the spinner and elapsed clock
+    // keep moving while a large file transfers (and during poll backoff),
+    // instead of the block looking frozen.
+    if (process.stderr.isTTY && !globalThis.__TIGRIS_JSON_MODE) {
+      renderTimer = setInterval(
+        () => renderProgress(state, bucket),
+        RENDER_INTERVAL_MS
+      );
+      renderTimer.unref?.();
+    }
 
     let batch: MigrationItem[] = [];
     let batchBytes = 0;
@@ -545,13 +638,11 @@ export default async function migrate(
         await flushScheduleBatch(batch, state, config, bucket);
         batch = [];
         batchBytes = 0;
-        printProgress(state, bucket);
       }
 
       // Throttle: wait until in-flight capacity (object count and bytes) frees.
       while (atCapacity(state, item.size) && !interrupted) {
-        await drainCompleted(state, config, bucket);
-        printProgress(state, bucket);
+        await drainCompleted(state, config, bucket, abortController.signal);
       }
 
       if (interrupted) break;
@@ -563,15 +654,14 @@ export default async function migrate(
     // Flush remaining batch
     if (batch.length > 0 && !interrupted) {
       await flushScheduleBatch(batch, state, config, bucket);
-      printProgress(state, bucket);
     }
 
     // Phase 3: Drain all remaining in-flight items
     while (state.inFlight.length > 0 && !interrupted) {
-      await drainCompleted(state, config, bucket);
-      printProgress(state, bucket);
+      await drainCompleted(state, config, bucket, abortController.signal);
     }
 
+    stopRendering();
     clearProgress();
 
     // Summary
@@ -596,7 +686,10 @@ export default async function migrate(
 
     if (interrupted) {
       console.error(
-        `\nInterrupted. ${state.confirmed} confirmed, ${state.inFlight.length} still in-flight, ${state.total - state.scheduled} not yet scheduled.`
+        `\nCancelled — ${state.confirmed.toLocaleString()} confirmed, ` +
+          `${state.inFlight.length.toLocaleString()} queued for migration, ` +
+          `${(state.total - state.scheduled).toLocaleString()} not scheduled. ` +
+          'Re-run migrate to resume.'
       );
       process.exit(1);
     }
@@ -626,6 +719,8 @@ export default async function migrate(
       `\nMigration complete: ${state.confirmed.toLocaleString()} object(s) migrated (${formatSize(state.confirmedBytes)}) in ${elapsed}`
     );
   } finally {
+    stopRendering();
     process.removeListener('SIGINT', sigintHandler);
+    process.stderr.removeListener('resize', resizeHandler);
   }
 }

--- a/packages/cli/src/lib/buckets/migrate.ts
+++ b/packages/cli/src/lib/buckets/migrate.ts
@@ -34,11 +34,11 @@ interface MigrationItem {
   size: number;
 }
 
-interface InFlightItem extends MigrationItem {
+export interface InFlightItem extends MigrationItem {
   checkFailures: number;
 }
 
-interface MigrationState {
+export interface MigrationState {
   total: number;
   totalBytes: number;
   scheduled: number;
@@ -47,6 +47,10 @@ interface MigrationState {
   failed: number;
   inFlight: InFlightItem[];
   inFlightBytes: number;
+  /** Rotating cursor into inFlight so drainCompleted sweeps the whole set. */
+  drainOffset: number;
+  /** In-flight items checked since the last completion (for backoff). */
+  drainSweepMisses: number;
   errors: Array<{ name: string; error: string }>;
   startTime: number;
 }
@@ -227,18 +231,29 @@ async function flushScheduleBatch(
   }
 }
 
-async function drainCompleted(
+export async function drainCompleted(
   state: MigrationState,
   config: Record<string, unknown>,
   bucket: string
 ): Promise<void> {
-  if (state.inFlight.length === 0) return;
+  const n = state.inFlight.length;
+  if (n === 0) return;
 
-  // Check oldest items first (FIFO), up to CONCURRENCY at a time
-  const toCheck = state.inFlight.slice(0, CONCURRENCY);
+  // Poll a rotating window across the WHOLE in-flight set — never a fixed head.
+  // Migrations don't complete in FIFO order, so only checking the oldest items
+  // lets a slow object at the front hide the completed objects behind it: their
+  // bytes are never freed, inFlightBytes stays pinned at the cap, and the whole
+  // migration deadlocks (head-of-line blocking). The cursor advances each call
+  // so every in-flight object is polled over successive rounds.
+  const start = state.drainOffset % n;
+  const window: InFlightItem[] = [];
+  for (let k = 0; k < Math.min(CONCURRENCY, n); k++) {
+    window.push(state.inFlight[(start + k) % n]);
+  }
+  state.drainOffset = start + window.length;
 
   const results = await executeWithConcurrency(
-    toCheck.map(
+    window.map(
       (item) => () =>
         isMigrated(item.name, {
           config: { ...config, bucket },
@@ -250,7 +265,7 @@ async function drainCompleted(
   const completedKeys = new Set<string>();
   for (let i = 0; i < results.length; i++) {
     const result = results[i];
-    const item = toCheck[i];
+    const item = window[i];
 
     if (result.error) {
       item.checkFailures++;
@@ -275,10 +290,17 @@ async function drainCompleted(
     state.inFlight = state.inFlight.filter(
       (item) => !completedKeys.has(item.name)
     );
+    state.drainSweepMisses = 0;
+    return;
   }
 
-  // If nothing completed, wait before next check
-  if (completedKeys.size === 0) {
+  // No completions in this window: advance to the next one instead of sleeping
+  // right away, so a slow head can't stall polling of the rest. Only back off
+  // once we've swept the whole in-flight set without a single completion —
+  // i.e. we are genuinely waiting on the gateway.
+  state.drainSweepMisses += window.length;
+  if (state.drainSweepMisses >= n) {
+    state.drainSweepMisses = 0;
     await sleep(CHECK_INTERVAL_MS);
   }
 }
@@ -363,6 +385,8 @@ export default async function migrate(
       failed: 0,
       inFlight: [],
       inFlightBytes: 0,
+      drainOffset: 0,
+      drainSweepMisses: 0,
       errors: [],
       startTime: Date.now(),
     };

--- a/packages/cli/src/lib/buckets/migrate.ts
+++ b/packages/cli/src/lib/buckets/migrate.ts
@@ -17,6 +17,13 @@ const context = msg('buckets', 'migrate');
 /** Max total bytes of in-flight (scheduled but not confirmed) migrations */
 const MAX_IN_FLIGHT_BYTES = 10 * 1024 * 1024 * 1024; // 10 GB
 
+/**
+ * Max number of in-flight objects, independent of size. Keeps the poll set
+ * bounded so a run with millions of tiny files can't balloon in-flight (which
+ * would make each drain sweep huge), and paces how far ahead we schedule.
+ */
+const MAX_IN_FLIGHT_OBJECTS = 1000;
+
 /** Max concurrent migrate() or isMigrated() calls */
 const CONCURRENCY = 50;
 
@@ -29,6 +36,15 @@ const SCHEDULE_BATCH_SIZE = 50;
 /** Max consecutive isMigrated failures before marking item as failed */
 const MAX_CHECK_FAILURES = 3;
 
+/**
+ * Surface the oldest in-flight object once it has been pulling this long, so a
+ * slow/large transfer is visibly named instead of looking like a stall.
+ */
+const SLOW_IN_FLIGHT_MS = 30_000;
+
+/** Window over which the displayed confirmed-object/byte rate is averaged. */
+const RATE_WINDOW_MS = 5_000;
+
 interface MigrationItem {
   name: string;
   size: number;
@@ -36,6 +52,8 @@ interface MigrationItem {
 
 export interface InFlightItem extends MigrationItem {
   checkFailures: number;
+  /** ms epoch when scheduled; used for the oldest-in-flight display. */
+  scheduledAt: number;
 }
 
 export interface MigrationState {
@@ -51,8 +69,55 @@ export interface MigrationState {
   drainOffset: number;
   /** In-flight items checked since the last completion (for backoff). */
   drainSweepMisses: number;
+  /** Rolling anchor for the displayed confirmed-object/byte rate. */
+  rate: {
+    anchorTime: number;
+    anchorConfirmed: number;
+    anchorBytes: number;
+    objPerSec: number;
+    bytesPerSec: number;
+  };
   errors: Array<{ name: string; error: string }>;
   startTime: number;
+}
+
+/**
+ * Migrate smallest objects first. This front-loads visible progress — the
+ * object count climbs fast while the many small files flow — and pushes large
+ * files to the end, where a slow pull reads as "finishing the big ones" rather
+ * than a mid-run stall. Sorts in place; ties keep their relative order.
+ */
+export function orderForMigration(items: MigrationItem[]): MigrationItem[] {
+  items.sort((a, b) => a.size - b.size);
+  return items;
+}
+
+/**
+ * Whether scheduling `itemSize` more bytes should wait for the in-flight set to
+ * drain. Blocks when the object-count cap is hit, or when the byte budget would
+ * be exceeded and there is something to drain. A single file larger than the
+ * whole byte budget is admitted once the queue empties (it can never otherwise
+ * fit) instead of deadlocking.
+ */
+export function atCapacity(state: MigrationState, itemSize: number): boolean {
+  if (state.inFlight.length >= MAX_IN_FLIGHT_OBJECTS) {
+    return true;
+  }
+  return (
+    state.inFlightBytes + itemSize > MAX_IN_FLIGHT_BYTES &&
+    state.inFlight.length > 0
+  );
+}
+
+/** The in-flight item that has been pulling longest, or null if none. */
+export function oldestInFlight(inFlight: InFlightItem[]): InFlightItem | null {
+  let oldest: InFlightItem | null = null;
+  for (const item of inFlight) {
+    if (oldest === null || item.scheduledAt < oldest.scheduledAt) {
+      oldest = item;
+    }
+  }
+  return oldest;
 }
 
 // ---------------------------------------------------------------------------
@@ -179,22 +244,60 @@ function formatElapsed(ms: number): string {
   return `${minutes}m ${seconds}s`;
 }
 
+/** Recompute the rolling confirmed rate once per RATE_WINDOW_MS. */
+function updateRate(state: MigrationState, now: number): void {
+  const dt = now - state.rate.anchorTime;
+  if (dt < RATE_WINDOW_MS) return;
+  state.rate.objPerSec =
+    ((state.confirmed - state.rate.anchorConfirmed) * 1000) / dt;
+  state.rate.bytesPerSec =
+    ((state.confirmedBytes - state.rate.anchorBytes) * 1000) / dt;
+  state.rate.anchorTime = now;
+  state.rate.anchorConfirmed = state.confirmed;
+  state.rate.anchorBytes = state.confirmedBytes;
+}
+
 function printProgress(state: MigrationState, bucket: string): void {
   if (!process.stderr.isTTY || globalThis.__TIGRIS_JSON_MODE) return;
 
-  const elapsed = formatElapsed(Date.now() - state.startTime);
-  const line =
-    `\rMigrating ${bucket}: ` +
-    `${state.confirmed.toLocaleString()} / ${state.total.toLocaleString()} objects | ` +
-    `In-flight: ${formatSize(state.inFlightBytes)} | ` +
-    `${elapsed}`;
+  const now = Date.now();
+  updateRate(state, now);
 
-  process.stderr.write(line + ' '.repeat(Math.max(0, 100 - line.length)));
+  const pct =
+    state.total > 0 ? Math.floor((state.confirmed / state.total) * 100) : 0;
+
+  const parts = [
+    `Migrating ${bucket}: ${state.confirmed.toLocaleString()} / ${state.total.toLocaleString()} (${pct}%)`,
+    `${Math.round(state.rate.objPerSec).toLocaleString()} obj/s, ${formatSize(state.rate.bytesPerSec)}/s`,
+    `in-flight ${state.inFlight.length.toLocaleString()} (${formatSize(state.inFlightBytes)})`,
+    formatElapsed(now - state.startTime),
+  ];
+
+  // Name the oldest in-flight object once it has been pulling a while, so a
+  // slow/large transfer is visibly attributed instead of looking like a stall.
+  const oldest = oldestInFlight(state.inFlight);
+  if (oldest && now - oldest.scheduledAt >= SLOW_IN_FLIGHT_MS) {
+    const label =
+      oldest.name.length > 40 ? `…${oldest.name.slice(-39)}` : oldest.name;
+    parts.push(
+      `pulling ${label} (${formatSize(oldest.size)}, ${formatElapsed(now - oldest.scheduledAt)})`
+    );
+  }
+
+  const width = process.stderr.columns ?? 100;
+  let text = parts.join(' | ');
+  if (text.length > width) {
+    text = `${text.slice(0, width - 1)}…`;
+  }
+  process.stderr.write(
+    `\r${text}${' '.repeat(Math.max(0, width - text.length))}`
+  );
 }
 
 function clearProgress(): void {
   if (!process.stderr.isTTY || globalThis.__TIGRIS_JSON_MODE) return;
-  process.stderr.write(`\r${' '.repeat(100)}\r`);
+  const width = process.stderr.columns ?? 100;
+  process.stderr.write(`\r${' '.repeat(width)}\r`);
 }
 
 async function flushScheduleBatch(
@@ -224,7 +327,11 @@ async function flushScheduleBatch(
         error: result.error.message,
       });
     } else {
-      state.inFlight.push({ ...item, checkFailures: 0 });
+      state.inFlight.push({
+        ...item,
+        checkFailures: 0,
+        scheduledAt: Date.now(),
+      });
       state.inFlightBytes += item.size;
       state.scheduled++;
     }
@@ -375,7 +482,12 @@ export default async function migrate(
       );
     }
 
+    // Migrate smallest first so progress climbs quickly and large files finish
+    // last (a slow pull there reads as "finishing up", not a mid-run stall).
+    orderForMigration(diff);
+
     // Phase 2: Migration loop
+    const now = Date.now();
     const state: MigrationState = {
       total: diff.length,
       totalBytes,
@@ -387,8 +499,15 @@ export default async function migrate(
       inFlightBytes: 0,
       drainOffset: 0,
       drainSweepMisses: 0,
+      rate: {
+        anchorTime: now,
+        anchorConfirmed: 0,
+        anchorBytes: 0,
+        objPerSec: 0,
+        bytesPerSec: 0,
+      },
       errors: [],
-      startTime: Date.now(),
+      startTime: now,
     };
 
     let batch: MigrationItem[] = [];
@@ -396,12 +515,8 @@ export default async function migrate(
     for (const item of diff) {
       if (interrupted) break;
 
-      // Throttle: wait until capacity is available
-      while (
-        state.inFlightBytes + item.size > MAX_IN_FLIGHT_BYTES &&
-        state.inFlight.length > 0 &&
-        !interrupted
-      ) {
+      // Throttle: wait until capacity (object count and bytes) is available
+      while (atCapacity(state, item.size) && !interrupted) {
         await drainCompleted(state, config, bucket);
         printProgress(state, bucket);
       }

--- a/packages/cli/test/lib/buckets/migrate.test.ts
+++ b/packages/cli/test/lib/buckets/migrate.test.ts
@@ -9,6 +9,7 @@ vi.mock('@tigrisdata/storage', () => ({
 
 import { isMigrated } from '@tigrisdata/storage';
 import {
+  activityLabel,
   atCapacity,
   drainCompleted,
   type MigrationState,
@@ -30,13 +31,8 @@ function makeState(items: { name: string; size: number }[]): MigrationState {
     inFlightBytes: bytes,
     drainOffset: 0,
     drainSweepMisses: 0,
-    rate: {
-      anchorTime: 0,
-      anchorConfirmed: 0,
-      anchorBytes: 0,
-      objPerSec: 0,
-      bytesPerSec: 0,
-    },
+    checkBackoffMs: 5_000,
+    spinnerFrame: 0,
     errors: [],
     startTime: 0,
   };
@@ -118,6 +114,30 @@ describe('oldestInFlight', () => {
   });
 });
 
+describe('activityLabel', () => {
+  it('names the file being migrated when something is in flight', () => {
+    const state = makeState([{ name: 'Videos/big.mp4', size: 21.9 * GB }]);
+    const label = activityLabel(state.inFlight[0], 60_000);
+    expect(label).toContain('migrating');
+    expect(label).toContain('Videos/big.mp4');
+    expect(label).not.toContain('obj/s');
+  });
+
+  it('truncates a long key to the available width, keeping the tail', () => {
+    const state = makeState([
+      { name: 'Videos/some/really/long/nested/path/merged.jsonl', size: GB },
+    ]);
+    const label = activityLabel(state.inFlight[0], 0, 15);
+    expect(label).toContain('…');
+    expect(label).toContain('merged.jsonl'); // tail preserved
+    expect(label).not.toContain('Videos/some'); // head dropped
+  });
+
+  it('falls back to a waiting indicator with no in-flight work', () => {
+    expect(activityLabel(null, 0)).toBe('waiting…');
+  });
+});
+
 describe('drainCompleted — head-of-line blocking', () => {
   it('frees completed objects behind a slow/stuck head instead of deadlocking', async () => {
     // 120 in-flight (1 MB each). The first 50 — a full CONCURRENCY window —
@@ -176,5 +196,46 @@ describe('drainCompleted — head-of-line blocking', () => {
     expect(state.confirmed).toBe(130);
     expect(state.inFlight.length).toBe(0);
     expect(state.inFlightBytes).toBe(0);
+  });
+});
+
+describe('drainCompleted — poll backoff', () => {
+  it('grows the poll backoff after each all-stuck sweep, up to the cap', async () => {
+    // Nothing ever migrates. An already-aborted signal makes the backoff sleep
+    // resolve instantly, so we can observe the interval growing without waiting.
+    vi.mocked(isMigrated).mockResolvedValue({
+      data: false,
+    } as Awaited<ReturnType<typeof isMigrated>>);
+    const aborted = new AbortController();
+    aborted.abort();
+
+    const state = makeState([{ name: 'a', size: 1 }]);
+    expect(state.checkBackoffMs).toBe(5_000);
+
+    const seen: number[] = [];
+    for (let i = 0; i < 4; i++) {
+      await drainCompleted(state, {}, 'bucket', aborted.signal);
+      seen.push(state.checkBackoffMs);
+    }
+    // 5s → 10s → 20s → 30s (capped at MAX_CHECK_INTERVAL_MS).
+    expect(seen).toEqual([10_000, 20_000, 30_000, 30_000]);
+  });
+
+  it('resets the poll backoff once something completes', async () => {
+    // 'a' migrates, 'b' is stuck — the completion resets the backoff.
+    vi.mocked(isMigrated).mockImplementation(
+      async (name: string) =>
+        ({ data: name === 'a' }) as Awaited<ReturnType<typeof isMigrated>>
+    );
+
+    const state = makeState([
+      { name: 'a', size: 1 },
+      { name: 'b', size: 1 },
+    ]);
+    state.checkBackoffMs = 20_000; // as if we'd already backed off
+
+    await drainCompleted(state, {}, 'bucket');
+
+    expect(state.checkBackoffMs).toBe(5_000);
   });
 });

--- a/packages/cli/test/lib/buckets/migrate.test.ts
+++ b/packages/cli/test/lib/buckets/migrate.test.ts
@@ -14,6 +14,7 @@ import {
   type MigrationState,
   oldestInFlight,
   orderForMigration,
+  shouldFlushBatch,
 } from '../../../src/lib/buckets/migrate.js';
 
 function makeState(items: { name: string; size: number }[]): MigrationState {
@@ -42,6 +43,27 @@ function makeState(items: { name: string; size: number }[]): MigrationState {
 }
 
 const GB = 1024 * 1024 * 1024;
+const MB = 1024 * 1024;
+
+describe('shouldFlushBatch', () => {
+  it('never flushes an empty batch', () => {
+    expect(shouldFlushBatch(makeState([]), 0, 0, 20 * GB)).toBe(false);
+  });
+
+  it('flushes before a large item would blow the byte budget', () => {
+    // The exact 2-object case from the bug report: an 877 MB batch, then a
+    // ~21.9 GB file would push in-flight to 22.8 GB — flush the 877 MB first.
+    expect(shouldFlushBatch(makeState([]), 1, 877 * MB, 21.9 * GB)).toBe(true);
+  });
+
+  it('keeps batching small items until the batch is full', () => {
+    expect(shouldFlushBatch(makeState([]), 10, 10 * MB, 1 * MB)).toBe(false);
+  });
+
+  it('flushes once the batch reaches the batch-size limit', () => {
+    expect(shouldFlushBatch(makeState([]), 50, 50 * MB, 1 * MB)).toBe(true);
+  });
+});
 
 describe('orderForMigration', () => {
   it('sorts smallest first', () => {

--- a/packages/cli/test/lib/buckets/migrate.test.ts
+++ b/packages/cli/test/lib/buckets/migrate.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock the SDK so drainCompleted's isMigrated() calls are controllable.
+vi.mock('@tigrisdata/storage', () => ({
+  isMigrated: vi.fn(),
+  migrate: vi.fn(),
+  list: vi.fn(),
+}));
+
+import { isMigrated } from '@tigrisdata/storage';
+import {
+  drainCompleted,
+  type MigrationState,
+} from '../../../src/lib/buckets/migrate.js';
+
+function makeState(items: { name: string; size: number }[]): MigrationState {
+  const bytes = items.reduce((s, i) => s + i.size, 0);
+  return {
+    total: items.length,
+    totalBytes: bytes,
+    scheduled: items.length,
+    confirmed: 0,
+    confirmedBytes: 0,
+    failed: 0,
+    inFlight: items.map((i) => ({ ...i, checkFailures: 0 })),
+    inFlightBytes: bytes,
+    drainOffset: 0,
+    drainSweepMisses: 0,
+    errors: [],
+    startTime: 0,
+  };
+}
+
+describe('drainCompleted — head-of-line blocking', () => {
+  it('frees completed objects behind a slow/stuck head instead of deadlocking', async () => {
+    // 120 in-flight (1 MB each). The first 50 — a full CONCURRENCY window —
+    // never migrate (slow/stuck head); objects 50..119 are already done. The
+    // old fixed-head drain only ever polled the first 50, so it would free
+    // nothing and leave inFlightBytes pinned. The rotating sweep must free the
+    // 70 completed objects regardless of the stuck head.
+    const SIZE = 1024 * 1024;
+    const items = Array.from({ length: 120 }, (_, i) => ({
+      name: `obj-${String(i).padStart(3, '0')}`,
+      size: SIZE,
+    }));
+    const stuckHead = new Set(items.slice(0, 50).map((i) => i.name));
+
+    vi.mocked(isMigrated).mockImplementation(
+      async (name: string) =>
+        ({ data: !stuckHead.has(name) }) as Awaited<
+          ReturnType<typeof isMigrated>
+        >
+    );
+
+    const state = makeState(items);
+    const startBytes = state.inFlightBytes;
+
+    // Stop as soon as the 70 completable objects are confirmed — before any
+    // all-stuck sweep would back off (sleep). A fixed-head drain never reaches
+    // 70, so the round cap also guards against an infinite loop on regression.
+    let rounds = 0;
+    while (state.confirmed < 70 && rounds < 8) {
+      await drainCompleted(state, {}, 'bucket');
+      rounds++;
+    }
+
+    expect(state.confirmed).toBe(70);
+    expect(state.inFlight.length).toBe(50);
+    expect(state.inFlightBytes).toBe(startBytes - 70 * SIZE);
+    expect(state.inFlight.every((i) => stuckHead.has(i.name))).toBe(true);
+  });
+
+  it('confirms every object across rounds when none are stuck', async () => {
+    const items = Array.from({ length: 130 }, (_, i) => ({
+      name: `k${i}`,
+      size: 10,
+    }));
+    vi.mocked(isMigrated).mockResolvedValue({
+      data: true,
+    } as Awaited<ReturnType<typeof isMigrated>>);
+
+    const state = makeState(items);
+    let rounds = 0;
+    while (state.inFlight.length > 0 && rounds < 8) {
+      await drainCompleted(state, {}, 'bucket');
+      rounds++;
+    }
+
+    expect(state.confirmed).toBe(130);
+    expect(state.inFlight.length).toBe(0);
+    expect(state.inFlightBytes).toBe(0);
+  });
+});

--- a/packages/cli/test/lib/buckets/migrate.test.ts
+++ b/packages/cli/test/lib/buckets/migrate.test.ts
@@ -9,8 +9,11 @@ vi.mock('@tigrisdata/storage', () => ({
 
 import { isMigrated } from '@tigrisdata/storage';
 import {
+  atCapacity,
   drainCompleted,
   type MigrationState,
+  oldestInFlight,
+  orderForMigration,
 } from '../../../src/lib/buckets/migrate.js';
 
 function makeState(items: { name: string; size: number }[]): MigrationState {
@@ -22,14 +25,76 @@ function makeState(items: { name: string; size: number }[]): MigrationState {
     confirmed: 0,
     confirmedBytes: 0,
     failed: 0,
-    inFlight: items.map((i) => ({ ...i, checkFailures: 0 })),
+    inFlight: items.map((i) => ({ ...i, checkFailures: 0, scheduledAt: 0 })),
     inFlightBytes: bytes,
     drainOffset: 0,
     drainSweepMisses: 0,
+    rate: {
+      anchorTime: 0,
+      anchorConfirmed: 0,
+      anchorBytes: 0,
+      objPerSec: 0,
+      bytesPerSec: 0,
+    },
     errors: [],
     startTime: 0,
   };
 }
+
+const GB = 1024 * 1024 * 1024;
+
+describe('orderForMigration', () => {
+  it('sorts smallest first', () => {
+    const items = [
+      { name: 'big', size: 100 },
+      { name: 'small', size: 1 },
+      { name: 'mid', size: 10 },
+    ];
+    expect(orderForMigration(items).map((i) => i.name)).toEqual([
+      'small',
+      'mid',
+      'big',
+    ]);
+  });
+});
+
+describe('atCapacity', () => {
+  it('allows scheduling when under both caps', () => {
+    expect(atCapacity(makeState([{ name: 'a', size: 1 }]), 1)).toBe(false);
+  });
+
+  it('blocks at the object-count cap (regardless of size)', () => {
+    // MAX_IN_FLIGHT_OBJECTS is 1000; a full queue of tiny objects still blocks.
+    const items = Array.from({ length: 1000 }, (_, i) => ({
+      name: `k${i}`,
+      size: 1,
+    }));
+    expect(atCapacity(makeState(items), 1)).toBe(true);
+  });
+
+  it('blocks when the byte budget would be exceeded with items in flight', () => {
+    expect(atCapacity(makeState([{ name: 'a', size: 10 * GB }]), 1)).toBe(true);
+  });
+
+  it('admits a single file larger than the whole budget once the queue is empty', () => {
+    expect(atCapacity(makeState([]), 20 * GB)).toBe(false);
+  });
+});
+
+describe('oldestInFlight', () => {
+  it('returns the item scheduled earliest, or null when empty', () => {
+    const state = makeState([
+      { name: 'a', size: 1 },
+      { name: 'b', size: 1 },
+      { name: 'c', size: 1 },
+    ]);
+    state.inFlight[0].scheduledAt = 300;
+    state.inFlight[1].scheduledAt = 100;
+    state.inFlight[2].scheduledAt = 200;
+    expect(oldestInFlight(state.inFlight)?.name).toBe('b');
+    expect(oldestInFlight([])).toBeNull();
+  });
+});
 
 describe('drainCompleted — head-of-line blocking', () => {
   it('frees completed objects behind a slow/stuck head instead of deadlocking', async () => {


### PR DESCRIPTION
## Problem

A customer migrating 12 TB / 3.4 M files from Backblaze B2 via `tigris buckets migrate` reported the CLI repeatedly **stalling** — progress freezes with `In-flight` pinned at ~10 GB and `confirmed` no longer advancing (e.g. `0 / 1,112,848 | In-flight: 10.1 GB | 45m 51s`). Restarting temporarily helps, then it stalls again. The progress line was also confusing on large files and duplicated itself on Ctrl-C and on window resize.

## Root cause — head-of-line blocking

`migrate` schedules server-side pulls into an in-flight queue capped by bytes (`MAX_IN_FLIGHT_BYTES = 10 GB`), then `drainCompleted()` polls `isMigrated()` to free completed objects. It only checked **the oldest `CONCURRENCY` (50)** in-flight objects. Migrations don't complete in FIFO order, so a slow/large object at the head kept returning `isMigrated: false`; the poller saw zero completions and re-polled the same 50 forever, while completed objects at positions 51+ were never checked. Their bytes were never freed, `inFlightBytes` stayed pinned at the cap, the scheduler throttle never released, and the migration deadlocked.

## What's in this PR

- **Deadlock fix** — `drainCompleted` polls a **rotating window across the entire in-flight set** (a `drainOffset` cursor advances each call), so completions anywhere are observed and their bytes freed. It only backs off after a full sweep with no completions.
- **Smallest-first** ordering, so progress climbs quickly and large files finish last instead of stalling mid-run.
- **In-flight caps** — bounded by object count (1000) *and* bytes, with the byte budget enforced across the pending schedule batch (`shouldFlushBatch`) so a huge file can't be scheduled alongside a full batch and blow the budget. A single file larger than the whole budget is admitted once the queue empties, instead of deadlocking.
- **Poll backoff** — `isMigrated` backs off 5s → 30s after sweeps with no completions and resets on the next completion, so an idle migration stops hammering the gateway with status checks.
- **Multi-line, live progress** — a sticky block (bucket + elapsed clock, file % and byte %, current activity + in-flight count) that redraws in place. Fixes the duplicated lines on **Ctrl-C** and **window resize**, and truncates each line to the terminal width so nothing wraps. Ctrl-C is now felt immediately (the poll wait is abortable) and a second Ctrl-C forces an immediate exit.

## Tests

`test/lib/buckets/migrate.test.ts` covers the rotating drain (out-of-order completion behind a stuck head, and all-confirmed when none are stuck), the capacity/flush helpers and sort order, the activity label, and the new poll backoff (growth + reset). `tsc`, biome, and the unit tests pass. (A 12 TB migration can't be run here; the customer re-run is the real-world confirmation.)

## Known follow-up

- **Genuinely-stuck server-side pulls** — a scheduled pull the gateway never completes still holds its in-flight slot. Recovering these reliably needs a gateway-side progress/health signal (today `isMigrated` is binary — `block_shadow` or not), so the CLI can tell "slow but progressing" from "wedged" without a magic timeout. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Targets a high-impact customer migration stall in core CLI orchestration logic, but changes are confined to the migrate command with new unit tests and no auth or data-path changes.
> 
> **Overview**
> Fixes **`tigris buckets migrate`** wedging on large runs when in-flight bytes stayed pinned at ~10 GB and confirmed counts stopped moving.
> 
> **Deadlock:** `drainCompleted` no longer polls only the oldest 50 in-flight objects. It walks a **rotating window** across the full queue (`drainOffset`), so completions behind a slow head free byte budget and scheduling can continue. Backoff (5s→30s) runs only after a full sweep with zero completions, and resets when anything completes.
> 
> **Pacing:** Objects are scheduled **smallest-first**. In-flight work is capped by **count (1000)** and **bytes (10 GB)**; `shouldFlushBatch` / `atCapacity` enforce the byte budget on pending batches so a huge file is not scheduled alongside a batch that would blow the cap (oversized singletons are still allowed when the queue is empty).
> 
> **UX:** Progress is a **sticky multi-line** stderr block (file/byte %, oldest in-flight activity, in-flight count) with width truncation and resize-safe redraw. **Ctrl-C** aborts discovery, poll sleeps, and rendering immediately via `AbortSignal`; a second Ctrl-C exits; cancel messaging clarifies resume behavior.
> 
> Adds **`migrate.test.ts`** for drain rotation, backoff, capacity/flush helpers, and activity labels, plus a patch **changeset** for `@tigrisdata/cli`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 970b36941032f4d3ef1df5898da523a30856fdeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->