### PR TITLE
feat: default-tier updates and snapshot-scoped object restore

### DIFF
--- a/.changeset/cli-default-tier-and-snapshot-restore.md
+++ b/.changeset/cli-default-tier-and-snapshot-restore.md
@@ -1,0 +1,5 @@
+---
+"@tigrisdata/cli": minor
+---
+
+Add `--default-tier` to `tigris buckets set` and `--snapshot-version` (alias `--snapshot`) to `tigris objects restore` / `tigris objects restore-info`.

--- a/.changeset/storage-default-tier-and-snapshot-restore.md
+++ b/.changeset/storage-default-tier-and-snapshot-restore.md
@@ -1,0 +1,5 @@
+---
+"@tigrisdata/storage": minor
+---
+
+Add `defaultTier` to `updateBucket` for changing an existing bucket's default storage tier, and `snapshotVersion` to `restoreObject` / `getRestoreInfo` to target a point-in-time bucket snapshot.

--- a/packages/cli/src/lib/buckets/set.ts
+++ b/packages/cli/src/lib/buckets/set.ts
@@ -1,5 +1,9 @@
 import { getStorageConfigWithOrg } from '@auth/provider.js';
-import { type UpdateBucketOptions, updateBucket } from '@tigrisdata/storage';
+import {
+  type StorageClass,
+  type UpdateBucketOptions,
+  updateBucket,
+} from '@tigrisdata/storage';
 import { failWithError } from '@utils/exit.js';
 import { parseLocations } from '@utils/locations.js';
 import { msg, printStart, printSuccess } from '@utils/messages.js';
