### PR TITLE
feat(cli): support TIGRIS_FORCE_PATH_STYLE and namespace Auth0 env vars

### DIFF
--- a/.changeset/cli-force-path-style-and-auth0-env-vars.md
+++ b/.changeset/cli-force-path-style-and-auth0-env-vars.md
@@ -1,0 +1,5 @@
+---
+"@tigrisdata/cli": minor
+---
+
+Add `TIGRIS_FORCE_PATH_STYLE` env var to force S3 path-style addressing (bucket in the URL path instead of the host), applied across every auth method. Useful behind gateways or proxies that don't support virtual-hosted-style requests. Also namespace the Auth0 env overrides (`AUTH0_DOMAIN`/`AUTH0_CLIENT_ID`/`AUTH0_AUDIENCE` → `TIGRIS_AUTH0_*`) for consistency with the other `TIGRIS_*` variables.

--- a/packages/cli/AUTHENTICATION.md
+++ b/packages/cli/AUTHENTICATION.md
@@ -86,6 +86,12 @@ You can override service endpoints independently:
 
 AWS_ endpoint variables take priority over TIGRIS_ endpoint variables.
 
+### Other variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TIGRIS_FORCE_PATH_STYLE` | Use S3 path-style addressing (bucket in the URL path instead of the host). Set to `1`, `true`, `yes`, or `on` to enable. Useful behind gateways or proxies that don't support virtual-hosted-style requests. | `false` |
+
 ## AWS Profile
 
 If you have Tigris credentials configured in `~/.aws/credentials`, the CLI picks them up automatically when `AWS_PROFILE` is set.

