### PR TITLE
fix(iam): return paginationToken from listPolicies

### DIFF
--- a/.changeset/iam-list-policies-pagination-token.md
+++ b/.changeset/iam-list-policies-pagination-token.md
@@ -1,0 +1,5 @@
+---
+"@tigrisdata/iam": patch
+---
+
+Fix `listPolicies` never returning a `paginationToken`. The `IsTruncated` and `Marker` fields are nested inside `ListPoliciesResult` in the API response, but were being read from the top level, so the next-page token was always `undefined`.

--- a/packages/iam/src/lib/policy/list.ts
+++ b/packages/iam/src/lib/policy/list.ts
@@ -15,9 +15,9 @@ export type ListPoliciesResponse = {
 };
 
 type ListPoliciesApiResponse = {
-  IsTruncated: boolean;
-  Marker?: string;
   ListPoliciesResult: {
+    IsTruncated: boolean;
+    Marker?: string;
     Policies: Array<{
       Arn: string;
       AttachmentCount: number;
@@ -75,8 +75,9 @@ export async function listPolicies(
 
   return {
     data: {
-      paginationToken:
-        response.data.Marker !== '' ? response.data.Marker : undefined,
+      paginationToken: response.data.ListPoliciesResult?.IsTruncated
+        ? response.data.ListPoliciesResult.Marker || undefined
+        : undefined,
       policies:
         response.data.ListPoliciesResult?.Policies?.map((policy) => ({
           attachmentCount: policy.AttachmentCount,


### PR DESCRIPTION
## Summary
`@tigrisdata/iam`'s `listPolicies` never returned a `paginationToken`, so `tigris iam policies list` could not page past the first result set — reported when 6 policies with `--limit 3` yielded no page token, in both table and `--json` output.

The AWS-standard `ListPolicies` response nests `IsTruncated` and `Marker` inside `ListPoliciesResult`, but the code read them from the top level, so `Marker` was always `undefined`. This matches the already-correct `listPoliciesForAccessKey` (`ListUserPolicies`) handling.

## Verification
Verified live: `--limit 3` now returns a `paginationToken`, and paging with it fetches a genuinely different second page (0 overlap) plus a further token.

## Audit
Swept every other list path (storage buckets/forks/objects/versions/snapshots/stats, iam access-keys, and all CLI list commands incl. `--json`/`--xml`) — no other pagination-token gaps found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow response-parsing fix in IAM policy listing with no auth or data-mutation changes; behavior only affects multi-page policy lists.
> 
> **Overview**
> **Fixes `listPolicies` pagination** so callers (e.g. `tigris iam policies list`) can page past the first result set.
> 
> The `ListPolicies` API nests `IsTruncated` and `Marker` under `ListPoliciesResult`, but the client typed and read them at the top level, so `paginationToken` was always missing. The response type and mapping now use `ListPoliciesResult`, and the next-page token is only set when `IsTruncated` is true—aligned with `listPoliciesForAccessKey`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2f0db031e5ce390e0e07e6ef7019c8b305ace8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->