@@ -14,6 +18,10 @@ export default async function set(options: Record<string, unknown>) {
 
   const name = getOption<string>(options, ['name']);
   const access = getOption<string>(options, ['access']);
+  const defaultTier = getOption<string>(options, [
+    'default-tier',
+    'defaultTier',
+  ]);
   const locations = getOption<string | string[]>(options, ['locations']);
   const allowObjectAcl = getOption<string | boolean>(options, [
     'allow-object-acl',
@@ -52,6 +60,7 @@ export default async function set(options: Record<string, unknown>) {
   // Check if at least one setting is provided
   if (
     access === undefined &&
+    defaultTier === undefined &&
     locations === undefined &&
     allowObjectAcl === undefined &&
     disableDirectoryListing === undefined &&
@@ -69,6 +78,10 @@ export default async function set(options: Record<string, unknown>) {
 
   if (access !== undefined) {
     updateOptions.access = access as 'public' | 'private';
+  }
+
+  if (defaultTier !== undefined) {
+    updateOptions.defaultTier = defaultTier as StorageClass;
   }
 
   if (locations !== undefined) {

--- a/packages/cli/src/lib/objects/restore-info.ts
+++ b/packages/cli/src/lib/objects/restore-info.ts
@@ -15,6 +15,11 @@ export default async function restoreInfo(options: Record<string, unknown>) {
   const bucketArg = getOption<string>(options, ['bucket']);
   const keyArg = getOption<string>(options, ['key']);
   const versionId = getOption<string>(options, ['version-id', 'versionId']);
+  const snapshotVersion = getOption<string>(options, [
+    'snapshot-version',
+    'snapshotVersion',
+    'snapshot',
+  ]);
 
   if (!bucketArg) {
     failWithError(context, 'Bucket name or path is required');
@@ -30,6 +35,7 @@ export default async function restoreInfo(options: Record<string, unknown>) {
 
   const { data, error } = await getRestoreInfo(key, {
     ...(versionId ? { versionId } : {}),
+    ...(snapshotVersion ? { snapshotVersion } : {}),
     config: {
       ...config,
       bucket,

--- a/packages/cli/src/lib/objects/restore.ts
+++ b/packages/cli/src/lib/objects/restore.ts
@@ -14,6 +14,11 @@ export default async function restore(options: Record<string, unknown>) {
   const bucketArg = getOption<string>(options, ['bucket']);
   const keyArg = getOption<string>(options, ['key']);
   const versionId = getOption<string>(options, ['version-id', 'versionId']);
+  const snapshotVersion = getOption<string>(options, [
+    'snapshot-version',
+    'snapshotVersion',
+    'snapshot',
+  ]);
   const daysArg = getOption<string | number>(options, ['days', 'd']);
 
   if (!bucketArg) {
@@ -39,6 +44,7 @@ export default async function restore(options: Record<string, unknown>) {
   const { error } = await restoreObject(key, {
     ...(days !== undefined ? { days } : {}),
     ...(versionId ? { versionId } : {}),
+    ...(snapshotVersion ? { snapshotVersion } : {}),
     config: {
       ...config,
       bucket,

--- a/packages/cli/src/specs.yaml
+++ b/packages/cli/src/specs.yaml
@@ -914,10 +914,11 @@ commands:
               - my-bucket
       # set
       - name: set
-        description: Update settings on an existing bucket such as access level, location, caching, or custom domain
+        description: Update settings on an existing bucket such as access level, default tier, location, caching, or custom domain
         alias: s
         examples:
           - "tigris buckets set my-bucket --access public"
+          - "tigris buckets set my-bucket --default-tier GLACIER"
           - "tigris buckets set my-bucket --locations iad,fra --cache-control 'max-age=3600'"
           - "tigris buckets set my-bucket --custom-domain assets.example.com"
           - "tigris buckets set my-bucket --soft-delete enable --retention-days 30"
@@ -936,6 +937,9 @@ commands:
           - name: access
             description: Bucket access level
             options: *access_options
+          - name: default-tier
+            description: Change the default storage tier for objects uploaded to the bucket
+            options: *tier_options
           - name: region
             removed: true
             replaced_by: --locations
@@ -1666,6 +1670,7 @@ commands:
           - "tigris objects restore my-bucket archived.bin"
           - "tigris objects restore my-bucket archived.bin --days 3"
           - "tigris objects restore t3://my-bucket/archived.bin --days 7"
+          - "tigris objects restore my-bucket archived.bin --snapshot-version 1765889000501544464"
         messages:
           onStart: 'Requesting restore...'
           onSuccess: "Restore requested for '{{key}}'"
@@ -1684,6 +1689,9 @@ commands:
             default: 1
           - name: version-id
             description: Restore a specific object version (requires bucket versioning). Omit to restore the current version
+          - name: snapshot-version
+            description: Restore the object as of a specific bucket snapshot. Accepts a snapshot version string or any UNIX nanosecond-precision timestamp (e.g. 1765889000501544464)
+            alias: snapshot
           - name: format
             description: Output format
             options: [json, table, xml]
@@ -1695,6 +1703,7 @@ commands:
         examples:
           - "tigris objects restore-info my-bucket archived.bin"
           - "tigris objects restore-info t3://my-bucket/archived.bin --format json"
+          - "tigris objects restore-info my-bucket archived.bin --snapshot-version 1765889000501544464"
         messages:
           onStart: ''
           onSuccess: ''
@@ -1710,6 +1719,9 @@ commands:
             description: Key of the object (omit if bucket contains the full path)
           - name: version-id
             description: Inspect a specific object version (requires bucket versioning). Omit to read the current version
+          - name: snapshot-version
+            description: Inspect the object as of a specific bucket snapshot. Accepts a snapshot version string or any UNIX nanosecond-precision timestamp (e.g. 1765889000501544464)
+            alias: snapshot
           - name: format
             description: Output format
             options: [json, table, xml]

--- a/packages/storage/src/lib/bucket/update.ts
+++ b/packages/storage/src/lib/bucket/update.ts
@@ -1,7 +1,11 @@
 import { TigrisHeaders } from '@shared/headers';
 import { createStorageClient } from '../http-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
-import type { BucketLocations, UpdateBucketResponse } from './types';
+import type {
+  BucketLocations,
+  StorageClass,
+  UpdateBucketResponse,
+} from './types';
 import type { UpdateBucketBody } from './utils/api';
 import { validateLocationValues } from './utils/regions';
 
@@ -14,12 +18,14 @@ type UpdateBucketRequestBody = Pick<
   | 'protection'
   | 'additional_http_headers'
   | 'soft_delete'
+  | 'storage_class'
 >;
 
 export type UpdateBucketOptions = {
   // access and sharing settings
   access?: 'public' | 'private';
   allowObjectAcl?: boolean;
+  defaultTier?: StorageClass;
   disableDirectoryListing?: boolean;
   // storage settings
   locations?: BucketLocations;
@@ -86,6 +92,10 @@ export async function updateBucket(
   // custom domain
   if (options?.customDomain !== undefined) {
     body.website = { domain_name: options.customDomain };
+  }
+
+  if (options?.defaultTier !== undefined) {
+    body.storage_class = options.defaultTier;
   }
 
   // deletion settings

--- a/packages/storage/src/lib/bucket/utils/api.ts
+++ b/packages/storage/src/lib/bucket/utils/api.ts
@@ -39,6 +39,7 @@ type BucketApiSettings = {
   acl_list_objects?: 'false' | 'true';
   object_regions?: string;
   cache_control?: string;
+  storage_class?: StorageClass;
   shadow_bucket?: {
     access_key?: string;
     secret_key?: string;

--- a/packages/storage/src/lib/object/get.ts
+++ b/packages/storage/src/lib/object/get.ts
@@ -1,9 +1,9 @@
 import { GetObjectCommand } from '@aws-sdk/client-s3';
-import type { HttpRequest } from '@aws-sdk/types';
-import { handleError, TigrisHeaders } from '@shared/index';
+import { handleError } from '@shared/index';
 import { getConfig } from '../config';
 import { createTigrisClient } from '../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
+import { addSnapshotVersionMiddleware } from './middleware';
 
 export type GetOptions = {
   config?: TigrisStorageConfig;
@@ -166,20 +166,7 @@ export async function get(
   });
 
   if (options?.snapshotVersion) {
-    get.middlewareStack.add(
-      (next) => async (args) => {
-        const req = args.request as HttpRequest;
-        req.headers[TigrisHeaders.SNAPSHOT_VERSION] =
-          `${options.snapshotVersion}`;
-        const result = await next(args);
-        return result;
-      },
-      {
-        name: 'X-Tigris-Snapshot-Middleware',
-        step: 'build',
-        override: true,
-      }
-    );
+    addSnapshotVersionMiddleware(get.middlewareStack, options.snapshotVersion);
   }
 
   try {

--- a/packages/storage/src/lib/object/head.ts
+++ b/packages/storage/src/lib/object/head.ts
@@ -1,10 +1,9 @@
 import { HeadObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import type { HttpRequest } from '@aws-sdk/types';
-import { TigrisHeaders } from '@shared/index';
 import { getConfig } from '../config';
 import { createTigrisClient } from '../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
+import { addSnapshotVersionMiddleware } from './middleware';
 
 export type HeadOptions = {
   snapshotVersion?: string;
@@ -41,20 +40,7 @@ export async function head(
   });
 
   if (options?.snapshotVersion) {
-    head.middlewareStack.add(
-      (next) => async (args) => {
-        const req = args.request as HttpRequest;
-        req.headers[TigrisHeaders.SNAPSHOT_VERSION] =
-          `${options.snapshotVersion}`;
-        const result = await next(args);
-        return result;
-      },
-      {
-        name: 'X-Tigris-Snapshot-Middleware',
-        step: 'build',
-        override: true,
-      }
-    );
+    addSnapshotVersionMiddleware(head.middlewareStack, options.snapshotVersion);
   }
 
   try {

--- a/packages/storage/src/lib/object/list.ts
+++ b/packages/storage/src/lib/object/list.ts
@@ -4,6 +4,7 @@ import { TigrisHeaders } from '@shared/index';
 import { getConfig, missingConfigError } from '../config';
 import { createTigrisClient } from '../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
+import { addSnapshotVersionMiddleware } from './middleware';
 
 export type ListOptions = {
   delimiter?: string;
@@ -53,20 +54,7 @@ export async function list(
   });
 
   if (options?.snapshotVersion) {
-    list.middlewareStack.add(
-      (next) => async (args) => {
-        const req = args.request as HttpRequest;
-        req.headers[TigrisHeaders.SNAPSHOT_VERSION] =
-          `${options.snapshotVersion}`;
-        const result = await next(args);
-        return result;
-      },
-      {
-        name: 'X-Tigris-Snapshot-Middleware',
-        step: 'build',
-        override: true,
-      }
-    );
+    addSnapshotVersionMiddleware(list.middlewareStack, options.snapshotVersion);
   }
 
   if (options?.source) {

--- a/packages/storage/src/lib/object/middleware.ts
+++ b/packages/storage/src/lib/object/middleware.ts
@@ -1,0 +1,31 @@
+import type { HttpRequest, MiddlewareStack } from '@aws-sdk/types';
+import { TigrisHeaders } from '@shared/index';
+
+/**
+ * Pin an S3 command to a point-in-time bucket snapshot by attaching the
+ * `X-Tigris-Snapshot-Version` header to its request.
+ *
+ * Registered at the `build` step so the header rides on the request after it
+ * has been serialized. Added to the *command's* own middleware stack (not the
+ * cached client's), so it only affects this single call. `get`, `head`,
+ * `list`, and `restore` all share this exact injection — keep it here rather
+ * than copy-pasting the block per operation.
+ */
+export function addSnapshotVersionMiddleware<
+  Input extends object,
+  Output extends object,
+>(middlewareStack: MiddlewareStack<Input, Output>, snapshotVersion: string) {
+  middlewareStack.add(
+    (next) => async (args) => {
+      const req = args.request as HttpRequest;
+      req.headers[TigrisHeaders.SNAPSHOT_VERSION] = `${snapshotVersion}`;
+      const result = await next(args);
+      return result;
+    },
+    {
+      name: 'X-Tigris-Snapshot-Middleware',
+      step: 'build',
+      override: true,
+    }
+  );
+}

--- a/packages/storage/src/lib/object/restore.ts
+++ b/packages/storage/src/lib/object/restore.ts
@@ -4,6 +4,7 @@ import { handleError, TigrisHeaders } from '@shared/index';
 import { getConfig } from '../config';
 import { createTigrisClient } from '../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
+import { addSnapshotVersionMiddleware } from './middleware';
 
 export type RestoreObjectOptions = {
   /**
@@ -15,6 +16,7 @@ export type RestoreObjectOptions = {
    * Restore a specific object version instead of the current one.
    */
   versionId?: string;
+  snapshotVersion?: string;
   config?: TigrisStorageConfig;
 };
 
@@ -45,6 +47,13 @@ export async function restoreObject(
       Days: options?.days ?? 1,
     },
   });
+
+  if (options?.snapshotVersion) {
+    addSnapshotVersionMiddleware(
+      restore.middlewareStack,
+      options.snapshotVersion
+    );
+  }
 
   try {
     return tigrisClient
@@ -83,6 +92,7 @@ export type RestoreInfo = {
 export type GetRestoreInfoOptions = {
   /** Inspect a specific object version instead of the current one. */
   versionId?: string;
+  snapshotVersion?: string;
   config?: TigrisStorageConfig;
 };
 
@@ -109,6 +119,10 @@ export async function getRestoreInfo(
     Key: path,
     VersionId: options?.versionId,
   });
+
+  if (options?.snapshotVersion) {
+    addSnapshotVersionMiddleware(head.middlewareStack, options.snapshotVersion);
+  }
 
   let responseHeaders: Record<string, string> = {};
 

--- a/packages/storage/src/test/bucket-update.integration.test.ts
+++ b/packages/storage/src/test/bucket-update.integration.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createBucket } from '../lib/bucket/create';
+import { getBucketInfo } from '../lib/bucket/info';
+import { removeBucket } from '../lib/bucket/remove';
+import type { StorageClass } from '../lib/bucket/types';
+import { updateBucket } from '../lib/bucket/update';
+import { getConfig } from '../lib/config';
+import { shouldSkipIntegrationTests } from './setup';
+
+const skipTests = shouldSkipIntegrationTests();
+
+const config = getConfig();
+
+const testBucket = (suffix: string) =>
+  `test-update-${suffix}-${Date.now()}`.toLowerCase();
+
+describe.skipIf(skipTests)('updateBucket Integration Tests', () => {
+  const bucketsToCleanup: string[] = [];
+
+  // The default-tier change lands via a PATCH and then has to propagate before
+  // getBucketInfo reflects it, so round-trip assertions poll rather than read
+  // once.
+  const POLL = { timeout: 15000, interval: 1000 };
+
+  const readTier = async (bucket: string) => {
+    const info = await getBucketInfo(bucket, { config });
+    return info.data?.settings.defaultTier;
+  };
+
+  afterEach(async () => {
+    for (const bucket of [...bucketsToCleanup].reverse()) {
+      await removeBucket(bucket, { force: true, config });
+    }
+    bucketsToCleanup.length = 0;
+  });
+
+  it('changes the default tier of an existing bucket and round-trips via getBucketInfo', async () => {
+    const name = testBucket('tier');
+    bucketsToCleanup.push(name);
+
+    // A plain bucket starts on STANDARD.
+    const created = await createBucket(name, { config });
+    expect(
+      created.error,
+      `create failed: ${created.error?.message}`
+    ).toBeUndefined();
+    expect(await readTier(name)).toBe('STANDARD');
+
+    // Change the default tier on the existing bucket.
+    const updated = await updateBucket(name, {
+      defaultTier: 'GLACIER',
+      config,
+    });
+    expect(
+      updated.error,
+      `update failed: ${updated.error?.message}`
+    ).toBeUndefined();
+    expect(updated.data).toEqual({ bucket: name, updated: true });
+
+    // The new tier should propagate to the bucket metadata.
+    await expect.poll(() => readTier(name), POLL).toBe('GLACIER');
+  });
+
+  it('updates the default tier to each storage class', async () => {
+    const name = testBucket('tiers');
+    bucketsToCleanup.push(name);
+
+    const created = await createBucket(name, { config });
+    expect(created.error).toBeUndefined();
+
+    // Walk through every non-default tier, then back to STANDARD.
+    const tiers: StorageClass[] = [
+      'STANDARD_IA',
+      'GLACIER_IR',
+      'GLACIER',
+      'STANDARD',
+    ];
+
+    for (const tier of tiers) {
+      const updated = await updateBucket(name, { defaultTier: tier, config });
+      expect(
+        updated.error,
+        `update to ${tier} failed: ${updated.error?.message}`
+      ).toBeUndefined();
+
+      await expect.poll(() => readTier(name), POLL).toBe(tier);
+    }
+  });
+
+  it('leaves the default tier unchanged when an unrelated setting is updated', async () => {
+    const name = testBucket('preserve');
+    bucketsToCleanup.push(name);
+
+    // Start on a non-default tier so a reset would be observable.
+    const created = await createBucket(name, {
+      defaultTier: 'STANDARD_IA',
+      config,
+    });
+    expect(created.error).toBeUndefined();
+    await expect.poll(() => readTier(name), POLL).toBe('STANDARD_IA');
+
+    // An update that omits defaultTier must not reset the tier.
+    const updated = await updateBucket(name, {
+      cacheControl: 'max-age=60',
+      config,
+    });
+    expect(updated.error).toBeUndefined();
+
+    // Give any propagation a chance, then confirm the tier is still STANDARD_IA.
+    await new Promise((r) => setTimeout(r, 2000));
+    expect(await readTier(name)).toBe('STANDARD_IA');
+  });
+});

--- a/packages/storage/src/test/restore.integration.test.ts
+++ b/packages/storage/src/test/restore.integration.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { createBucket } from '../lib/bucket/create';
 import { removeBucket } from '../lib/bucket/remove';
+import { createBucketSnapshot } from '../lib/bucket/snapshot';
 import { getConfig } from '../lib/config';
 import { put } from '../lib/object/put';
 import {
@@ -138,3 +139,99 @@ describe.skipIf(skipTests)('restoreObject Integration Tests', () => {
     expect(restored.data?.path).toBe(key);
   });
 });
+
+describe.skipIf(skipTests)(
+  'restoreObject + snapshotVersion Integration Tests',
+  () => {
+    const bucketsToCleanup: string[] = [];
+
+    const POLL = { timeout: 30000, interval: 2000 };
+
+    afterEach(async () => {
+      for (const bucket of bucketsToCleanup) {
+        await removeBucket(bucket, { force: true, config });
+      }
+      bucketsToCleanup.length = 0;
+    });
+
+    it('restores and reports an archived object as of a specific snapshot version', async () => {
+      const bucket = testBucket('snap-glacier');
+      bucketsToCleanup.push(bucket);
+      const bucketConfig = { ...config, bucket };
+
+      // Snapshot-enabled archive bucket: objects default to GLACIER, and we can
+      // pin reads/restores to a point-in-time snapshot.
+      const created = await createBucket(bucket, {
+        defaultTier: 'GLACIER',
+        enableSnapshot: true,
+        config,
+      });
+      expect(
+        created.error,
+        `create bucket failed: ${created.error?.message}`
+      ).toBeUndefined();
+
+      // Upload a 1-byte object; it inherits the bucket's GLACIER default.
+      const key = `archived-${Date.now()}.txt`;
+      const uploaded = await put(key, 'a', { config: bucketConfig });
+      expect(
+        uploaded.error,
+        `put failed: ${uploaded.error?.message}`
+      ).toBeUndefined();
+
+      // Wait until the object is recognized as archived in live state before
+      // snapshotting, so the snapshot captures it in the GLACIER tier.
+      await expect
+        .poll(async () => {
+          const info = await getRestoreInfo(key, { config: bucketConfig });
+          return info.data?.status;
+        }, POLL)
+        .toBe(RestoreStatus.Archived);
+
+      // Take a snapshot that captures the archived object.
+      const snap = await createBucketSnapshot(bucket, {
+        name: `restore-snap-${Date.now()}`,
+        config,
+      });
+      expect(
+        snap.error,
+        `snapshot failed: ${snap.error?.message}`
+      ).toBeUndefined();
+      const snapshotVersion = snap.data?.snapshotVersion;
+      expect(snapshotVersion).toBeTruthy();
+
+      // Inspecting the object as of the snapshot should report it archived.
+      await expect
+        .poll(async () => {
+          const info = await getRestoreInfo(key, {
+            snapshotVersion,
+            config: bucketConfig,
+          });
+          return info.data?.status;
+        }, POLL)
+        .toBe(RestoreStatus.Archived);
+
+      // Restore the object as of the snapshot version.
+      const restored = await restoreObject(key, {
+        snapshotVersion,
+        config: bucketConfig,
+      });
+      expect(
+        restored.error,
+        `restore failed: ${restored.error?.message}`
+      ).toBeUndefined();
+      expect(restored.data?.path).toBe(key);
+
+      // Reading restore info as of the snapshot should now report progress.
+      await expect
+        .poll(async () => {
+          const info = await getRestoreInfo(key, {
+            snapshotVersion,
+            config: bucketConfig,
+          });
+          return info.data?.status;
+        }, POLL)
+        .toBe(RestoreStatus.InProgress);
+    });
+  }
+);


### PR DESCRIPTION
## Summary

Adds two capabilities across the storage SDK and CLI:

1. **Change an existing bucket's default tier** — `updateBucket({ defaultTier })`
   in the SDK, surfaced as `tigris buckets set --default-tier <tier>`.
2. **Snapshot-scoped object restore** — `restoreObject` / `getRestoreInfo` accept
   `snapshotVersion` to target a point-in-time bucket snapshot, surfaced as
   `tigris objects restore|restore-info --snapshot-version <version>` (alias `--snapshot`).

Also refactors the duplicated snapshot-version build middleware (previously
copy-pasted across get/head/list/restore) into a shared
`addSnapshotVersionMiddleware` helper.

## Changes

**`@tigrisdata/storage`** (`a3b3222`)
- `updateBucket`: new `defaultTier` option → `storage_class` in the settings PATCH body
- `restoreObject` / `getRestoreInfo`: new `snapshotVersion` option → `X-Tigris-Snapshot-Version` header
- Extract shared `addSnapshotVersionMiddleware` helper (get/head/list/restore)

**`@tigrisdata/cli`** (`2c43dfe`)
- `buckets set --default-tier`
- `objects restore --snapshot-version` / `restore-info --snapshot-version` (alias `--snapshot`)

## Testing

- SDK: new integration tests — `bucket-update` default-tier round-trip and
  snapshot-scoped restore, verified against the live gateway; existing
  restore/object-versions suites pass (16/16).
- CLI: `specs-completeness` passes (313/313); built-CLI `--help` shows all three
  flags; `tsc` + Biome clean.

## Notes

- **Changesets intentionally deferred** — will add `pnpm changeset` entries for
  both `@tigrisdata/storage` and `@tigrisdata/cli` (minor) after review and amend
  them into their respective commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bucket default tier via PATCH (affects future uploads) and adds snapshot-scoped restore against live storage APIs; additive but touches core bucket/object behavior.
> 
> **Overview**
> Adds **default storage tier updates** for existing buckets and **snapshot-pinned archive restore** across the storage SDK and CLI.
> 
> **Bucket default tier:** `updateBucket` accepts `defaultTier`, sent as `storage_class` on the bucket settings PATCH. The CLI exposes this as `tigris buckets set --default-tier` (reusing existing tier options).
> 
> **Snapshot-scoped restore:** `restoreObject` and `getRestoreInfo` accept optional `snapshotVersion`, which sets `X-Tigris-Snapshot-Version` on the S3 request. CLI: `tigris objects restore` and `restore-info` add `--snapshot-version` (alias `--snapshot`).
> 
> **Refactor:** Duplicated snapshot-header middleware in get/head/list/restore is consolidated into `addSnapshotVersionMiddleware`; restore paths now use the same helper.
> 
> Minor changesets for `@tigrisdata/storage` and `@tigrisdata/cli`, plus integration tests for tier round-trips and snapshot restore flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d48f51a59d8ba53acecff933c72bfc84f03e939. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->