--- a/packages/cli/src/auth/client.ts
+++ b/packages/cli/src/auth/client.ts
@@ -25,14 +25,15 @@ export interface Auth0Config {
 export function getAuth0Config(): Auth0Config {
   const isDev = process.env.TIGRIS_ENV === 'development';
   const domain = isDev
-    ? (process.env.AUTH0_DOMAIN ?? 'auth-storage.tigris.dev')
-    : (process.env.AUTH0_DOMAIN ?? 'auth.storage.tigrisdata.io');
+    ? (process.env.TIGRIS_AUTH0_DOMAIN ?? 'auth-storage.tigris.dev')
+    : (process.env.TIGRIS_AUTH0_DOMAIN ?? 'auth.storage.tigrisdata.io');
   const clientId = isDev
-    ? (process.env.AUTH0_CLIENT_ID ?? 'JdJVYIyw0O1uHi5L5OJH903qaWBgd3gF')
-    : (process.env.AUTH0_CLIENT_ID ?? 'DMejqeM3CQ4IqTjEcd3oA9eEiT40hn8D');
+    ? (process.env.TIGRIS_AUTH0_CLIENT_ID ?? 'JdJVYIyw0O1uHi5L5OJH903qaWBgd3gF')
+    : (process.env.TIGRIS_AUTH0_CLIENT_ID ??
+      'DMejqeM3CQ4IqTjEcd3oA9eEiT40hn8D');
   const audience = isDev
-    ? (process.env.AUTH0_AUDIENCE ?? 'https://tigris-api-dev')
-    : (process.env.AUTH0_AUDIENCE ?? 'https://tigris-os-api');
+    ? (process.env.TIGRIS_AUTH0_AUDIENCE ?? 'https://tigris-api-dev')
+    : (process.env.TIGRIS_AUTH0_AUDIENCE ?? 'https://tigris-os-api');
   const claimsNamespace =
     process.env.TIGRIS_CLAIMS_NAMESPACE ?? 'https://tigris';
   return { domain, clientId, audience, claimsNamespace };

--- a/packages/cli/src/auth/provider.ts
+++ b/packages/cli/src/auth/provider.ts
@@ -44,6 +44,20 @@ export function getTigrisConfig(): TigrisConfig {
   };
 }
 
+/**
+ * Whether to force S3 path-style addressing (bucket in the URL path rather
+ * than the host), read from TIGRIS_FORCE_PATH_STYLE. Useful against gateways
+ * or proxies that don't support virtual-hosted-style requests.
+ *
+ * Truthy values: `1`, `true`, `yes`, `on` (case-insensitive). Anything else
+ * — including unset — is false. Read per-call so it stays overridable at
+ * runtime, matching how the endpoint vars are consulted.
+ */
+export function getEnvForcePathStyle(): boolean {
+  const raw = process.env.TIGRIS_FORCE_PATH_STYLE?.trim().toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on';
+}
+
 const tigrisConfig = getTigrisConfig();
 const auth0Config = getAuth0Config();
 
@@ -198,6 +212,7 @@ export type TigrisStorageConfig = {
   accessKeyId?: string;
   secretAccessKey?: string;
   endpoint?: string;
+  forcePathStyle?: boolean;
   sessionToken?: string;
   organizationId?: string;
   iamEndpoint?: string;
@@ -211,6 +226,14 @@ export type TigrisStorageConfig = {
 };
 
 export async function getStorageConfig(options?: {
+  withCredentialProvider?: boolean;
+}): Promise<TigrisStorageConfig> {
+  const config = await resolveStorageConfig(options);
+  // Transport-level override that applies regardless of auth method.
+  return getEnvForcePathStyle() ? { ...config, forcePathStyle: true } : config;
+}
+
+async function resolveStorageConfig(options?: {
   withCredentialProvider?: boolean;
 }): Promise<TigrisStorageConfig> {
   const method = await resolveAuthMethod();
@@ -293,7 +316,7 @@ export async function getStorageConfig(options?: {
     case 'none': {
       // No valid auth method found — try auto-login in interactive terminals
       if (await triggerAutoLogin()) {
-        return getStorageConfig(options);
+        return resolveStorageConfig(options);
       }
       throw new Error(
         'Not authenticated. Please run "tigris login" or "tigris configure" first.'

--- a/packages/cli/test/auth/iam.test.ts
+++ b/packages/cli/test/auth/iam.test.ts
@@ -62,7 +62,7 @@ describe('getOAuthIAMConfig', () => {
       getAccessToken: vi.fn(),
     };
     vi.mocked(getAuthClient).mockReturnValue(
-      mockClient as ReturnType<typeof getAuthClient>
+      mockClient as unknown as ReturnType<typeof getAuthClient>
     );
 
     await expect(getOAuthIAMConfig(context)).rejects.toThrow(
@@ -78,7 +78,7 @@ describe('getOAuthIAMConfig', () => {
       getAccessToken: vi.fn().mockResolvedValue('tok-123'),
     };
     vi.mocked(getAuthClient).mockReturnValue(
-      mockClient as ReturnType<typeof getAuthClient>
+      mockClient as unknown as ReturnType<typeof getAuthClient>
     );
 
     const config = await getOAuthIAMConfig(context);
@@ -98,7 +98,7 @@ describe('getOAuthIAMConfig', () => {
       getAccessToken: vi.fn().mockResolvedValue('tok-123'),
     };
     vi.mocked(getAuthClient).mockReturnValue(
-      mockClient as ReturnType<typeof getAuthClient>
+      mockClient as unknown as ReturnType<typeof getAuthClient>
     );
 
     const config = await getOAuthIAMConfig(context);
@@ -117,7 +117,7 @@ describe('getIAMConfig', () => {
       getAccessToken: vi.fn().mockResolvedValue('tok-456'),
     };
     vi.mocked(getAuthClient).mockReturnValue(
-      mockClient as ReturnType<typeof getAuthClient>
+      mockClient as unknown as ReturnType<typeof getAuthClient>
     );
     vi.mocked(getSelectedOrganization).mockReturnValue('org-1');
 

--- a/packages/cli/test/auth/provider.test.ts
+++ b/packages/cli/test/auth/provider.test.ts
@@ -57,6 +57,7 @@ const ENV_KEYS = [
   'TIGRIS_STORAGE_ACCESS_KEY_ID',
   'TIGRIS_STORAGE_SECRET_ACCESS_KEY',
   'TIGRIS_STORAGE_ENDPOINT',
+  'TIGRIS_FORCE_PATH_STYLE',
 ];
 
 describe('resolveAuthMethod', () => {
@@ -363,5 +364,99 @@ describe('resolveAuthMethod', () => {
       secretAccessKey: 'AWS-SK',
       source: 'aws',
     });
+  });
+});
+
+describe('getEnvForcePathStyle', () => {
+  let saved: string | undefined;
+
+  beforeEach(() => {
+    saved = process.env.TIGRIS_FORCE_PATH_STYLE;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (saved !== undefined) {
+      process.env.TIGRIS_FORCE_PATH_STYLE = saved;
+    } else {
+      delete process.env.TIGRIS_FORCE_PATH_STYLE;
+    }
+  });
+
+  it.each(['1', 'true', 'TRUE', 'yes', 'on', '  On  '])(
+    'is true for %j',
+    async (value) => {
+      process.env.TIGRIS_FORCE_PATH_STYLE = value;
+      const { getEnvForcePathStyle } = await import(
+        '../../src/auth/provider.js'
+      );
+      expect(getEnvForcePathStyle()).toBe(true);
+    }
+  );
+
+  it.each(['0', 'false', 'no', 'off', '', 'nope'])(
+    'is false for %j',
+    async (value) => {
+      process.env.TIGRIS_FORCE_PATH_STYLE = value;
+      const { getEnvForcePathStyle } = await import(
+        '../../src/auth/provider.js'
+      );
+      expect(getEnvForcePathStyle()).toBe(false);
+    }
+  );
+
+  it('is false when unset', async () => {
+    delete process.env.TIGRIS_FORCE_PATH_STYLE;
+    const { getEnvForcePathStyle } = await import('../../src/auth/provider.js');
+    expect(getEnvForcePathStyle()).toBe(false);
+  });
+});
+
+describe('getStorageConfig forcePathStyle overlay', () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    tempHome = mkdtempSync(join(tmpdir(), 'tigris-test-'));
+    vi.resetModules();
+    savedEnv = {};
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    rmSync(tempHome, { recursive: true, force: true });
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] !== undefined) {
+        process.env[key] = savedEnv[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
+
+  it('adds forcePathStyle when TIGRIS_FORCE_PATH_STYLE is truthy', async () => {
+    writeRawConfig({ version: 2 });
+    process.env.TIGRIS_STORAGE_ACCESS_KEY_ID = 'TIG-AK';
+    process.env.TIGRIS_STORAGE_SECRET_ACCESS_KEY = 'TIG-SK';
+    process.env.TIGRIS_FORCE_PATH_STYLE = 'true';
+
+    const { getStorageConfig } = await import('../../src/auth/provider.js');
+    const config = await getStorageConfig();
+
+    expect(config.forcePathStyle).toBe(true);
+    expect(config.accessKeyId).toBe('TIG-AK');
+  });
+
+  it('omits forcePathStyle when TIGRIS_FORCE_PATH_STYLE is unset', async () => {
+    writeRawConfig({ version: 2 });
+    process.env.TIGRIS_STORAGE_ACCESS_KEY_ID = 'TIG-AK';
+    process.env.TIGRIS_STORAGE_SECRET_ACCESS_KEY = 'TIG-SK';
+
+    const { getStorageConfig } = await import('../../src/auth/provider.js');
+    const config = await getStorageConfig();
+
+    expect(config.forcePathStyle).toBeUndefined();
   });
 });

--- a/packages/cli/test/utils/exit.test.ts
+++ b/packages/cli/test/utils/exit.test.ts
@@ -109,7 +109,7 @@ describe('exitWithError', () => {
     setJsonMode(true);
     exitWithError(new Error('access denied'));
 
-    const jsonCalls = errorSpy.mock.calls.filter((call) => {
+    const jsonCalls = errorSpy.mock.calls.filter((call: unknown[]) => {
       try {
         JSON.parse(call[0] as string);
         return true;
@@ -132,7 +132,7 @@ describe('exitWithError', () => {
     setJsonMode(true);
     exitWithError(new Error('something went wrong'));
 
-    const jsonCalls = errorSpy.mock.calls.filter((call) => {
+    const jsonCalls = errorSpy.mock.calls.filter((call: unknown[]) => {
       try {
         JSON.parse(call[0] as string);
         return true;
@@ -150,7 +150,9 @@ describe('exitWithError', () => {
     setStderrTTY(true);
     exitWithError(new Error('access denied'));
 
-    const allOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    const allOutput = errorSpy.mock.calls
+      .map((c: unknown[]) => c.join(' '))
+      .join('\n');
     expect(allOutput).toContain('Next steps:');
     expect(allOutput).toContain('access-keys list');
   });
@@ -160,7 +162,9 @@ describe('exitWithError', () => {
     setJsonMode(false);
     exitWithError(new Error('access denied'));
 
-    const allOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    const allOutput = errorSpy.mock.calls
+      .map((c: unknown[]) => c.join(' '))
+      .join('\n');
     expect(allOutput).not.toContain('Next steps:');
   });
 });
@@ -220,7 +224,9 @@ describe('printNextActions', () => {
       { name: 'my-bucket' }
     );
 
-    const allOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    const allOutput = logSpy.mock.calls
+      .map((c: unknown[]) => c.join(' '))
+      .join('\n');
     expect(allOutput).toContain('Next steps:');
     expect(allOutput).toContain('my-bucket');
   });

--- a/packages/cli/test/utils/messages.test.ts
+++ b/packages/cli/test/utils/messages.test.ts
@@ -66,7 +66,9 @@ describe('messages', () => {
       setTTY(true);
       printFailure(ctx, 'something went wrong');
       expect(errorSpy).toHaveBeenCalled();
-      const allArgs = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+      const allArgs = errorSpy.mock.calls
+        .map((c: unknown[]) => c.join(' '))
+        .join('\n');
       expect(allArgs).toContain('✖');
       expect(allArgs).toContain('something went wrong');
     });

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "lib": ["ES2022"],
-    "types": ["node"],
+    "types": ["node", "vitest/globals"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
@@ -17,6 +17,6 @@
       "@utils/*": ["./src/utils/*"]
     }
   },
-  "include": ["src"],
+  "include": ["src", "test"],
   "exclude": ["src/cli-binary.ts", "src/command-registry.ts"]
 }


### PR DESCRIPTION
## Summary

CLI config improvements:

- **`TIGRIS_FORCE_PATH_STYLE` env var** — force S3 path-style addressing (bucket in the URL path instead of the host). Applied across *every* auth method via `getStorageConfig`, so it works for OAuth, credentials, environment, AWS-profile, and configured logins alike. Truthy values: `1`, `true`, `yes`, `on` (case-insensitive). Useful behind gateways/proxies that don't support virtual-hosted-style requests. The storage SDK's `createTigrisClient` already honored `forcePathStyle`; this just wires it through from the CLI.
- **Namespaced Auth0 env overrides** — `AUTH0_DOMAIN` / `AUTH0_CLIENT_ID` / `AUTH0_AUDIENCE` → `TIGRIS_AUTH0_*`, for consistency with the other `TIGRIS_*` variables. Defaults are unchanged.
- **CLI tsconfig now covers `test/`** — added `test` to `include` and `vitest/globals` to `types`, matching the pattern already used in `agent-kit` and `react`. Previously `test/` was outside every tsconfig, so editors fell back to an inferred project without Node types (e.g. `node:os` flagged as unresolved) and the build never typechecked tests. This surfaced 10 pre-existing type errors in three test files, which are fixed here so `tsc --noEmit` stays green.

## Behavior change

Renaming the Auth0 env vars is a breaking change for anyone who set `AUTH0_*` to point at a non-default (e.g. dev) auth tenant — they now need the `TIGRIS_AUTH0_*` names. These are undocumented internal overrides; defaults are untouched, so normal users are unaffected.

## Testing

- `tsc --noEmit` (src + tests): clean
- `biome check`: clean
- `vitest`: affected suites pass (provider, iam, exit, messages — 72 tests)

Includes a changeset (`@tigrisdata/cli`, minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk for typical users; custom Auth0 env users must switch to TIGRIS_AUTH0_* names.
> 
> **Overview**
> Adds **`TIGRIS_FORCE_PATH_STYLE`** so the CLI can force S3 path-style URLs (bucket in the path, not the host). `getStorageConfig` applies this on top of every auth path via `getEnvForcePathStyle()`; truthy values are `1`, `true`, `yes`, or `on` (case-insensitive). Documented in `AUTHENTICATION.md`.
> 
> OAuth overrides move from **`AUTH0_DOMAIN` / `AUTH0_CLIENT_ID` / `AUTH0_AUDIENCE`** to **`TIGRIS_AUTH0_*`** in `getAuth0Config`; built-in defaults are unchanged.
> 
> **`tsconfig.json`** now typechecks **`test/`** (`vitest/globals`, include `test`), with small test typing fixes so `tsc --noEmit` stays clean.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7919935446c743336da39dba86503a9a1de028d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->