### PR TITLE
feat(cli): add `tigris init` wizard for AI agent onboarding

### DIFF
--- a/.changeset/cli-init-wizard.md
+++ b/.changeset/cli-init-wizard.md
@@ -1,0 +1,10 @@
+---
+"@tigrisdata/cli": minor
+---
+
+Add `tigris init` to connect Tigris to AI coding agents. The interactive wizard
+detects installed editors, installs/updates the CLI, writes the Tigris remote
+MCP server config for 10 editors (Claude Code, Cursor, VS Code, Windsurf, Codex,
+Antigravity CLI, Cline, Zed, Roo Code, opencode), and installs the Tigris agent
+skills. `tigris init --agent` instead prints a plain-text setup recipe for a
+coding agent to run itself.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -60,6 +60,7 @@
   "license": "MIT",
   "dependencies": {
     "@aws-sdk/credential-providers": "^3.1038.0",
+    "@clack/prompts": "^0.11.0",
     "@sentry/node": "^10.66.0",
     "@smithy/shared-ini-file-loader": "^4.4.9",
     "@tigrisdata/iam": "workspace:^",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -60,7 +60,7 @@
   "license": "MIT",
   "dependencies": {
     "@aws-sdk/credential-providers": "^3.1038.0",
-    "@clack/prompts": "^0.11.0",
+    "@clack/prompts": "^1.7.0",
     "@sentry/node": "^10.66.0",
     "@smithy/shared-ini-file-loader": "^4.4.9",
     "@tigrisdata/iam": "workspace:^",
@@ -68,6 +68,7 @@
     "commander": "^15.0.0",
     "enquirer": "^2.4.1",
     "jose": "^6.2.3",
+    "jsonc-parser": "^3.3.1",
     "open": "^11.0.0",
     "yaml": "^2.8.3"
   },

--- a/packages/cli/src/lib/init/index.ts
+++ b/packages/cli/src/lib/init/index.ts
@@ -1,23 +1,27 @@
 import { getOption } from '@utils/options.js';
 
 import { runInteractive } from './interactive.js';
-import { emitGettingStarted } from './plan.js';
+import { AGENT_SETUP } from './plan.js';
 
 /**
  * `tigris init` — two modes:
  *  - bare (interactive): set up the local AI tooling (CLI, MCP config, skills),
  *    then hand the user a command to give their agent.
- *  - `--agent --getting-started`: emit a JSON onboarding plan (a list of
- *    `{ id, description, command }` steps) for an AI coding agent to execute.
+ *  - `--agent`: print a plain-text onboarding recipe for an AI coding agent to
+ *    follow (it runs the `tigris` commands itself).
  */
 export default async function init(options: Record<string, unknown>) {
   const agentMode = getOption<boolean>(options, ['agent']);
+
+  // init manages CLI currency itself (ensureCli here, steps 1–2 in the recipe),
+  // so suppress the CLI's post-command update-notifier — it's redundant and, on
+  // a TTY, would print mid-wizard or pollute the --agent recipe on stdout.
+  process.env.TIGRIS_NO_UPDATE_CHECK = '1';
 
   if (!agentMode) {
     await runInteractive();
     return;
   }
 
-  // Only one step today; --getting-started is the default.
-  emitGettingStarted();
+  console.log(AGENT_SETUP);
 }

--- a/packages/cli/src/lib/init/index.ts
+++ b/packages/cli/src/lib/init/index.ts
@@ -1,0 +1,23 @@
+import { getOption } from '@utils/options.js';
+
+import { runInteractive } from './interactive.js';
+import { emitGettingStarted } from './plan.js';
+
+/**
+ * `tigris init` — two modes:
+ *  - bare (interactive): set up the local AI tooling (CLI, MCP config, skills),
+ *    then hand the user a command to give their agent.
+ *  - `--agent --getting-started`: emit a JSON onboarding plan (a list of
+ *    `{ id, description, command }` steps) for an AI coding agent to execute.
+ */
+export default async function init(options: Record<string, unknown>) {
+  const agentMode = getOption<boolean>(options, ['agent']);
+
+  if (!agentMode) {
+    await runInteractive();
+    return;
+  }
+
+  // Only one step today; --getting-started is the default.
+  emitGettingStarted();
+}

--- a/packages/cli/src/lib/init/interactive.ts
+++ b/packages/cli/src/lib/init/interactive.ts
@@ -16,6 +16,7 @@ import {
   SUPPORTED_EDITORS,
   skillsDirsFor,
   TIGRIS_SKILLS,
+  upsertTomlServer,
 } from './shared.js';
 
 /**
@@ -58,7 +59,7 @@ export async function runInteractive() {
       {
         value: 'defaults',
         label: 'Defaults',
-        hint: 'CLI (global), MCP server (global), agent skills (project)',
+        hint: 'CLI - Global, MCP - Global, Skills - Project',
       },
       { value: 'custom', label: 'Customize installation' },
     ],
@@ -74,15 +75,16 @@ export async function runInteractive() {
     skillsLocation = await location('Agent skills:', 'project');
   }
 
-  // 3. Which skills to install.
-  let skillIds: string[] = TIGRIS_SKILLS.filter((s) => s.recommended).map(
-    (s) => s.id
-  );
-  if (skillsLocation !== 'skip') {
+  // 3. Which skills to install. Defaults installs every skill without asking;
+  // only the custom flow prompts (recommended ones pre-checked).
+  let skillIds: string[] = TIGRIS_SKILLS.map((s) => s.id);
+  if (mode === 'custom' && skillsLocation !== 'skip') {
     const picked = await p.multiselect({
       message: 'Which skills should your agent get? (space to toggle)',
       options: TIGRIS_SKILLS.map((s) => ({ value: s.id, label: s.label })),
-      initialValues: skillIds,
+      initialValues: TIGRIS_SKILLS.filter((s) => s.recommended).map(
+        (s) => s.id
+      ),
       required: false,
     });
     if (p.isCancel(picked)) return cancel();
@@ -114,7 +116,7 @@ export async function runInteractive() {
       `Installing ${skillIds.length} Tigris skill(s) (${skillsLocation})`
     );
     if (result.ok) {
-      for (const dir of skillsDirsFor(editors, skillsLocation, cwd, home)) {
+      for (const dir of skillsDirsFor(editors, skillsLocation, cwd)) {
         p.log.success(`Skills → ${prettyPath(dir, home)}`);
       }
     } else if (result.output) {
@@ -124,8 +126,8 @@ export async function runInteractive() {
 
   // 7. Hand off to the agent — use the installed CLI, or npx if unavailable.
   const runner = cliAvailable
-    ? 'tigris init --agent --getting-started'
-    : 'npx @tigrisdata/cli init --agent --getting-started';
+    ? 'tigris init --agent'
+    : 'npx @tigrisdata/cli init --agent';
   p.note(runner, 'Paste this to your AI coding agent to finish setup');
   p.outro('Your agent will authenticate with Tigris in-browser on first use.');
 }
@@ -156,49 +158,83 @@ function prettyPath(path: string, home: string): string {
   return path.startsWith(home) ? `~${path.slice(home.length)}` : path;
 }
 
-/** Merge the Tigris remote MCP entry into an editor's config at the chosen scope. */
+/** Write the Tigris remote MCP entry into an editor's config at the chosen scope. */
 function writeMcp(
   editor: EditorInfo,
   requested: 'global' | 'project',
   cwd: string,
   home: string
 ): void {
-  const target = resolveMcpTarget(editor, requested, cwd, home);
-  if (!target) {
+  const mcp = editor.mcp;
+  const target = resolveMcpTarget(editor, requested, cwd);
+  if (!mcp || !target) {
     p.log.warn(`${editor.label}: no writable MCP config — skipped.`);
     return;
   }
 
-  const existing = existsSync(target.path)
-    ? readFileSync(target.path, 'utf8')
-    : null;
-  let merged: { content: string; replaced: boolean };
-  try {
-    merged = mergeMcpServers(
-      existing,
-      editor.mcpKey,
-      MCP_SERVER_NAME,
-      editor.mcpEntry
-    );
-  } catch {
-    p.log.error(
-      `${editor.label}: could not parse ${target.path} as JSON — skipped.`
-    );
+  // Prefer an existing JSONC sibling (e.g. opencode.jsonc) over creating a
+  // second `.json` config the editor would then ignore or merge unexpectedly.
+  let targetPath = target.path;
+  if (
+    !existsSync(targetPath) &&
+    targetPath.endsWith('.json') &&
+    existsSync(`${targetPath}c`)
+  ) {
+    targetPath = `${targetPath}c`;
+  }
+
+  const dir = dirname(targetPath);
+  // App-managed locations (e.g. Cline's VS Code globalStorage): only write when
+  // the editor is actually installed, so we don't create a junk config tree.
+  if (mcp.createDirs === false && !existsSync(dirname(dir))) {
+    p.log.warn(`${editor.label}: not installed — skipped.`);
     return;
   }
 
-  mkdirSync(dirname(target.path), { recursive: true });
-  writeFileSync(target.path, merged.content);
+  // Read → merge → write per editor, so one editor's failure (unparseable or
+  // incompatible existing config, permission error, full disk) is reported and
+  // skipped without aborting the remaining editors.
+  try {
+    const existing = existsSync(targetPath)
+      ? readFileSync(targetPath, 'utf8')
+      : null;
+    const written =
+      mcp.format === 'toml'
+        ? upsertTomlServer(
+            existing,
+            mcp.key,
+            MCP_SERVER_NAME,
+            stringFields(mcp.entry)
+          )
+        : mergeMcpServers(existing, mcp.key, MCP_SERVER_NAME, mcp.entry);
 
-  const scopeNote = target.scope === requested ? '' : ` (${target.scope}-only)`;
-  p.log.success(
-    `${editor.label}: MCP → ${prettyPath(target.path, home)}${scopeNote}`
-  );
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(targetPath, written.content);
+
+    const scopeNote =
+      target.scope === requested ? '' : ` (${target.scope}-only)`;
+    p.log.success(
+      `${editor.label}: MCP → ${prettyPath(targetPath, home)}${scopeNote}`
+    );
+  } catch {
+    p.log.error(
+      `${editor.label}: could not update ${prettyPath(targetPath, home)} (incompatible or unwritable) — skipped.`
+    );
+  }
+}
+
+/** Keep only string-valued fields (TOML upsert writes `k = "v"`). */
+function stringFields(entry: Record<string, unknown>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(entry)) {
+    if (typeof v === 'string') out[k] = v;
+  }
+  return out;
 }
 
 /** The globally-installed `tigris` CLI version, or null if not on PATH. */
 function getInstalledCliVersion(): string | null {
-  const r = spawnSync('tigris', ['--version'], { encoding: 'utf8' });
+  const r = spawnSync('tigris', ['--version'], spawnOpts());
   if (r.error || r.status !== 0 || !r.stdout) return null;
   const v = r.stdout.trim().split('\n')[0].trim();
   return /^\d+\.\d+\.\d+/.test(v) ? v : null;
@@ -207,43 +243,82 @@ function getInstalledCliVersion(): string | null {
 /**
  * Ensure the Tigris CLI is present and current: install it if missing, update
  * it if a newer version is published, and do nothing (no step) if it's already
- * the latest. Returns whether the `tigris` command is available afterwards.
+ * the latest. Returns whether an up-to-date `tigris` command is available
+ * afterwards (false if an install/update was attempted and failed).
  */
 async function ensureCli(): Promise<boolean> {
   const installed = getInstalledCliVersion();
-
-  let latest: string | null;
-  try {
-    // Cap the registry check so a slow network can't stall the wizard.
-    latest = await Promise.race([
-      fetchLatestVersion({ unref: true }),
-      new Promise<string>((_, reject) =>
-        setTimeout(() => reject(new Error('timeout')), 3000)
-      ),
-    ]);
-  } catch {
-    latest = null;
-  }
+  const latest = await fetchLatestVersionCapped(3000);
 
   if (!installed) {
-    return runCommand(
+    const result = runCommand(
       'npm',
       ['install', '-g', '@tigrisdata/cli', '--ignore-scripts'],
       'Installing Tigris CLI (global)'
-    ).ok;
+    );
+    if (!reportIfFailed(result)) return false;
+    // A zero exit doesn't guarantee `tigris` is resolvable — npm's global bin
+    // may not be on PATH. Confirm before recommending it over `npx`.
+    if (getInstalledCliVersion() === null) {
+      p.log.warn(
+        'Tigris CLI installed but not on PATH — the agent handoff will use npx.'
+      );
+      return false;
+    }
+    return true;
   }
 
   if (latest && isNewerVersion(installed, latest)) {
-    runCommand(
-      'npm',
-      ['install', '-g', '@tigrisdata/cli@latest', '--ignore-scripts'],
-      `Updating Tigris CLI ${installed} → ${latest}`
+    // Delegate to the installed CLI's own updater so we respect how it was
+    // installed (npm / Homebrew / standalone binary) rather than forcing npm,
+    // which could fail or leave a second copy on PATH. If it fails, report
+    // unavailable so the handoff falls back to `npx` (an outdated CLI may
+    // predate `init`).
+    return reportIfFailed(
+      runCommand(
+        'tigris',
+        ['update'],
+        `Updating Tigris CLI ${installed} → ${latest}`
+      )
     );
-    return true;
   }
 
   // Installed and current (or latest unknown) — no CLI step shown.
   return true;
+}
+
+/**
+ * Latest published version, or null if the registry check errors or exceeds
+ * `ms`. Never rejects: a late `fetchLatestVersion` failure is swallowed (so it
+ * can't surface as an unhandled rejection). The timeout timer is intentionally
+ * left ref'd — it's what keeps the process alive during this await (the fetch
+ * socket is unref'd) — and is always cleared in `finally`, so the fetch winning
+ * adds no delay and a still-pending fetch can't hold the process open after.
+ */
+async function fetchLatestVersionCapped(ms: number): Promise<string | null> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      fetchLatestVersion({ unref: true }).catch(() => null),
+      new Promise<null>((resolve) => {
+        timer = setTimeout(() => resolve(null), ms);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
+ * spawnSync options. On Windows npm/npx/tigris are `.cmd` shims that need a
+ * shell to resolve; use `shell: true` (cmd.exe) rather than PowerShell, which
+ * treats a leading `@` (as in `@tigrisdata/cli`) as its splat operator.
+ */
+function spawnOpts() {
+  return {
+    encoding: 'utf8' as const,
+    ...(process.platform === 'win32' ? { shell: true } : {}),
+  };
 }
 
 /** Run a command under a spinner; capture output and surface it on failure. */
@@ -254,11 +329,23 @@ function runCommand(
 ): { ok: boolean; output?: string } {
   const s = p.spinner();
   s.start(startMsg);
-  const r = spawnSync(cmd, args, { encoding: 'utf8' });
+  const r = spawnSync(cmd, args, spawnOpts());
   if (r.status === 0) {
     s.stop(`${startMsg} — done`);
     return { ok: true };
   }
   s.stop(`${startMsg} — failed`);
-  return { ok: false, output: (r.stderr || r.stdout || '').trim() };
+  // Include spawnSync's own error (e.g. ENOENT) — stderr/stdout are empty then.
+  return {
+    ok: false,
+    output: (r.stderr || r.stdout || r.error?.message || '').trim(),
+  };
+}
+
+/** Surface a failed command's captured output (last lines) and return its ok. */
+function reportIfFailed(result: { ok: boolean; output?: string }): boolean {
+  if (!result.ok && result.output) {
+    p.log.error(result.output.split('\n').slice(-6).join('\n'));
+  }
+  return result.ok;
 }

--- a/packages/cli/src/lib/init/interactive.ts
+++ b/packages/cli/src/lib/init/interactive.ts
@@ -1,0 +1,264 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname } from 'node:path';
+import * as p from '@clack/prompts';
+import { fetchLatestVersion, isNewerVersion } from '@utils/update-check.js';
+
+import {
+  buildSkillsArgs,
+  detectEditors,
+  type EditorInfo,
+  type InstallLocation,
+  MCP_SERVER_NAME,
+  mergeMcpServers,
+  resolveMcpTarget,
+  SUPPORTED_EDITORS,
+  skillsDirsFor,
+  TIGRIS_SKILLS,
+} from './shared.js';
+
+/**
+ * Interactive setup (`tigris init`): pick the AI editor(s), optionally install
+ * the CLI, point the editors at the Tigris remote MCP server, and install the
+ * chosen agent skills — then hand the user a command to give their AI agent.
+ * No login: the remote MCP server authenticates in-browser on first connect.
+ */
+export async function runInteractive() {
+  if (!process.stdin.isTTY) {
+    console.error('Run `tigris init` in an interactive terminal.');
+    process.exit(1);
+  }
+
+  const cwd = process.cwd();
+  const home = homedir();
+
+  p.intro('Connect Tigris to your AI coding agent');
+
+  // 1. Which editor(s) — detected ones pre-checked.
+  const detected = detectEditors({
+    env: process.env,
+    cwd,
+    home,
+    fileExists: existsSync,
+  });
+  const editorIds = await p.multiselect({
+    message: 'Which editor(s) should use Tigris?',
+    options: SUPPORTED_EDITORS.map((e) => ({ value: e.id, label: e.label })),
+    initialValues: detected,
+    required: true,
+  });
+  if (p.isCancel(editorIds)) return cancel();
+  const editors = SUPPORTED_EDITORS.filter((e) => editorIds.includes(e.id));
+
+  // 2. Defaults or customize (installation targets/scopes).
+  const mode = await p.select({
+    message: 'What would you like to install?',
+    options: [
+      {
+        value: 'defaults',
+        label: 'Defaults',
+        hint: 'CLI (global), MCP server (global), agent skills (project)',
+      },
+      { value: 'custom', label: 'Customize installation' },
+    ],
+    initialValue: 'defaults',
+  });
+  if (p.isCancel(mode)) return cancel();
+
+  let mcpLocation: InstallLocation = 'global';
+  let skillsLocation: InstallLocation = 'project';
+
+  if (mode === 'custom') {
+    mcpLocation = await location('MCP server:', 'global');
+    skillsLocation = await location('Agent skills:', 'project');
+  }
+
+  // 3. Which skills to install.
+  let skillIds: string[] = TIGRIS_SKILLS.filter((s) => s.recommended).map(
+    (s) => s.id
+  );
+  if (skillsLocation !== 'skip') {
+    const picked = await p.multiselect({
+      message: 'Which skills should your agent get? (space to toggle)',
+      options: TIGRIS_SKILLS.map((s) => ({ value: s.id, label: s.label })),
+      initialValues: skillIds,
+      required: false,
+    });
+    if (p.isCancel(picked)) return cancel();
+    skillIds = picked;
+  }
+
+  // 4. Tigris CLI — install if missing, update if outdated, skip if current.
+  const cliAvailable = await ensureCli();
+
+  // 5. Point each editor at the remote MCP server.
+  if (mcpLocation === 'skip') {
+    p.log.info('MCP server: skipped');
+  } else {
+    for (const editor of editors) {
+      writeMcp(editor, mcpLocation, cwd, home);
+    }
+  }
+
+  // 6. Install the chosen Tigris agent skills. Output is captured (the skills
+  // tool prints a big banner); we report the destination dirs ourselves.
+  if (skillsLocation === 'skip' || skillIds.length === 0) {
+    p.log.info('Agent skills: skipped');
+  } else {
+    const agents = editors.map((e) => e.skillsAgent);
+    const args = buildSkillsArgs(skillIds, agents, skillsLocation === 'global');
+    const result = runCommand(
+      'npx',
+      args,
+      `Installing ${skillIds.length} Tigris skill(s) (${skillsLocation})`
+    );
+    if (result.ok) {
+      for (const dir of skillsDirsFor(editors, skillsLocation, cwd, home)) {
+        p.log.success(`Skills → ${prettyPath(dir, home)}`);
+      }
+    } else if (result.output) {
+      p.log.error(result.output.split('\n').slice(-6).join('\n'));
+    }
+  }
+
+  // 7. Hand off to the agent — use the installed CLI, or npx if unavailable.
+  const runner = cliAvailable
+    ? 'tigris init --agent --getting-started'
+    : 'npx @tigrisdata/cli init --agent --getting-started';
+  p.note(runner, 'Paste this to your AI coding agent to finish setup');
+  p.outro('Your agent will authenticate with Tigris in-browser on first use.');
+}
+
+async function location(
+  message: string,
+  initialValue: 'global' | 'project'
+): Promise<InstallLocation> {
+  const value = await p.select<InstallLocation>({
+    message,
+    options: [
+      { value: 'global', label: 'Global (available in all projects)' },
+      { value: 'project', label: 'Project-level (this project only)' },
+      { value: 'skip', label: 'Skip' },
+    ],
+    initialValue,
+  });
+  if (p.isCancel(value)) cancel();
+  return value;
+}
+
+function cancel(): never {
+  p.cancel('Setup cancelled.');
+  process.exit(1);
+}
+
+function prettyPath(path: string, home: string): string {
+  return path.startsWith(home) ? `~${path.slice(home.length)}` : path;
+}
+
+/** Merge the Tigris remote MCP entry into an editor's config at the chosen scope. */
+function writeMcp(
+  editor: EditorInfo,
+  requested: 'global' | 'project',
+  cwd: string,
+  home: string
+): void {
+  const target = resolveMcpTarget(editor, requested, cwd, home);
+  if (!target) {
+    p.log.warn(`${editor.label}: no writable MCP config — skipped.`);
+    return;
+  }
+
+  const existing = existsSync(target.path)
+    ? readFileSync(target.path, 'utf8')
+    : null;
+  let merged: { content: string; replaced: boolean };
+  try {
+    merged = mergeMcpServers(
+      existing,
+      editor.mcpKey,
+      MCP_SERVER_NAME,
+      editor.mcpEntry
+    );
+  } catch {
+    p.log.error(
+      `${editor.label}: could not parse ${target.path} as JSON — skipped.`
+    );
+    return;
+  }
+
+  mkdirSync(dirname(target.path), { recursive: true });
+  writeFileSync(target.path, merged.content);
+
+  const scopeNote = target.scope === requested ? '' : ` (${target.scope}-only)`;
+  p.log.success(
+    `${editor.label}: MCP → ${prettyPath(target.path, home)}${scopeNote}`
+  );
+}
+
+/** The globally-installed `tigris` CLI version, or null if not on PATH. */
+function getInstalledCliVersion(): string | null {
+  const r = spawnSync('tigris', ['--version'], { encoding: 'utf8' });
+  if (r.error || r.status !== 0 || !r.stdout) return null;
+  const v = r.stdout.trim().split('\n')[0].trim();
+  return /^\d+\.\d+\.\d+/.test(v) ? v : null;
+}
+
+/**
+ * Ensure the Tigris CLI is present and current: install it if missing, update
+ * it if a newer version is published, and do nothing (no step) if it's already
+ * the latest. Returns whether the `tigris` command is available afterwards.
+ */
+async function ensureCli(): Promise<boolean> {
+  const installed = getInstalledCliVersion();
+
+  let latest: string | null;
+  try {
+    // Cap the registry check so a slow network can't stall the wizard.
+    latest = await Promise.race([
+      fetchLatestVersion({ unref: true }),
+      new Promise<string>((_, reject) =>
+        setTimeout(() => reject(new Error('timeout')), 3000)
+      ),
+    ]);
+  } catch {
+    latest = null;
+  }
+
+  if (!installed) {
+    return runCommand(
+      'npm',
+      ['install', '-g', '@tigrisdata/cli', '--ignore-scripts'],
+      'Installing Tigris CLI (global)'
+    ).ok;
+  }
+
+  if (latest && isNewerVersion(installed, latest)) {
+    runCommand(
+      'npm',
+      ['install', '-g', '@tigrisdata/cli@latest', '--ignore-scripts'],
+      `Updating Tigris CLI ${installed} → ${latest}`
+    );
+    return true;
+  }
+
+  // Installed and current (or latest unknown) — no CLI step shown.
+  return true;
+}
+
+/** Run a command under a spinner; capture output and surface it on failure. */
+function runCommand(
+  cmd: string,
+  args: string[],
+  startMsg: string
+): { ok: boolean; output?: string } {
+  const s = p.spinner();
+  s.start(startMsg);
+  const r = spawnSync(cmd, args, { encoding: 'utf8' });
+  if (r.status === 0) {
+    s.stop(`${startMsg} — done`);
+    return { ok: true };
+  }
+  s.stop(`${startMsg} — failed`);
+  return { ok: false, output: (r.stderr || r.stdout || '').trim() };
+}

--- a/packages/cli/src/lib/init/plan.ts
+++ b/packages/cli/src/lib/init/plan.ts
@@ -1,63 +1,42 @@
-import { ENV_KEYS } from './shared.js';
-
 /**
- * Emit the agent onboarding plan for `tigris init --agent --getting-started`.
+ * The onboarding recipe printed by `tigris init --agent`.
  *
- * This does NOT execute anything. It returns a recipe — an ordered list of
- * `{ id, description, command }` steps — that an AI coding agent follows,
- * running the listed `tigris` commands itself and making decisions per each
- * description (Neon's `init --agent` model).
+ * This does NOT execute anything — it is a plain-text set of steps for an AI
+ * coding agent to follow, running the listed `tigris` commands itself and
+ * making decisions per step.
  */
-export function emitGettingStarted() {
-  const plan = {
-    phase: 'setup',
-    status: 'getting_started',
-    nextAction: {
-      type: 'agent_action',
-      steps: [
-        {
-          id: 'ensure_cli',
-          description:
-            'Ensure the Tigris CLI is available; install it only if the `tigris` command is not already on PATH.',
-          command:
-            'command -v tigris >/dev/null 2>&1 || npm install -g @tigrisdata/cli --ignore-scripts',
-        },
-        {
-          id: 'select_org',
-          description:
-            "List the user's Tigris organizations. If only one exists, use it automatically. If several exist, ask the user which to use. Remember the selected org for the next steps.",
-          command: 'tigris orgs list --format json',
-        },
-        {
-          id: 'create_bucket',
-          description:
-            'Create a bucket for this project, or reuse an existing one from `tigris buckets list --format json`. Choose a clear, project-specific name.',
-          command: 'tigris buckets create <bucket> --format json',
-        },
-        {
-          id: 'create_access_key',
-          description:
-            'Create an access key for the application to use with the Tigris SDK.',
-          command: 'tigris access-keys create <key-name> --format json',
-        },
-        {
-          id: 'assign_role',
-          description:
-            'Grant the new access key Editor access to the bucket created above, using the key id returned by the previous step.',
-          command:
-            'tigris access-keys assign <key-id> --bucket <bucket> --role Editor --format json',
-        },
-        {
-          id: 'write_env',
-          description:
-            `Write the credentials to the project's .env so the SDK picks them up: ` +
-            `${ENV_KEYS.accessKeyId} and ${ENV_KEYS.secretAccessKey} from create_access_key, ` +
-            `${ENV_KEYS.bucket} = the bucket name, and ${ENV_KEYS.endpoint} = https://t3.storage.dev.`,
-          command: null,
-        },
-      ],
-    },
-  };
+export const AGENT_SETUP = `Help the user set up their project with Tigris:
 
-  console.log(JSON.stringify(plan, null, 2));
-}
+1. If \`tigris\` isn't on $PATH (\`command -v tigris\`), ask permission, then \`npm install -g @tigrisdata/cli --ignore-scripts\`.
+2. If \`tigris\` is on $PATH, ensure it's latest version using \`tigris update\`.
+3. Check if the user is already authenticated using \`tigris whoami\`. If not, authenticate using \`tigris login oauth\`.
+4. Run \`tigris orgs list --format json\`. If there's more than one org, ask which to use, then make it active with \`tigris orgs select <org>\` so the following commands target it.
+5. Infer the project name from metadata (package.json, go.mod, pyproject.toml, ...). Check \`tigris buckets list --format json\` first; if the bucket is absent, \`tigris buckets create <name> --format json\`. Ask the user whenever anything is ambiguous.
+6. Create the access key into a private temp file (overwrite, never append), then print only the ID:
+   \`umask 077; tmpfile=$(mktemp); tigris access-keys create <username>-<project>-devel --format json > "$tmpfile" && jq -r '.id' < "$tmpfile"\`
+7. Grant bucket access: \`tigris access-keys assign <id> --bucket <bucket> --role Editor --format json\`.
+8. Detect whether the code uses the Tigris SDK or the AWS SDK, then have a small script append the right vars to .env, reading \`.id\`/\`.secret\` from the temp file. Do NOT read the secret into your context — append it via script. Delete the temp file when done: \`rm -f "$tmpfile"\`.
+
+   Tigris SDK (@tigrisdata/storage, storage-go):
+     TIGRIS_STORAGE_ACCESS_KEY_ID     = .id
+     TIGRIS_STORAGE_SECRET_ACCESS_KEY = .secret   (secret)
+     TIGRIS_STORAGE_BUCKET            = <bucket>
+
+   AWS SDK:
+     AWS_ACCESS_KEY_ID       = .id
+     AWS_SECRET_ACCESS_KEY   = .secret            (secret)
+     AWS_ENDPOINT_URL_S3     = https://t3.storage.dev    (required)
+     AWS_ENDPOINT_URL_IAM    = https://iam.storageapi.dev (required)
+     AWS_REGION              = auto                        (required)
+
+9. Congratulate the user and point them to:
+   - JS:    https://www.tigrisdata.com/docs/sdks/tigris/
+   - Go:    https://pkg.go.dev/github.com/tigrisdata/storage-go
+   - Docs:  https://www.tigrisdata.com/docs/
+   - Discord: https://community.tigrisdata.com/
+   - Skills: https://www.tigrisdata.com/docs/skills/
+
+   Suggest adding to their agent config:
+     > ## Tigris object storage
+     > This project uses Tigris. For any Tigris questions, consult https://www.tigrisdata.com/llms.txt before acting; look it up rather than relying on memory.
+`;

--- a/packages/cli/src/lib/init/plan.ts
+++ b/packages/cli/src/lib/init/plan.ts
@@ -1,0 +1,63 @@
+import { ENV_KEYS } from './shared.js';
+
+/**
+ * Emit the agent onboarding plan for `tigris init --agent --getting-started`.
+ *
+ * This does NOT execute anything. It returns a recipe — an ordered list of
+ * `{ id, description, command }` steps — that an AI coding agent follows,
+ * running the listed `tigris` commands itself and making decisions per each
+ * description (Neon's `init --agent` model).
+ */
+export function emitGettingStarted() {
+  const plan = {
+    phase: 'setup',
+    status: 'getting_started',
+    nextAction: {
+      type: 'agent_action',
+      steps: [
+        {
+          id: 'ensure_cli',
+          description:
+            'Ensure the Tigris CLI is available; install it only if the `tigris` command is not already on PATH.',
+          command:
+            'command -v tigris >/dev/null 2>&1 || npm install -g @tigrisdata/cli --ignore-scripts',
+        },
+        {
+          id: 'select_org',
+          description:
+            "List the user's Tigris organizations. If only one exists, use it automatically. If several exist, ask the user which to use. Remember the selected org for the next steps.",
+          command: 'tigris orgs list --format json',
+        },
+        {
+          id: 'create_bucket',
+          description:
+            'Create a bucket for this project, or reuse an existing one from `tigris buckets list --format json`. Choose a clear, project-specific name.',
+          command: 'tigris buckets create <bucket> --format json',
+        },
+        {
+          id: 'create_access_key',
+          description:
+            'Create an access key for the application to use with the Tigris SDK.',
+          command: 'tigris access-keys create <key-name> --format json',
+        },
+        {
+          id: 'assign_role',
+          description:
+            'Grant the new access key Editor access to the bucket created above, using the key id returned by the previous step.',
+          command:
+            'tigris access-keys assign <key-id> --bucket <bucket> --role Editor --format json',
+        },
+        {
+          id: 'write_env',
+          description:
+            `Write the credentials to the project's .env so the SDK picks them up: ` +
+            `${ENV_KEYS.accessKeyId} and ${ENV_KEYS.secretAccessKey} from create_access_key, ` +
+            `${ENV_KEYS.bucket} = the bucket name, and ${ENV_KEYS.endpoint} = https://t3.storage.dev.`,
+          command: null,
+        },
+      ],
+    },
+  };
+
+  console.log(JSON.stringify(plan, null, 2));
+}

--- a/packages/cli/src/lib/init/shared.ts
+++ b/packages/cli/src/lib/init/shared.ts
@@ -1,17 +1,61 @@
+import { homedir } from 'node:os';
 import { join } from 'node:path';
+import {
+  applyEdits,
+  modify,
+  type ParseError,
+  parse as parseJsonc,
+} from 'jsonc-parser';
 
-export type AgentTarget = 'claude-code' | 'cursor' | 'vscode' | 'windsurf';
+export type AgentTarget =
+  | 'claude-code'
+  | 'cursor'
+  | 'vscode'
+  | 'windsurf'
+  | 'codex'
+  | 'antigravity-cli'
+  | 'cline'
+  | 'zed'
+  | 'roo'
+  | 'opencode';
 
 // ---------------------------------------------------------------------------
-// .env helpers
+// Platform paths
 // ---------------------------------------------------------------------------
 
-export const ENV_KEYS = {
-  accessKeyId: 'TIGRIS_STORAGE_ACCESS_KEY_ID',
-  secretAccessKey: 'TIGRIS_STORAGE_SECRET_ACCESS_KEY',
-  endpoint: 'TIGRIS_STORAGE_ENDPOINT',
-  bucket: 'TIGRIS_STORAGE_BUCKET',
-} as const;
+const HOME = homedir();
+const CONFIG_HOME =
+  process.env.XDG_CONFIG_HOME?.trim() || join(HOME, '.config');
+const CODEX_HOME = process.env.CODEX_HOME?.trim() || join(HOME, '.codex');
+
+/** The VS Code user directory (where extensions keep globalStorage). */
+function vsCodeUserDir(home: string, env: NodeJS.ProcessEnv): string {
+  if (process.platform === 'darwin') {
+    return join(home, 'Library', 'Application Support', 'Code', 'User');
+  }
+  if (process.platform === 'win32') {
+    return join(
+      env.APPDATA?.trim() || join(home, 'AppData', 'Roaming'),
+      'Code',
+      'User'
+    );
+  }
+  return join(
+    env.XDG_CONFIG_HOME?.trim() || join(home, '.config'),
+    'Code',
+    'User'
+  );
+}
+
+const VSCODE_USER_DIR = vsCodeUserDir(HOME, process.env);
+
+/** Cline's VS Code extension id; its globalStorage folder exists when installed. */
+const CLINE_EXTENSION_ID = 'saoudrizwan.claude-dev';
+
+/** MCP settings file for a VS Code extension, inside its globalStorage. */
+function vscodeExtensionMcpPath(extensionId: string, file: string): string {
+  return join(VSCODE_USER_DIR, 'globalStorage', extensionId, 'settings', file);
+}
 
 // ---------------------------------------------------------------------------
 // MCP config (Tigris remote hosted MCP server, OAuth-in-browser auth)
@@ -22,8 +66,11 @@ export const REMOTE_MCP_URL = 'https://mcp.storage.dev/mcp';
 
 /**
  * Merge an MCP server entry into existing config content (or a fresh file)
- * under the given top-level key (`mcpServers` or VS Code's `servers`),
- * preserving other servers. Throws if the existing content is not valid JSON.
+ * under the given top-level key (`mcpServers`, VS Code's `servers`, Zed's
+ * `context_servers`, opencode's `mcp`). The file may be JSONC (comments,
+ * trailing commas) — common for editor settings like Zed's — and the edit is
+ * applied surgically so existing comments, key order, and formatting are kept.
+ * Throws if the content isn't valid JSON/JSONC or the target isn't an object.
  */
 export function mergeMcpServers(
   existing: string | null,
@@ -31,16 +78,135 @@ export function mergeMcpServers(
   name: string,
   entry: Record<string, unknown>
 ): { content: string; replaced: boolean } {
-  let root: Record<string, unknown> = {};
-  if (existing?.trim()) {
-    root = JSON.parse(existing) as Record<string, unknown>;
+  const text = existing?.trim() ? existing : '{}';
+
+  // Parse tolerantly to validate shape (comments / trailing commas allowed).
+  const errors: ParseError[] = [];
+  const root: unknown = parseJsonc(text, errors, { allowTrailingComma: true });
+  if (errors.length > 0) {
+    throw new Error('config is not valid JSON/JSONC');
+  }
+  if (!isPlainObject(root)) {
+    throw new Error('config root is not an object');
+  }
+  // Guard against a non-object server map (e.g. `"mcpServers": "disabled"`).
+  const existingServers = root[key];
+  if (existingServers !== undefined && !isPlainObject(existingServers)) {
+    throw new Error(`"${key}" is not an object`);
+  }
+  const replaced =
+    isPlainObject(existingServers) && Object.hasOwn(existingServers, name);
+
+  // Surgical edit — preserves the rest of the file's comments and formatting.
+  const edits = modify(text, [key, name], entry, {
+    formattingOptions: { insertSpaces: true, tabSize: 2 },
+  });
+  return {
+    content: ensureTrailingNewline(applyEdits(text, edits)),
+    replaced,
+  };
+}
+
+/** True for a non-null, non-array object. */
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Upsert a `[<key>.<name>]` table into TOML content (Codex's `config.toml`),
+ * replacing the table's body if it already exists, else appending. Only string
+ * fields are supported, which is all our remote-server entry needs. Idempotent.
+ */
+export function upsertTomlServer(
+  existing: string | null,
+  key: string,
+  name: string,
+  fields: Record<string, string>
+): { content: string; replaced: boolean } {
+  const header = `[${key}.${name}]`;
+  const bodyLines = [
+    header,
+    ...Object.entries(fields).map(([k, v]) => `${k} = ${JSON.stringify(v)}`),
+  ];
+
+  const src = existing ?? '';
+  // An inline `mcp_servers.tigris = { ... }` (vs a `[mcp_servers.tigris]`
+  // table) would collide with the table we append and make the file invalid;
+  // refuse rather than corrupt it.
+  if (hasInlineTomlKey(src, key, name)) {
+    throw new Error(`existing TOML defines ${key}.${name} inline`);
+  }
+  const target = `${key}.${name}`;
+  const lines = src.length ? src.split('\n') : [];
+  const start = lines.findIndex((l) => tomlTableHeader(l) === target);
+
+  if (start !== -1) {
+    // Replace the table body: from the header up to the next table header/EOF.
+    let end = start + 1;
+    while (end < lines.length && tomlTableHeader(lines[end]) === null) end++;
+    lines.splice(start, end - start, ...bodyLines);
+    return { content: ensureTrailingNewline(lines.join('\n')), replaced: true };
   }
 
-  const servers = (root[key] as Record<string, unknown>) ?? {};
-  const replaced = Object.hasOwn(servers, name);
+  const prefix = src.length === 0 ? '' : ensureTrailingNewline(src);
+  const gap = prefix.length === 0 ? '' : '\n';
+  return {
+    content: ensureTrailingNewline(prefix + gap + bodyLines.join('\n')),
+    replaced: false,
+  };
+}
 
-  const nextRoot = { ...root, [key]: { ...servers, [name]: entry } };
-  return { content: `${JSON.stringify(nextRoot, null, 2)}\n`, replaced };
+function ensureTrailingNewline(s: string): string {
+  return s.endsWith('\n') ? s : `${s}\n`;
+}
+
+/**
+ * The normalized dotted key of a TOML table-header line, or null if the line
+ * isn't a table header. Tolerates a trailing comment and whitespace inside the
+ * brackets / around dots: `[ mcp_servers . tigris ]  # x` → `mcp_servers.tigris`.
+ */
+function tomlTableHeader(line: string): string | null {
+  const m = line.trim().match(/^\[([^[\]]*)\]/);
+  if (!m) return null;
+  return m[1]
+    .split('.')
+    .map((s) => s.trim())
+    .join('.');
+}
+
+/**
+ * True if `<key>.<name>` is already defined as an inline assignment (e.g.
+ * `tigris = { ... }` under `[mcp_servers]`, or a top-level `mcp_servers.tigris`
+ * dotted key) rather than as a `[<key>.<name>]` table. Appending our table in
+ * that case would redefine the key and make the TOML invalid.
+ */
+function hasInlineTomlKey(src: string, key: string, name: string): boolean {
+  let table = '';
+  for (const raw of src.split('\n')) {
+    const line = raw.trim();
+    if (line === '' || line.startsWith('#')) continue;
+    const tableHeader = tomlTableHeader(line);
+    if (tableHeader !== null) {
+      table = tableHeader;
+      continue;
+    }
+    const eq = line.indexOf('=');
+    if (eq === -1) continue;
+    const lhs = line
+      .slice(0, eq)
+      .trim()
+      .replace(/^['"]|['"]$/g, '');
+    if (table === key && (lhs === name || lhs.startsWith(`${name}.`))) {
+      return true;
+    }
+    if (
+      table === '' &&
+      (lhs === `${key}.${name}` || lhs.startsWith(`${key}.${name}.`))
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -49,69 +215,201 @@ export function mergeMcpServers(
 
 export type InstallLocation = 'global' | 'project' | 'skip';
 
+export interface McpServerConfig {
+  /** Config file format. */
+  format: 'json' | 'toml';
+  /** Top-level key (JSON) or table namespace (TOML, e.g. `mcp_servers`). */
+  key: string;
+  /** The server entry written under `key` → `MCP_SERVER_NAME`. */
+  entry: Record<string, unknown>;
+  /** Config path relative to cwd, when the editor supports project scope. */
+  projectPath?: string;
+  /** Absolute config path, when the editor supports global scope. */
+  globalPath?: string;
+  /**
+   * When false, only write if the target's parent directory already exists.
+   * Used for app-managed locations (e.g. Cline's VS Code globalStorage) so we
+   * never create a junk config tree for an editor that isn't installed.
+   */
+  createDirs?: boolean;
+}
+
 export interface EditorInfo {
   id: AgentTarget;
   label: string;
-  /** Top-level key in the MCP config file. */
-  mcpKey: 'mcpServers' | 'servers';
-  /** The remote MCP server entry (shape varies per editor). */
-  mcpEntry: Record<string, string>;
-  /** MCP config path relative to cwd, when the editor supports project scope. */
-  mcpProjectPath?: string;
-  /** MCP config path relative to home, when the editor supports global scope. */
-  mcpGlobalPath?: string;
+  /** MCP config, when we can write one for this editor. */
+  mcp?: McpServerConfig;
   /** Agent flag passed to `npx skills add ... -a <skillsAgent>`. */
   skillsAgent: string;
   /** Directory where `npx skills` installs, relative to cwd (project scope). */
   skillsProjectDir: string;
-  /** Directory where `npx skills` installs, relative to home (global scope). */
+  /** Absolute directory where `npx skills` installs at global scope. */
   skillsGlobalDir: string;
 }
+
+/** A remote MCP server reached through the `mcp-remote` stdio bridge (for
+ *  editors that only spawn stdio child processes, e.g. Zed). */
+const MCP_REMOTE_BRIDGE: Record<string, unknown> = {
+  source: 'custom',
+  command: 'npx',
+  args: ['-y', 'mcp-remote', REMOTE_MCP_URL],
+};
 
 export const SUPPORTED_EDITORS: EditorInfo[] = [
   {
     id: 'claude-code',
     label: 'Claude Code',
-    mcpKey: 'mcpServers',
-    mcpEntry: { type: 'http', url: REMOTE_MCP_URL },
-    mcpProjectPath: '.mcp.json',
-    mcpGlobalPath: '.claude.json',
+    mcp: {
+      format: 'json',
+      key: 'mcpServers',
+      entry: { type: 'http', url: REMOTE_MCP_URL },
+      projectPath: '.mcp.json',
+      globalPath: join(HOME, '.claude.json'),
+    },
     skillsAgent: 'claude-code',
     skillsProjectDir: join('.claude', 'skills'),
-    skillsGlobalDir: join('.claude', 'skills'),
+    skillsGlobalDir: join(HOME, '.claude', 'skills'),
   },
   {
     id: 'cursor',
     label: 'Cursor',
-    mcpKey: 'mcpServers',
-    mcpEntry: { url: REMOTE_MCP_URL },
-    mcpProjectPath: join('.cursor', 'mcp.json'),
-    mcpGlobalPath: join('.cursor', 'mcp.json'),
+    mcp: {
+      format: 'json',
+      key: 'mcpServers',
+      entry: { url: REMOTE_MCP_URL },
+      projectPath: join('.cursor', 'mcp.json'),
+      globalPath: join(HOME, '.cursor', 'mcp.json'),
+    },
     skillsAgent: 'cursor',
     skillsProjectDir: join('.agents', 'skills'),
-    skillsGlobalDir: join('.cursor', 'skills'),
+    skillsGlobalDir: join(HOME, '.cursor', 'skills'),
   },
   {
     id: 'vscode',
     label: 'VS Code',
-    mcpKey: 'servers',
-    mcpEntry: { type: 'http', url: REMOTE_MCP_URL },
-    mcpProjectPath: join('.vscode', 'mcp.json'),
-    // VS Code's user-level mcp.json path is platform-specific; project only.
+    mcp: {
+      format: 'json',
+      key: 'servers',
+      entry: { type: 'http', url: REMOTE_MCP_URL },
+      // VS Code's user-level mcp.json path is platform-specific; project only.
+      projectPath: join('.vscode', 'mcp.json'),
+    },
     skillsAgent: 'github-copilot',
     skillsProjectDir: join('.agents', 'skills'),
-    skillsGlobalDir: join('.copilot', 'skills'),
+    skillsGlobalDir: join(HOME, '.copilot', 'skills'),
   },
   {
     id: 'windsurf',
     label: 'Windsurf',
-    mcpKey: 'mcpServers',
-    mcpEntry: { serverUrl: REMOTE_MCP_URL },
-    // Windsurf only reads a single global config file.
-    mcpGlobalPath: join('.codeium', 'windsurf', 'mcp_config.json'),
+    mcp: {
+      format: 'json',
+      key: 'mcpServers',
+      entry: { serverUrl: REMOTE_MCP_URL },
+      // Windsurf only reads a single global config file.
+      globalPath: join(HOME, '.codeium', 'windsurf', 'mcp_config.json'),
+    },
     skillsAgent: 'windsurf',
     skillsProjectDir: join('.windsurf', 'skills'),
-    skillsGlobalDir: join('.codeium', 'windsurf', 'skills'),
+    skillsGlobalDir: join(HOME, '.codeium', 'windsurf', 'skills'),
+  },
+  {
+    id: 'codex',
+    label: 'Codex',
+    mcp: {
+      format: 'toml',
+      key: 'mcp_servers',
+      entry: { url: REMOTE_MCP_URL },
+      projectPath: join('.codex', 'config.toml'),
+      globalPath: join(CODEX_HOME, 'config.toml'),
+    },
+    skillsAgent: 'codex',
+    skillsProjectDir: join('.agents', 'skills'),
+    skillsGlobalDir: join(CODEX_HOME, 'skills'),
+  },
+  {
+    id: 'antigravity-cli',
+    label: 'Antigravity CLI',
+    mcp: {
+      format: 'json',
+      key: 'mcpServers',
+      // Antigravity (the Gemini CLI successor) shares one MCP config across its
+      // IDE and CLI at this global path; remote servers use `serverUrl`
+      // (url/httpUrl unsupported). Its project-local path is unstable across
+      // versions, so we target only the authoritative global file.
+      entry: { serverUrl: REMOTE_MCP_URL },
+      globalPath: join(HOME, '.gemini', 'config', 'mcp_config.json'),
+    },
+    skillsAgent: 'antigravity-cli',
+    skillsProjectDir: join('.agents', 'skills'),
+    skillsGlobalDir: join(HOME, '.gemini', 'antigravity-cli', 'skills'),
+  },
+  {
+    id: 'cline',
+    label: 'Cline',
+    mcp: {
+      format: 'json',
+      key: 'mcpServers',
+      entry: {
+        type: 'streamableHttp',
+        url: REMOTE_MCP_URL,
+        disabled: false,
+        autoApprove: [],
+      },
+      // Cline stores MCP config in its VS Code globalStorage — global only, and
+      // only written if Cline is actually installed (createDirs: false).
+      globalPath: vscodeExtensionMcpPath(
+        CLINE_EXTENSION_ID,
+        'cline_mcp_settings.json'
+      ),
+      createDirs: false,
+    },
+    skillsAgent: 'cline',
+    skillsProjectDir: join('.agents', 'skills'),
+    skillsGlobalDir: join(HOME, '.agents', 'skills'),
+  },
+  {
+    id: 'zed',
+    label: 'Zed',
+    mcp: {
+      format: 'json',
+      key: 'context_servers',
+      // Zed spawns stdio servers only; reach the remote server via mcp-remote.
+      entry: MCP_REMOTE_BRIDGE,
+      projectPath: join('.zed', 'settings.json'),
+      globalPath: join(CONFIG_HOME, 'zed', 'settings.json'),
+    },
+    skillsAgent: 'zed',
+    skillsProjectDir: join('.agents', 'skills'),
+    skillsGlobalDir: join(HOME, '.agents', 'skills'),
+  },
+  {
+    id: 'roo',
+    label: 'Roo Code',
+    mcp: {
+      format: 'json',
+      key: 'mcpServers',
+      entry: { type: 'streamable-http', url: REMOTE_MCP_URL },
+      // Roo reads a project-level .roo/mcp.json (its global store is VS Code
+      // globalStorage); project scope is the reliable target.
+      projectPath: join('.roo', 'mcp.json'),
+    },
+    skillsAgent: 'roo',
+    skillsProjectDir: join('.roo', 'skills'),
+    skillsGlobalDir: join(HOME, '.roo', 'skills'),
+  },
+  {
+    id: 'opencode',
+    label: 'opencode',
+    mcp: {
+      format: 'json',
+      key: 'mcp',
+      entry: { type: 'remote', url: REMOTE_MCP_URL, enabled: true },
+      projectPath: 'opencode.json',
+      globalPath: join(CONFIG_HOME, 'opencode', 'opencode.json'),
+    },
+    skillsAgent: 'opencode',
+    skillsProjectDir: join('.agents', 'skills'),
+    skillsGlobalDir: join(CONFIG_HOME, 'opencode', 'skills'),
   },
 ];
 
@@ -119,13 +417,10 @@ export const SUPPORTED_EDITORS: EditorInfo[] = [
 export function skillsDirsFor(
   editors: EditorInfo[],
   scope: 'global' | 'project',
-  cwd: string,
-  home: string
+  cwd: string
 ): string[] {
   const dirs = editors.map((e) =>
-    scope === 'global'
-      ? join(home, e.skillsGlobalDir)
-      : join(cwd, e.skillsProjectDir)
+    scope === 'global' ? e.skillsGlobalDir : join(cwd, e.skillsProjectDir)
   );
   return [...new Set(dirs)];
 }
@@ -133,17 +428,19 @@ export function skillsDirsFor(
 /**
  * Resolve the MCP config path for an editor at the requested scope, falling
  * back to the editor's only supported scope when the requested one is absent
- * (e.g. Windsurf is global-only, VS Code is project-only). Returns null if the
- * editor has no writable MCP config path.
+ * (e.g. Windsurf/Cline are global-only, VS Code/Roo are project-only). Returns
+ * null if the editor has no writable MCP config path.
  */
 export function resolveMcpTarget(
   editor: EditorInfo,
   requested: 'global' | 'project',
-  cwd: string,
-  home: string
+  cwd: string
 ): { path: string; scope: 'global' | 'project' } | null {
-  const canGlobal = editor.mcpGlobalPath !== undefined;
-  const canProject = editor.mcpProjectPath !== undefined;
+  const mcp = editor.mcp;
+  if (!mcp) return null;
+
+  const canGlobal = mcp.globalPath !== undefined;
+  const canProject = mcp.projectPath !== undefined;
 
   const scope: 'global' | 'project' | null =
     requested === 'global'
@@ -158,10 +455,8 @@ export function resolveMcpTarget(
           ? 'global'
           : null;
 
-  if (scope === 'global')
-    return { path: join(home, editor.mcpGlobalPath!), scope };
-  if (scope === 'project')
-    return { path: join(cwd, editor.mcpProjectPath!), scope };
+  if (scope === 'global') return { path: mcp.globalPath!, scope };
+  if (scope === 'project') return { path: join(cwd, mcp.projectPath!), scope };
   return null;
 }
 
@@ -176,6 +471,7 @@ export function detectEditors(deps: {
   fileExists: (p: string) => boolean;
 }): AgentTarget[] {
   const { env, cwd, home, fileExists } = deps;
+  const configHome = env.XDG_CONFIG_HOME?.trim() || join(home, '.config');
   const found: AgentTarget[] = [];
 
   if (
@@ -197,6 +493,40 @@ export function detectEditors(deps: {
   }
   if (fileExists(join(home, '.codeium', 'windsurf'))) {
     found.push('windsurf');
+  }
+  if (env.CODEX_HOME?.trim() || fileExists(join(home, '.codex'))) {
+    found.push('codex');
+  }
+  if (
+    fileExists(join(home, '.gemini', 'antigravity-cli')) ||
+    fileExists(join(home, '.gemini', 'antigravity')) ||
+    fileExists(join(home, '.gemini', 'config'))
+  ) {
+    found.push('antigravity-cli');
+  }
+  if (
+    fileExists(join(home, '.cline')) ||
+    fileExists(
+      join(vsCodeUserDir(home, env), 'globalStorage', CLINE_EXTENSION_ID)
+    )
+  ) {
+    found.push('cline');
+  }
+  if (
+    fileExists(join(configHome, 'zed')) ||
+    fileExists('/Applications/Zed.app')
+  ) {
+    found.push('zed');
+  }
+  if (fileExists(join(cwd, '.roo'))) {
+    found.push('roo');
+  }
+  if (
+    fileExists(join(configHome, 'opencode')) ||
+    fileExists(join(cwd, 'opencode.json')) ||
+    fileExists(join(cwd, 'opencode.jsonc'))
+  ) {
+    found.push('opencode');
   }
 
   return found;

--- a/packages/cli/src/lib/init/shared.ts
+++ b/packages/cli/src/lib/init/shared.ts
@@ -1,0 +1,287 @@
+import { join } from 'node:path';
+
+export type AgentTarget = 'claude-code' | 'cursor' | 'vscode' | 'windsurf';
+
+// ---------------------------------------------------------------------------
+// .env helpers
+// ---------------------------------------------------------------------------
+
+export const ENV_KEYS = {
+  accessKeyId: 'TIGRIS_STORAGE_ACCESS_KEY_ID',
+  secretAccessKey: 'TIGRIS_STORAGE_SECRET_ACCESS_KEY',
+  endpoint: 'TIGRIS_STORAGE_ENDPOINT',
+  bucket: 'TIGRIS_STORAGE_BUCKET',
+} as const;
+
+// ---------------------------------------------------------------------------
+// MCP config (Tigris remote hosted MCP server, OAuth-in-browser auth)
+// ---------------------------------------------------------------------------
+
+export const MCP_SERVER_NAME = 'tigris';
+export const REMOTE_MCP_URL = 'https://mcp.storage.dev/mcp';
+
+/**
+ * Merge an MCP server entry into existing config content (or a fresh file)
+ * under the given top-level key (`mcpServers` or VS Code's `servers`),
+ * preserving other servers. Throws if the existing content is not valid JSON.
+ */
+export function mergeMcpServers(
+  existing: string | null,
+  key: string,
+  name: string,
+  entry: Record<string, unknown>
+): { content: string; replaced: boolean } {
+  let root: Record<string, unknown> = {};
+  if (existing?.trim()) {
+    root = JSON.parse(existing) as Record<string, unknown>;
+  }
+
+  const servers = (root[key] as Record<string, unknown>) ?? {};
+  const replaced = Object.hasOwn(servers, name);
+
+  const nextRoot = { ...root, [key]: { ...servers, [name]: entry } };
+  return { content: `${JSON.stringify(nextRoot, null, 2)}\n`, replaced };
+}
+
+// ---------------------------------------------------------------------------
+// Supported editors
+// ---------------------------------------------------------------------------
+
+export type InstallLocation = 'global' | 'project' | 'skip';
+
+export interface EditorInfo {
+  id: AgentTarget;
+  label: string;
+  /** Top-level key in the MCP config file. */
+  mcpKey: 'mcpServers' | 'servers';
+  /** The remote MCP server entry (shape varies per editor). */
+  mcpEntry: Record<string, string>;
+  /** MCP config path relative to cwd, when the editor supports project scope. */
+  mcpProjectPath?: string;
+  /** MCP config path relative to home, when the editor supports global scope. */
+  mcpGlobalPath?: string;
+  /** Agent flag passed to `npx skills add ... -a <skillsAgent>`. */
+  skillsAgent: string;
+  /** Directory where `npx skills` installs, relative to cwd (project scope). */
+  skillsProjectDir: string;
+  /** Directory where `npx skills` installs, relative to home (global scope). */
+  skillsGlobalDir: string;
+}
+
+export const SUPPORTED_EDITORS: EditorInfo[] = [
+  {
+    id: 'claude-code',
+    label: 'Claude Code',
+    mcpKey: 'mcpServers',
+    mcpEntry: { type: 'http', url: REMOTE_MCP_URL },
+    mcpProjectPath: '.mcp.json',
+    mcpGlobalPath: '.claude.json',
+    skillsAgent: 'claude-code',
+    skillsProjectDir: join('.claude', 'skills'),
+    skillsGlobalDir: join('.claude', 'skills'),
+  },
+  {
+    id: 'cursor',
+    label: 'Cursor',
+    mcpKey: 'mcpServers',
+    mcpEntry: { url: REMOTE_MCP_URL },
+    mcpProjectPath: join('.cursor', 'mcp.json'),
+    mcpGlobalPath: join('.cursor', 'mcp.json'),
+    skillsAgent: 'cursor',
+    skillsProjectDir: join('.agents', 'skills'),
+    skillsGlobalDir: join('.cursor', 'skills'),
+  },
+  {
+    id: 'vscode',
+    label: 'VS Code',
+    mcpKey: 'servers',
+    mcpEntry: { type: 'http', url: REMOTE_MCP_URL },
+    mcpProjectPath: join('.vscode', 'mcp.json'),
+    // VS Code's user-level mcp.json path is platform-specific; project only.
+    skillsAgent: 'github-copilot',
+    skillsProjectDir: join('.agents', 'skills'),
+    skillsGlobalDir: join('.copilot', 'skills'),
+  },
+  {
+    id: 'windsurf',
+    label: 'Windsurf',
+    mcpKey: 'mcpServers',
+    mcpEntry: { serverUrl: REMOTE_MCP_URL },
+    // Windsurf only reads a single global config file.
+    mcpGlobalPath: join('.codeium', 'windsurf', 'mcp_config.json'),
+    skillsAgent: 'windsurf',
+    skillsProjectDir: join('.windsurf', 'skills'),
+    skillsGlobalDir: join('.codeium', 'windsurf', 'skills'),
+  },
+];
+
+/** Distinct skills install directories for the given editors at a scope. */
+export function skillsDirsFor(
+  editors: EditorInfo[],
+  scope: 'global' | 'project',
+  cwd: string,
+  home: string
+): string[] {
+  const dirs = editors.map((e) =>
+    scope === 'global'
+      ? join(home, e.skillsGlobalDir)
+      : join(cwd, e.skillsProjectDir)
+  );
+  return [...new Set(dirs)];
+}
+
+/**
+ * Resolve the MCP config path for an editor at the requested scope, falling
+ * back to the editor's only supported scope when the requested one is absent
+ * (e.g. Windsurf is global-only, VS Code is project-only). Returns null if the
+ * editor has no writable MCP config path.
+ */
+export function resolveMcpTarget(
+  editor: EditorInfo,
+  requested: 'global' | 'project',
+  cwd: string,
+  home: string
+): { path: string; scope: 'global' | 'project' } | null {
+  const canGlobal = editor.mcpGlobalPath !== undefined;
+  const canProject = editor.mcpProjectPath !== undefined;
+
+  const scope: 'global' | 'project' | null =
+    requested === 'global'
+      ? canGlobal
+        ? 'global'
+        : canProject
+          ? 'project'
+          : null
+      : canProject
+        ? 'project'
+        : canGlobal
+          ? 'global'
+          : null;
+
+  if (scope === 'global')
+    return { path: join(home, editor.mcpGlobalPath!), scope };
+  if (scope === 'project')
+    return { path: join(cwd, editor.mcpProjectPath!), scope };
+  return null;
+}
+
+/**
+ * Best-effort detection of which supported editors are present, used to
+ * pre-check the multi-select. Returns the editor ids that look configured.
+ */
+export function detectEditors(deps: {
+  env: NodeJS.ProcessEnv;
+  cwd: string;
+  home: string;
+  fileExists: (p: string) => boolean;
+}): AgentTarget[] {
+  const { env, cwd, home, fileExists } = deps;
+  const found: AgentTarget[] = [];
+
+  if (
+    env.CLAUDECODE === '1' ||
+    fileExists(join(cwd, '.claude')) ||
+    fileExists(join(home, '.claude.json'))
+  ) {
+    found.push('claude-code');
+  }
+  if (
+    env.TERM_PROGRAM === 'cursor' ||
+    fileExists(join(cwd, '.cursor')) ||
+    fileExists(join(home, '.cursor'))
+  ) {
+    found.push('cursor');
+  }
+  if (env.TERM_PROGRAM === 'vscode' || fileExists(join(cwd, '.vscode'))) {
+    found.push('vscode');
+  }
+  if (fileExists(join(home, '.codeium', 'windsurf'))) {
+    found.push('windsurf');
+  }
+
+  return found;
+}
+
+// ---------------------------------------------------------------------------
+// Skills
+// ---------------------------------------------------------------------------
+
+export const TIGRIS_SKILLS_REPO = 'github.com/tigrisdata/skills';
+
+export interface SkillInfo {
+  id: string;
+  label: string;
+  /** Pre-selected in the picker. */
+  recommended: boolean;
+}
+
+/** Available Tigris skills (mirrors github.com/tigrisdata/skills). */
+export const TIGRIS_SKILLS: SkillInfo[] = [
+  { id: 'tigris-agent-kit', label: 'Agent kit', recommended: true },
+  {
+    id: 'tigris-object-operations',
+    label: 'Object operations',
+    recommended: true,
+  },
+  {
+    id: 'tigris-bucket-management',
+    label: 'Bucket management',
+    recommended: true,
+  },
+  { id: 'tigris-sdk-guide', label: 'SDK guide', recommended: true },
+  {
+    id: 'tigris-snapshots-forking',
+    label: 'Snapshots & forking',
+    recommended: false,
+  },
+  {
+    id: 'tigris-snapshots-recovery',
+    label: 'Snapshots recovery',
+    recommended: false,
+  },
+  {
+    id: 'tigris-lifecycle-management',
+    label: 'Lifecycle management',
+    recommended: false,
+  },
+  {
+    id: 'tigris-security-access-control',
+    label: 'Security & access control',
+    recommended: false,
+  },
+  { id: 'tigris-s3-migration', label: 'S3 migration', recommended: false },
+  { id: 'tigris-static-assets', label: 'Static assets', recommended: false },
+  {
+    id: 'tigris-image-optimization',
+    label: 'Image optimization',
+    recommended: false,
+  },
+  {
+    id: 'tigris-egress-optimizer',
+    label: 'Egress optimizer',
+    recommended: false,
+  },
+  { id: 'tigris-backup-export', label: 'Backup & export', recommended: false },
+  { id: 'tigris-python-sdk', label: 'Python SDK', recommended: false },
+];
+
+/**
+ * Args for the `npx` skills installer — non-interactive: installs the chosen
+ * skills to the given agents in one call. Run as `npx <args>`, e.g.
+ * `npx -y skills add github.com/tigrisdata/skills --skill tigris-sdk-guide -a claude-code`.
+ * `global` adds `-g` (user directory) instead of the default project scope.
+ */
+export function buildSkillsArgs(
+  skillIds: string[],
+  skillsAgents: string[],
+  global: boolean
+): string[] {
+  // Leading `-y` is npx's auto-install; trailing `--yes` makes the skills tool
+  // itself non-interactive (it prompts by default).
+  const args = ['-y', 'skills', 'add', TIGRIS_SKILLS_REPO];
+  for (const skill of skillIds) args.push('--skill', skill);
+  if (global) args.push('-g');
+  for (const agent of skillsAgents) args.push('-a', agent);
+  args.push('--yes');
+  return args;
+}

--- a/packages/cli/src/specs.yaml
+++ b/packages/cli/src/specs.yaml
@@ -91,6 +91,29 @@ definitions:
 
 commands:
   #########################
+  # Onboarding
+  #########################
+  # init
+  - name: init
+    alias: start
+    description: Connect Tigris to your AI coding agent — MCP server config and agent skills
+    examples:
+      - "tigris init"
+      - "npx @tigrisdata/cli init"
+      - "tigris init --agent --getting-started"
+    messages:
+      onStart: ''
+      onSuccess: ''
+      onFailure: 'Setup failed'
+    arguments:
+      - name: agent
+        description: Emit a JSON onboarding plan for an AI coding agent (pair with --getting-started)
+        type: flag
+      - name: getting-started
+        description: '[--agent] Emit the getting-started plan (default)'
+        type: flag
+
+  #########################
   # Authentication
   #########################
   # configure

--- a/packages/cli/src/specs.yaml
+++ b/packages/cli/src/specs.yaml
@@ -100,17 +100,14 @@ commands:
     examples:
       - "tigris init"
       - "npx @tigrisdata/cli init"
-      - "tigris init --agent --getting-started"
+      - "tigris init --agent"
     messages:
       onStart: ''
       onSuccess: ''
       onFailure: 'Setup failed'
     arguments:
       - name: agent
-        description: Emit a JSON onboarding plan for an AI coding agent (pair with --getting-started)
-        type: flag
-      - name: getting-started
-        description: '[--agent] Emit the getting-started plan (default)'
+        description: Print a setup recipe for an AI coding agent to follow instead of running the interactive wizard
         type: flag
 
   #########################

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ importers:
         specifier: ^3.1038.0
         version: 3.1090.0
       '@clack/prompts':
-        specifier: ^0.11.0
-        version: 0.11.0
+        specifier: ^1.7.0
+        version: 1.7.0
       '@sentry/node':
         specifier: ^10.66.0
         version: 10.66.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))
@@ -114,6 +114,9 @@ importers:
       jose:
         specifier: ^6.2.3
         version: 6.2.3
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       open:
         specifier: ^11.0.0
         version: 11.0.0
@@ -509,11 +512,13 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@clack/core@0.5.0':
-    resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
+  '@clack/core@1.4.3':
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
+    engines: {node: '>= 20.12.0'}
 
-  '@clack/prompts@0.11.0':
-    resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
+  '@clack/prompts@1.7.0':
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
+    engines: {node: '>= 20.12.0'}
 
   '@commitlint/cli@20.5.3':
     resolution: {integrity: sha512-OJdL0EXWD5y9LPa0nr/geOwzaS8BsdaybKkcloB0JgsguGxNv2R+hC2FTPqrAcprg35zF33KOQerY0x8W1aesA==}
@@ -1981,8 +1986,17 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.1.4:
     resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
   fast-xml-builder@1.3.0:
     resolution: {integrity: sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==}
@@ -2292,6 +2306,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -3833,15 +3850,16 @@ snapshots:
       human-id: 4.2.0
       prettier: 2.8.8
 
-  '@clack/core@0.5.0':
+  '@clack/core@1.4.3':
     dependencies:
-      picocolors: 1.1.1
+      fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@clack/prompts@0.11.0':
+  '@clack/prompts@1.7.0':
     dependencies:
-      '@clack/core': 0.5.0
-      picocolors: 1.1.1
+      '@clack/core': 1.4.3
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
   '@commitlint/cli@20.5.3(@types/node@20.19.43)(conventional-commits-parser@6.4.0)(typescript@5.9.3)':
@@ -5167,7 +5185,17 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.4: {}
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fast-xml-builder@1.3.0:
     dependencies:
@@ -5493,6 +5521,8 @@ snapshots:
   json-parse-even-better-errors@2.3.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  jsonc-parser@3.3.1: {}
 
   jsonfile@4.0.0:
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       '@aws-sdk/credential-providers':
         specifier: ^3.1038.0
         version: 3.1090.0
+      '@clack/prompts':
+        specifier: ^0.11.0
+        version: 0.11.0
       '@sentry/node':
         specifier: ^10.66.0
         version: 10.66.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))
@@ -505,6 +508,12 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@clack/core@0.5.0':
+    resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
+
+  '@clack/prompts@0.11.0':
+    resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
 
   '@commitlint/cli@20.5.3':
     resolution: {integrity: sha512-OJdL0EXWD5y9LPa0nr/geOwzaS8BsdaybKkcloB0JgsguGxNv2R+hC2FTPqrAcprg35zF33KOQerY0x8W1aesA==}
@@ -2900,6 +2909,9 @@ packages:
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -3820,6 +3832,17 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.2.0
       prettier: 2.8.8
+
+  '@clack/core@0.5.0':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@0.11.0':
+    dependencies:
+      '@clack/core': 0.5.0
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
 
   '@commitlint/cli@20.5.3(@types/node@20.19.43)(conventional-commits-parser@6.4.0)(typescript@5.9.3)':
     dependencies:
@@ -6109,6 +6132,8 @@ snapshots:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
+
+  sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
 


### PR DESCRIPTION
## What

Adds `tigris init` — brings over the init-wizard work from the old `tigrisdata/cli` repo (`feat/init-wizard`) into the monorepo's `packages/cli`, then extends it.

Two modes:

- **`tigris init`** — interactive wizard: detects installed editors, installs/updates the CLI, writes the Tigris remote MCP server config, and installs the Tigris agent skills (via `npx skills`). No login — the remote MCP server authenticates in-browser on first connect.
- **`tigris init --agent`** — prints a plain-text setup recipe for an AI coding agent to run itself (no interactive prompts, no JSON).

## Editors supported (MCP config + skills)

10 editors, each written with its real MCP config shape (verified against each tool's docs):

| Editor | Format | Notes |
|---|---|---|
| Claude Code, Cursor, VS Code, Windsurf | JSON | original four |
| Gemini CLI | JSON `mcpServers` | `httpUrl` |
| opencode | JSON `mcp` | `{type:remote,enabled}` |
| Roo Code | JSON `mcpServers` | `streamable-http`, project `.roo/mcp.json` |
| Zed | JSON `context_servers` | stdio-only → `mcp-remote` bridge |
| Codex | **TOML** | idempotent `[mcp_servers.tigris]` upsert |
| Cline | JSON | VS Code globalStorage; only written if Cline is installed |

## Notes

- "Defaults" installs **all** skills without prompting; only the "Customize" flow shows the skill picker.
- `@clack/prompts` pinned to `^1.7.0`.
- Two least-clean targets: **Cline** (global-only, deep per-OS VS Code path, guarded) and **Codex** (TOML).

## Verification

- Typecheck (main + binary tsconfigs), Biome, and build all pass.
- Config generation verified for all 10 editors — correct shapes, idempotent, preserves pre-existing servers/tables.
- `tigris init --agent` output and the non-TTY guard exercised end-to-end.
- Full CLI suite: **780 passed / 214 skipped** (incl. `specs-completeness`).
- Changeset added (`@tigrisdata/cli` minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The wizard writes and merges user/editor config files and can run global `npm install`/`npx`; mistakes could break local MCP setups, though errors are isolated per editor and secrets are only described in the `--agent` recipe, not written by init itself.
> 
> **Overview**
> Adds **`tigris init`** (alias `start`) as a new onboarding command in `specs.yaml`, wired through `packages/cli/src/lib/init/`.
> 
> **Interactive mode** runs a `@clack/prompts` wizard: detect installed AI editors, optionally install/update the global CLI (`npm install -g` or `tigris update`), merge the hosted Tigris MCP server (`https://mcp.storage.dev/mcp`) into each editor’s config (JSON/JSONC via `jsonc-parser`, TOML for Codex), and install Tigris skills via `npx skills add`. It sets `TIGRIS_NO_UPDATE_CHECK` so the normal post-command update notifier doesn’t interrupt the flow, requires a TTY, and ends with a note to run `tigris init --agent` (or `npx @tigrisdata/cli init --agent`).
> 
> **`--agent` mode** only prints the plain-text recipe from `plan.ts` (login, org/bucket, access key + `.env` guidance) for a coding agent to execute—no prompts or file writes in that path.
> 
> Shared logic in `shared.ts` covers 10 editors (per-tool MCP shapes, scope fallbacks, editor detection, skills args). Per-editor MCP failures are logged and skipped so one bad config doesn’t abort the rest.
> 
> Minor release noted in `.changeset/cli-init-wizard.md`; lockfile picks up the new dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c29adce96014f099ab3db607e12ccbedda634a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->