### PR TITLE
feat(cli): improve tigris init and add npx tigris alias

### DIFF
--- a/.changeset/cli-init-existing-install-and-npx-alias.md
+++ b/.changeset/cli-init-existing-install-and-npx-alias.md
@@ -1,0 +1,24 @@
+---
+'@tigrisdata/cli': minor
+'tigris': minor
+---
+
+`tigris init` no longer offers to install a CLI you already have, and the CLI is
+now reachable unscoped as `npx tigris`.
+
+- The wizard installs the CLI only when `tigris` isn't on PATH; when it is, the
+  "Defaults" hint drops the `CLI - Global` step and the existing install is
+  brought up to date instead. Updating delegates to `tigris update`, which
+  matches how the CLI was installed (npm / Homebrew / standalone binary). If
+  that fails and leaves a CLI too old to serve the agent handoff (predating
+  `init --agent` in 3.5.0), the handoff falls back to `npx`.
+- Run through a package runner (`npx tigris init`, `pnpm dlx`), `init` no longer
+  counts the runner's own throwaway copy as an installed CLI — that copy is gone
+  the moment the runner exits, so it installs a real one instead.
+- `tigris init --agent` now opens with a single CLI step chosen from what `init`
+  detected — install when `tigris` is missing, update when it's present —
+  instead of printing both behind `if tigris isn't on $PATH` conditions for the
+  agent to evaluate.
+- New `tigris` package: an unscoped alias that hands straight over to
+  `@tigrisdata/cli`, so `npx tigris init` works without the scope. Every
+  command, flag and exit code behaves identically.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
     { "repo": "tigrisdata/storage" }
   ],
   "commit": false,
-  "fixed": [],
+  "fixed": [["@tigrisdata/cli", "tigris"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -14,6 +14,13 @@ You can also install CLI using brew
 brew install tigrisdata/tap/tigris
 ```
 
+To try it without installing anything, run it through the unscoped
+[`tigris`](https://www.npmjs.com/package/tigris) alias:
+
+```bash
+npx tigris init
+```
+
 ## Usage
 
 ```

--- a/packages/cli/src/lib/init/index.ts
+++ b/packages/cli/src/lib/init/index.ts
@@ -1,7 +1,8 @@
 import { getOption } from '@utils/options.js';
 
 import { runInteractive } from './interactive.js';
-import { AGENT_SETUP } from './plan.js';
+import { buildAgentSetup } from './plan.js';
+import { getInstalledCliVersion, withoutEphemeralBins } from './shared.js';
 
 /**
  * `tigris init` — two modes:
@@ -13,15 +14,23 @@ import { AGENT_SETUP } from './plan.js';
 export default async function init(options: Record<string, unknown>) {
   const agentMode = getOption<boolean>(options, ['agent']);
 
-  // init manages CLI currency itself (ensureCli here, steps 1–2 in the recipe),
+  // init manages CLI currency itself (updateCli here, step 1 in the recipe),
   // so suppress the CLI's post-command update-notifier — it's redundant and, on
   // a TTY, would print mid-wizard or pollute the --agent recipe on stdout.
   process.env.TIGRIS_NO_UPDATE_CHECK = '1';
+
+  // Under `npx tigris init` this process *is* the CLI, reached through a bin
+  // directory npx drops from PATH as soon as it exits. Strip those entries for
+  // the whole command so no probe, update or handoff below can mistake that
+  // throwaway copy for an installed CLI.
+  process.env.PATH = withoutEphemeralBins(process.env.PATH);
 
   if (!agentMode) {
     await runInteractive();
     return;
   }
 
-  console.log(AGENT_SETUP);
+  // Reached through `npx` (no `tigris` on PATH) the recipe has to install the
+  // CLI first; otherwise it just keeps the existing one current.
+  console.log(buildAgentSetup(getInstalledCliVersion() !== null));
 }

--- a/packages/cli/src/lib/init/interactive.ts
+++ b/packages/cli/src/lib/init/interactive.ts
@@ -3,27 +3,30 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname } from 'node:path';
 import * as p from '@clack/prompts';
-import { fetchLatestVersion, isNewerVersion } from '@utils/update-check.js';
 
 import {
   buildSkillsArgs,
+  defaultsHint,
   detectEditors,
   type EditorInfo,
+  getInstalledCliVersion,
   type InstallLocation,
   MCP_SERVER_NAME,
   mergeMcpServers,
   resolveMcpTarget,
   SUPPORTED_EDITORS,
   skillsDirsFor,
+  spawnOpts,
   TIGRIS_SKILLS,
   upsertTomlServer,
 } from './shared.js';
 
 /**
- * Interactive setup (`tigris init`): pick the AI editor(s), optionally install
- * the CLI, point the editors at the Tigris remote MCP server, and install the
- * chosen agent skills — then hand the user a command to give their AI agent.
- * No login: the remote MCP server authenticates in-browser on first connect.
+ * Interactive setup (`tigris init`): pick the AI editor(s), install the CLI if
+ * it's missing, point the editors at the Tigris remote MCP server, and install
+ * the chosen agent skills — then hand the user a command to give their AI
+ * agent. No login: the remote MCP server authenticates in-browser on first
+ * connect.
  */
 export async function runInteractive() {
   if (!process.stdin.isTTY) {
@@ -52,14 +55,18 @@ export async function runInteractive() {
   if (p.isCancel(editorIds)) return cancel();
   const editors = SUPPORTED_EDITORS.filter((e) => editorIds.includes(e.id));
 
-  // 2. Defaults or customize (installation targets/scopes).
+  // 2. Is `tigris` already on PATH? Decides whether this run installs the CLI
+  // at all — and so whether the defaults hint below advertises a CLI step.
+  const installedCli = getInstalledCliVersion();
+
+  // 3. Defaults or customize (installation targets/scopes).
   const mode = await p.select({
     message: 'What would you like to install?',
     options: [
       {
         value: 'defaults',
         label: 'Defaults',
-        hint: 'CLI - Global, MCP - Global, Skills - Project',
+        hint: defaultsHint(installedCli !== null),
       },
       { value: 'custom', label: 'Customize installation' },
     ],
@@ -75,7 +82,7 @@ export async function runInteractive() {
     skillsLocation = await location('Agent skills:', 'project');
   }
 
-  // 3. Which skills to install. Defaults installs every skill without asking;
+  // 4. Which skills to install. Defaults installs every skill without asking;
   // only the custom flow prompts (recommended ones pre-checked).
   let skillIds: string[] = TIGRIS_SKILLS.map((s) => s.id);
   if (mode === 'custom' && skillsLocation !== 'skip') {
@@ -91,10 +98,18 @@ export async function runInteractive() {
     skillIds = picked;
   }
 
-  // 4. Tigris CLI — install if missing, update if outdated, skip if current.
-  const cliAvailable = await ensureCli();
+  // 5. Tigris CLI — install it when missing, otherwise bring it up to date.
+  // A successful update leaves a CLI new enough for the handoff; only when it
+  // fails is it worth checking what's actually there.
+  let cliAvailable: boolean;
+  if (installedCli) {
+    cliAvailable =
+      updateCli(installedCli) || installedCliCanHandOff(installedCli);
+  } else {
+    cliAvailable = installCli();
+  }
 
-  // 5. Point each editor at the remote MCP server.
+  // 6. Point each editor at the remote MCP server.
   if (mcpLocation === 'skip') {
     p.log.info('MCP server: skipped');
   } else {
@@ -103,7 +118,7 @@ export async function runInteractive() {
     }
   }
 
-  // 6. Install the chosen Tigris agent skills. Output is captured (the skills
+  // 7. Install the chosen Tigris agent skills. Output is captured (the skills
   // tool prints a big banner); we report the destination dirs ourselves.
   if (skillsLocation === 'skip' || skillIds.length === 0) {
     p.log.info('Agent skills: skipped');
@@ -124,10 +139,10 @@ export async function runInteractive() {
     }
   }
 
-  // 7. Hand off to the agent — use the installed CLI, or npx if unavailable.
+  // 8. Hand off to the agent — use the installed CLI, or npx if unavailable.
   const runner = cliAvailable
     ? 'tigris init --agent'
-    : 'npx @tigrisdata/cli init --agent';
+    : 'npx tigris init --agent';
   p.note(runner, 'Paste this to your AI coding agent to finish setup');
   p.outro('Your agent will authenticate with Tigris in-browser on first use.');
 }
@@ -232,93 +247,69 @@ function stringFields(entry: Record<string, unknown>): Record<string, string> {
   return out;
 }
 
-/** The globally-installed `tigris` CLI version, or null if not on PATH. */
-function getInstalledCliVersion(): string | null {
-  const r = spawnSync('tigris', ['--version'], spawnOpts());
-  if (r.error || r.status !== 0 || !r.stdout) return null;
-  const v = r.stdout.trim().split('\n')[0].trim();
-  return /^\d+\.\d+\.\d+/.test(v) ? v : null;
-}
-
 /**
- * Ensure the Tigris CLI is present and current: install it if missing, update
- * it if a newer version is published, and do nothing (no step) if it's already
- * the latest. Returns whether an up-to-date `tigris` command is available
- * afterwards (false if an install/update was attempted and failed).
+ * Install the Tigris CLI globally. Returns whether a `tigris` command is
+ * available afterwards — a zero exit doesn't guarantee it, since npm's global
+ * bin may not be on PATH, and the handoff should fall back to `npx` if so.
  */
-async function ensureCli(): Promise<boolean> {
-  const installed = getInstalledCliVersion();
-  const latest = await fetchLatestVersionCapped(3000);
-
-  if (!installed) {
-    const result = runCommand(
-      'npm',
-      ['install', '-g', '@tigrisdata/cli', '--ignore-scripts'],
-      'Installing Tigris CLI (global)'
+function installCli(): boolean {
+  const result = runCommand(
+    'npm',
+    ['install', '-g', '@tigrisdata/cli', '--ignore-scripts'],
+    'Installing Tigris CLI (global)'
+  );
+  if (!reportIfFailed(result)) return false;
+  if (getInstalledCliVersion() === null) {
+    p.log.warn(
+      'Tigris CLI installed but not on PATH — the agent handoff will use npx.'
     );
-    if (!reportIfFailed(result)) return false;
-    // A zero exit doesn't guarantee `tigris` is resolvable — npm's global bin
-    // may not be on PATH. Confirm before recommending it over `npx`.
-    if (getInstalledCliVersion() === null) {
-      p.log.warn(
-        'Tigris CLI installed but not on PATH — the agent handoff will use npx.'
-      );
-      return false;
-    }
-    return true;
+    return false;
   }
-
-  if (latest && isNewerVersion(installed, latest)) {
-    // Delegate to the installed CLI's own updater so we respect how it was
-    // installed (npm / Homebrew / standalone binary) rather than forcing npm,
-    // which could fail or leave a second copy on PATH. If it fails, report
-    // unavailable so the handoff falls back to `npx` (an outdated CLI may
-    // predate `init`).
-    return reportIfFailed(
-      runCommand(
-        'tigris',
-        ['update'],
-        `Updating Tigris CLI ${installed} → ${latest}`
-      )
-    );
-  }
-
-  // Installed and current (or latest unknown) — no CLI step shown.
   return true;
 }
 
 /**
- * Latest published version, or null if the registry check errors or exceeds
- * `ms`. Never rejects: a late `fetchLatestVersion` failure is swallowed (so it
- * can't surface as an unhandled rejection). The timeout timer is intentionally
- * left ref'd — it's what keeps the process alive during this await (the fetch
- * socket is unref'd) — and is always cleared in `finally`, so the fetch winning
- * adds no delay and a still-pending fetch can't hold the process open after.
+ * Bring an existing CLI up to date. Delegates to the CLI's own `update`, which
+ * runs its own registry check and picks the upgrade path matching how it was
+ * installed (npm / Homebrew / standalone binary) — forcing `npm install -g`
+ * here could fail or leave a second copy on PATH. A no-op when already current,
+ * so there's nothing to check before calling it.
  */
-async function fetchLatestVersionCapped(ms: number): Promise<string | null> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    return await Promise.race([
-      fetchLatestVersion({ unref: true }).catch(() => null),
-      new Promise<null>((resolve) => {
-        timer = setTimeout(() => resolve(null), ms);
-      }),
-    ]);
-  } finally {
-    if (timer) clearTimeout(timer);
+function updateCli(installed: string): boolean {
+  const ok = reportIfFailed(
+    runCommand(
+      'tigris',
+      ['update'],
+      `Checking for Tigris CLI updates (${installed})`
+    )
+  );
+  if (!ok) return false;
+  // Report the jump only when there was one — `update` is usually a no-op.
+  const updated = getInstalledCliVersion();
+  if (updated && updated !== installed) {
+    p.log.success(`Tigris CLI ${installed} → ${updated}`);
   }
+  return true;
 }
 
 /**
- * spawnSync options. On Windows npm/npx/tigris are `.cmd` shims that need a
- * shell to resolve; use `shell: true` (cmd.exe) rather than PowerShell, which
- * treats a leading `@` (as in `@tigrisdata/cli`) as its splat operator.
+ * Whether the CLI on PATH can serve the agent handoff. Only consulted when
+ * `update` failed (offline, no write permission), which can leave a CLI
+ * predating `init --agent` (< 3.5.0) in place — still a perfectly good
+ * `tigris`, but handing the agent `tigris init --agent` would just error, so
+ * the handoff falls back to `npx`. Probed rather than version-matched, so it
+ * stays correct as the recipe moves; `--agent` only writes to stdout, which is
+ * captured and discarded.
  */
-function spawnOpts() {
-  return {
-    encoding: 'utf8' as const,
-    ...(process.platform === 'win32' ? { shell: true } : {}),
-  };
+function installedCliCanHandOff(installed: string): boolean {
+  const r = spawnSync('tigris', ['init', '--agent'], spawnOpts());
+  if (r.error || r.status !== 0) {
+    p.log.warn(
+      `Tigris CLI ${installed} predates \`init --agent\` — the agent handoff will use npx.`
+    );
+    return false;
+  }
+  return true;
 }
 
 /** Run a command under a spinner; capture output and surface it on failure. */

--- a/packages/cli/src/lib/init/plan.ts
+++ b/packages/cli/src/lib/init/plan.ts
@@ -5,17 +5,26 @@
  * coding agent to follow, running the listed `tigris` commands itself and
  * making decisions per step.
  */
-export const AGENT_SETUP = `Help the user set up their project with Tigris:
 
-1. If \`tigris\` isn't on $PATH (\`command -v tigris\`), ask permission, then \`npm install -g @tigrisdata/cli --ignore-scripts\`.
-2. If \`tigris\` is on $PATH, ensure it's latest version using \`tigris update\`.
-3. Check if the user is already authenticated using \`tigris whoami\`. If not, authenticate using \`tigris login oauth\`.
-4. Run \`tigris orgs list --format json\`. If there's more than one org, ask which to use, then make it active with \`tigris orgs select <org>\` so the following commands target it.
-5. Infer the project name from metadata (package.json, go.mod, pyproject.toml, ...). Check \`tigris buckets list --format json\` first; if the bucket is absent, \`tigris buckets create <name> --format json\`. Ask the user whenever anything is ambiguous.
-6. Create the access key into a private temp file (overwrite, never append), then print only the ID:
-   \`umask 077; tmpfile=$(mktemp); tigris access-keys create <username>-<project>-devel --format json > "$tmpfile" && jq -r '.id' < "$tmpfile"\`
-7. Grant bucket access: \`tigris access-keys assign <id> --bucket <bucket> --role Editor --format json\`.
-8. Detect whether the code uses the Tigris SDK or the AWS SDK, then have a small script append the right vars to .env, reading \`.id\`/\`.secret\` from the temp file. Do NOT read the secret into your context — append it via script. Delete the temp file when done: \`rm -f "$tmpfile"\`.
+/**
+ * The recipe always opens with exactly one CLI step, picked from what `init`
+ * already detected rather than left to the agent to work out. Install when
+ * `tigris` isn't on PATH — i.e. the recipe was reached through `npx`; update
+ * when it is. `tigris update` runs its own version check and knows how the CLI
+ * was installed, so it's safe to run unconditionally.
+ */
+const INSTALL_STEP =
+  'Ask permission, then install the CLI: `npm install -g @tigrisdata/cli --ignore-scripts`.';
+const UPDATE_STEP = 'Ensure the CLI is on the latest version: `tigris update`.';
+
+const SETUP_STEPS = [
+  'Check if the user is already authenticated using `tigris whoami`. If not, authenticate using `tigris login oauth`.',
+  "Run `tigris orgs list --format json`. If there's more than one org, ask which to use, then make it active with `tigris orgs select <org>` so the following commands target it.",
+  'Infer the project name from metadata (package.json, go.mod, pyproject.toml, ...). Check `tigris buckets list --format json` first; if the bucket is absent, `tigris buckets create <name> --format json`. Ask the user whenever anything is ambiguous.',
+  `Create the access key into a private temp file (overwrite, never append), then print only the ID:
+   \`umask 077; tmpfile=$(mktemp); tigris access-keys create <username>-<project>-devel --format json > "$tmpfile" && jq -r '.id' < "$tmpfile"\``,
+  'Grant bucket access: `tigris access-keys assign <id> --bucket <bucket> --role Editor --format json`.',
+  `Detect whether the code uses the Tigris SDK or the AWS SDK, then have a small script append the right vars to .env, reading \`.id\`/\`.secret\` from the temp file. Do NOT read the secret into your context — append it via script. Delete the temp file when done: \`rm -f "$tmpfile"\`.
 
    Tigris SDK (@tigrisdata/storage, storage-go):
      TIGRIS_STORAGE_ACCESS_KEY_ID     = .id
@@ -28,8 +37,8 @@ export const AGENT_SETUP = `Help the user set up their project with Tigris:
      AWS_ENDPOINT_URL_S3     = https://t3.storage.dev    (required)
      AWS_ENDPOINT_URL_IAM    = https://iam.storageapi.dev (required)
      AWS_REGION              = auto                        (required)
-
-9. Congratulate the user and point them to:
+`,
+  `Congratulate the user and point them to:
    - JS:    https://www.tigrisdata.com/docs/sdks/tigris/
    - Go:    https://pkg.go.dev/github.com/tigrisdata/storage-go
    - Docs:  https://www.tigrisdata.com/docs/
@@ -38,5 +47,16 @@ export const AGENT_SETUP = `Help the user set up their project with Tigris:
 
    Suggest adding to their agent config:
      > ## Tigris object storage
-     > This project uses Tigris. For any Tigris questions, consult https://www.tigrisdata.com/llms.txt before acting; look it up rather than relying on memory.
-`;
+     > This project uses Tigris. For any Tigris questions, consult https://www.tigrisdata.com/llms.txt before acting; look it up rather than relying on memory.`,
+];
+
+/**
+ * Render the recipe for the CLI state `init` found. Resolving install-vs-update
+ * here rather than printing both behind `if tigris isn't on $PATH` conditions
+ * leaves the agent one unambiguous instruction it can't misread.
+ */
+export function buildAgentSetup(cliInstalled: boolean): string {
+  const steps = [cliInstalled ? UPDATE_STEP : INSTALL_STEP, ...SETUP_STEPS];
+  const body = steps.map((step, i) => `${i + 1}. ${step}`).join('\n');
+  return `Help the user set up their project with Tigris:\n\n${body}\n`;
+}

--- a/packages/cli/src/lib/init/shared.ts
+++ b/packages/cli/src/lib/init/shared.ts
@@ -1,5 +1,7 @@
+import { spawnSync } from 'node:child_process';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { delimiter, join, normalize, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   applyEdits,
   modify,
@@ -18,6 +20,117 @@ export type AgentTarget =
   | 'zed'
   | 'roo'
   | 'opencode';
+
+// ---------------------------------------------------------------------------
+// Installed CLI
+// ---------------------------------------------------------------------------
+
+/**
+ * spawnSync options. On Windows npm/npx/tigris are `.cmd` shims that need a
+ * shell to resolve; use `shell: true` (cmd.exe) rather than PowerShell, which
+ * treats a leading `@` (as in `@tigrisdata/cli`) as its splat operator.
+ */
+export function spawnOpts() {
+  return {
+    encoding: 'utf8' as const,
+    ...(process.platform === 'win32' ? { shell: true } : {}),
+  };
+}
+
+/**
+ * The `node_modules/.bin` this process is running out of, or null when it isn't
+ * inside a `node_modules` tree (a compiled binary, or the repo during dev).
+ *
+ * Package runners all work the same way: unpack the package into a throwaway
+ * tree and put that tree's `.bin` on PATH for one run. Deriving the directory
+ * from our own location catches every one of them — `npx`, `pnpm dlx`,
+ * `yarn dlx`, `bunx` — without tracking cache layouts that differ per manager
+ * and move between versions.
+ *
+ * Harmless for a global npm install: its module lives in
+ * `<prefix>/lib/node_modules/`, while the `tigris` on PATH is linked into
+ * `<prefix>/bin/`, so the directory named here isn't the one that matters.
+ */
+function ownPackageBinDir(): string | null {
+  let self: string;
+  try {
+    self = fileURLToPath(import.meta.url);
+  } catch {
+    return null;
+  }
+  // First `node_modules`, not last: under pnpm the real file sits deeper, in
+  // `node_modules/.pnpm/<pkg>/node_modules/...`, and it's the outermost tree
+  // whose `.bin` the runner exposes.
+  const i = self.indexOf(`${sep}node_modules${sep}`);
+  return i === -1 ? null : join(self.slice(0, i), 'node_modules', '.bin');
+}
+
+/**
+ * A PATH entry that looks like a package runner's cache even when it isn't the
+ * one we're running from — `npx` unpacks into `~/.npm/_npx/<hash>/`, `pnpm dlx`
+ * into `<cache>/dlx/<hash>/<id>/`, older `yarn dlx` into `dlx-<n>/`. A backstop
+ * behind ownPackageBinDir, which is the mechanism that actually generalises.
+ */
+const EPHEMERAL_BIN_DIR = /[\\/](?:_npx|dlx(?:-[^\\/]*)?)(?:[\\/]|$)/;
+
+/**
+ * `PATH` with package-runner bin directories dropped.
+ *
+ * `npx tigris init` puts its own throwaway `.bin` first on PATH, so probing for
+ * `tigris` finds the very copy that disappears the moment npx exits — and init
+ * would tell the agent to `tigris update` a CLI that was never installed.
+ * Nothing init spawns wants that copy: it either needs the persistent CLI or
+ * needs to know there isn't one.
+ *
+ * `ownBinDir` is injectable so this stays a pure function under test.
+ */
+export function withoutEphemeralBins(
+  path: string | undefined,
+  ownBinDir: string | null = ownPackageBinDir()
+): string {
+  const own = ownBinDir === null ? null : canonicalDir(ownBinDir);
+  return (path ?? '')
+    .split(delimiter)
+    .filter(
+      (dir) =>
+        dir !== '' &&
+        !EPHEMERAL_BIN_DIR.test(dir) &&
+        (own === null || canonicalDir(dir) !== own)
+    )
+    .join(delimiter);
+}
+
+/**
+ * A PATH entry in comparable form — normalized, no trailing separator, and
+ * case-folded on Windows, where paths are case-insensitive. PATH entries are
+ * hand-written often enough that `.../.bin` and `.../.bin/` both show up.
+ */
+function canonicalDir(dir: string): string {
+  const n = normalize(dir);
+  const trimmed = n.length > 1 ? n.replace(/[\\/]+$/, '') : n;
+  return process.platform === 'win32' ? trimmed.toLowerCase() : trimmed;
+}
+
+/** The globally-installed `tigris` CLI version, or null if not on PATH. */
+export function getInstalledCliVersion(): string | null {
+  const r = spawnSync('tigris', ['--version'], spawnOpts());
+  if (r.error || r.status !== 0 || !r.stdout) return null;
+  const v = r.stdout.trim().split('\n')[0].trim();
+  return /^\d+\.\d+\.\d+/.test(v) ? v : null;
+}
+
+/**
+ * What the wizard's "Defaults" option promises to do. The CLI is only listed
+ * when it isn't installed yet — advertising a step this run won't take reads
+ * as though `init` is about to reinstall a CLI the user already has.
+ */
+export function defaultsHint(cliInstalled: boolean): string {
+  return [
+    ...(cliInstalled ? [] : ['CLI - Global']),
+    'MCP - Global',
+    'Skills - Project',
+  ].join(', ');
+}
 
 // ---------------------------------------------------------------------------
 // Platform paths

--- a/packages/cli/src/specs.yaml
+++ b/packages/cli/src/specs.yaml
@@ -99,7 +99,7 @@ commands:
     description: Connect Tigris to your AI coding agent — MCP server config and agent skills
     examples:
       - "tigris init"
-      - "npx @tigrisdata/cli init"
+      - "npx tigris init"
       - "tigris init --agent"
     messages:
       onStart: ''

--- a/packages/cli/test/lib/init/plan.test.ts
+++ b/packages/cli/test/lib/init/plan.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildAgentSetup } from '../../../src/lib/init/plan.js';
+
+/** The leading "N. " of every top-level step, in order. */
+function stepNumbers(recipe: string): number[] {
+  return [...recipe.matchAll(/^(\d+)\. /gm)].map((m) => Number(m[1]));
+}
+
+describe('buildAgentSetup', () => {
+  it('leads with an update, not an install, when the CLI is on PATH', () => {
+    const recipe = buildAgentSetup(true);
+    expect(recipe).toMatch(
+      /^1\. Ensure the CLI is on the latest version: `tigris update`\.$/m
+    );
+    expect(recipe).not.toContain('npm install -g @tigrisdata/cli');
+  });
+
+  it('leads with an install, not an update, when the CLI is missing', () => {
+    const recipe = buildAgentSetup(false);
+    expect(recipe).toMatch(
+      /^1\. Ask permission, then install the CLI: `npm install -g @tigrisdata\/cli --ignore-scripts`\.$/m
+    );
+    expect(recipe).not.toContain('tigris update');
+  });
+
+  it('opens with exactly one CLI step in both modes', () => {
+    for (const cliInstalled of [true, false]) {
+      const recipe = buildAgentSetup(cliInstalled);
+      // Step 2 onwards is the shared setup, which never touches the CLI itself.
+      expect(recipe).toMatch(
+        /^2\. Check if the user is already authenticated/m
+      );
+    }
+  });
+
+  it('numbers steps consecutively from 1 in both modes', () => {
+    for (const cliInstalled of [true, false]) {
+      const numbers = stepNumbers(buildAgentSetup(cliInstalled));
+      expect(numbers.length).toBeGreaterThan(1);
+      expect(numbers).toEqual(numbers.map((_, i) => i + 1));
+    }
+  });
+
+  it('swaps the CLI step without changing the step count', () => {
+    expect(stepNumbers(buildAgentSetup(false))).toHaveLength(
+      stepNumbers(buildAgentSetup(true)).length
+    );
+  });
+
+  it('keeps every step after the CLI step identical', () => {
+    const afterCliStep = (recipe: string) =>
+      recipe.split(/^2\. /m)[1] ?? recipe;
+    expect(afterCliStep(buildAgentSetup(false))).toBe(
+      afterCliStep(buildAgentSetup(true))
+    );
+  });
+
+  it('indents continuation lines to clear the step number', () => {
+    // Steps stay single-digit, so multi-line bodies line up under "N. ".
+    const recipe = buildAgentSetup(true);
+    expect(stepNumbers(recipe).every((n) => n < 10)).toBe(true);
+    expect(recipe).toContain('\n   - Docs:  https://www.tigrisdata.com/docs/');
+  });
+});

--- a/packages/cli/test/lib/init/shared.test.ts
+++ b/packages/cli/test/lib/init/shared.test.ts
@@ -1,0 +1,125 @@
+import { delimiter } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  defaultsHint,
+  withoutEphemeralBins,
+} from '../../../src/lib/init/shared.js';
+
+describe('defaultsHint', () => {
+  it('offers to install the CLI when it is missing', () => {
+    expect(defaultsHint(false)).toBe(
+      'CLI - Global, MCP - Global, Skills - Project'
+    );
+  });
+
+  it('drops the CLI step once the CLI is installed', () => {
+    expect(defaultsHint(true)).toBe('MCP - Global, Skills - Project');
+  });
+
+  it('always promises the MCP and skills steps', () => {
+    for (const cliInstalled of [true, false]) {
+      const hint = defaultsHint(cliInstalled);
+      expect(hint).toContain('MCP - Global');
+      expect(hint).toContain('Skills - Project');
+    }
+  });
+});
+
+describe('withoutEphemeralBins', () => {
+  const path = (...dirs: string[]) => dirs.join(delimiter);
+  /**
+   * Pattern-only cases: pin the own-bin directory to null so they exercise
+   * EPHEMERAL_BIN_DIR alone and don't depend on where the suite runs from.
+   */
+  const byPattern = (p: string | undefined) => withoutEphemeralBins(p, null);
+
+  it("drops npx's throwaway bin directory", () => {
+    // The real shape: `npx tigris init` puts this first on PATH, and it is gone
+    // the moment npx exits — so a `tigris` found there is not an install.
+    expect(
+      byPattern(
+        path(
+          '/Users/me/.npm/_npx/f753ea211850000b/node_modules/.bin',
+          '/usr/local/bin'
+        )
+      )
+    ).toBe('/usr/local/bin');
+  });
+
+  it("drops pnpm dlx's cache directory", () => {
+    // Measured from a real `pnpm dlx` run: a bare `dlx/` segment, not `dlx-<n>`.
+    expect(
+      byPattern(
+        path(
+          '/Users/me/Library/Caches/pnpm/dlx/f9e99c43/19fcbba383c-53a2/node_modules/.bin',
+          '/usr/bin'
+        )
+      )
+    ).toBe('/usr/bin');
+  });
+
+  it("drops older yarn dlx's temp directory", () => {
+    expect(
+      byPattern(path('/tmp/dlx-12345/node_modules/.bin', '/usr/bin'))
+    ).toBe('/usr/bin');
+  });
+
+  it('drops the bin directory this process was launched from', () => {
+    // The runner-agnostic guard: whatever cache layout a runner uses, the
+    // directory it puts on PATH is the `.bin` beside our own install.
+    const own = '/tmp/xfs-9f2a1c/node_modules/.bin'; // yarn berry: no _npx, no dlx
+    expect(withoutEphemeralBins(path(own, '/usr/bin'), own)).toBe('/usr/bin');
+  });
+
+  it('ignores a trailing separator when matching its own bin directory', () => {
+    const own = '/tmp/xfs-9f2a1c/node_modules/.bin';
+    expect(withoutEphemeralBins(path(`${own}/`, '/usr/bin'), own)).toBe(
+      '/usr/bin'
+    );
+  });
+
+  it("keeps a global install's bin when its module dir is excluded", () => {
+    // ownPackageBinDir names <prefix>/lib/node_modules/.bin, but the real
+    // `tigris` is linked into <prefix>/bin — that must survive.
+    const own = '/Users/me/.npm-global/lib/node_modules/.bin';
+    expect(
+      withoutEphemeralBins(path('/Users/me/.npm-global/bin', '/usr/bin'), own)
+    ).toBe(path('/Users/me/.npm-global/bin', '/usr/bin'));
+  });
+
+  it('keeps real install directories, including npm-global', () => {
+    const real = path(
+      '/Users/me/.npm-global/bin',
+      '/opt/homebrew/bin',
+      '/usr/local/bin',
+      '/usr/bin'
+    );
+    expect(byPattern(real)).toBe(real);
+  });
+
+  it('matches whole path segments, not substrings', () => {
+    // `_npxtools` is somebody's real directory, not an npx cache.
+    const real = path('/Users/me/_npxtools/bin', '/srv/dlxtools/bin');
+    expect(byPattern(real)).toBe(real);
+  });
+
+  it('handles Windows-style backslash separators', () => {
+    // Drive letter omitted on purpose: `delimiter` is ':' on POSIX, so "C:\..."
+    // would split at the colon here. What matters is that '\' reads as a path
+    // separator, so `_npx` is matched as a segment on Windows too.
+    expect(
+      byPattern(
+        path(
+          '\\Users\\me\\AppData\\npm-cache\\_npx\\abc\\node_modules\\.bin',
+          '/usr/bin'
+        )
+      )
+    ).toBe('/usr/bin');
+  });
+
+  it('drops empty entries and tolerates an unset PATH', () => {
+    expect(byPattern(path('', '/usr/bin', ''))).toBe('/usr/bin');
+    expect(byPattern(undefined)).toBe('');
+  });
+});

--- a/packages/tigris/README.md
+++ b/packages/tigris/README.md
@@ -1,0 +1,20 @@
+# tigris
+
+Command line interface for [Tigris](https://www.tigrisdata.com/) object storage.
+
+## Get started
+
+```bash
+npx tigris init
+```
+
+Connects Tigris to your AI coding agent: installs the CLI, points your editor
+at the Tigris MCP server, and installs the Tigris agent skills.
+
+## Documentation
+
+[Tigris CLI docs](https://www.tigrisdata.com/docs/cli/)
+
+## License
+
+MIT

--- a/packages/tigris/bin.js
+++ b/packages/tigris/bin.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+// `tigris` is an unscoped alias for `@tigrisdata/cli`, so `npx tigris init`
+// works without anyone having to remember the scope. Importing the CLI's entry
+// point runs it in this process — argv, stdio, signals and the exit code all
+// pass through unchanged, and `--version`/help still report the real CLI
+// (Commander takes its program name from the specs, not from this file).
+import '@tigrisdata/cli';

--- a/packages/tigris/package.json
+++ b/packages/tigris/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "tigris",
+  "version": "3.6.1",
+  "description": "Unscoped alias for @tigrisdata/cli — the command line interface for Tigris object storage",
+  "type": "module",
+  "bin": {
+    "tigris": "./bin.js",
+    "t3": "./bin.js"
+  },
+  "files": [
+    "bin.js",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "publint": "publint"
+  },
+  "keywords": [
+    "cli",
+    "object",
+    "storage",
+    "tigris",
+    "blob"
+  ],
+  "author": "Tigris Data",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tigrisdata/storage.git",
+    "directory": "packages/tigris"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@tigrisdata/cli": "workspace:^"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,12 @@ importers:
         specifier: ^17.4.2
         version: 17.4.2
 
+  packages/tigris:
+    dependencies:
+      '@tigrisdata/cli':
+        specifier: workspace:^
+        version: link:../cli
+
   shared:
     dependencies:
       '@aws-crypto/sha256-js':
@@ -1097,6 +1103,12 @@ packages:
   '@publint/pack@0.1.6':
     resolution: {integrity: sha512-3uVNyGcVplhPZSLVyeIpL7+cIRn1YCSNHLG/rUIlBQMVH8YuN9++YF+5+UDIIO9RW98dujiUoTltO7RDB5bFJA==}
     engines: {node: '>=18'}
+
+  '@rolldown/binding-android-arm64@1.2.2':
+    resolution: {integrity: sha512-l7x215OGvo1s52JWmR8U/DAVzEDWBCIbTm28aeJV/WDTSHgcKXaZTuBT0hJMs5NggilfJTW3clZVvd24yfKJxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
 
   '@rolldown/binding-darwin-arm64@1.2.2':
     resolution: {integrity: sha512-9u9Xv6c1AJZT0FfwH5vrMG5Jjcwhc1MlyrPu0XfTqkzsmqfks2M6W/o5XwAJgVVN/jHpqqngC1WevHKKTIUtIA==}
@@ -4316,6 +4328,9 @@ snapshots:
     dependencies:
       tinyexec: 1.3.0
 
+  '@rolldown/binding-android-arm64@1.2.2':
+    optional: true
+
   '@rolldown/binding-darwin-arm64@1.2.2':
     optional: true
 
@@ -6013,6 +6028,7 @@ snapshots:
       '@oxc-project/types': 0.142.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.2
       '@rolldown/binding-darwin-arm64': 1.2.2
       '@rolldown/binding-darwin-x64': 1.2.2
       '@rolldown/binding-freebsd-x64': 1.2.2


### PR DESCRIPTION
## Summary

Two changes to `tigris init`, plus the package that makes `npx tigris init` work.

### `init` no longer offers to install a CLI you already have

The wizard advertised `CLI - Global` in its "Defaults" hint and ran a CLI step on every run, regardless of whether `tigris` was already on PATH. Now:

- The PATH check moved ahead of the mode prompt, so the hint reflects reality:

  | | hint |
  |---|---|
  | `tigris` on PATH | `MCP - Global, Skills - Project` |
  | not on PATH | `CLI - Global, MCP - Global, Skills - Project` |

- An existing install is **updated** rather than reinstalled, by delegating to `tigris update`. That command runs its own registry check and `getUpdateCommand()` picks the path matching how the CLI was installed — `npm install -g`, `brew upgrade tigris`, or the curl/PowerShell installer for standalone binaries. Forcing `npm install -g` from `init` could fail or leave a second copy on PATH. It's a no-op when current, so nothing needs checking before calling it — which let the bespoke `fetchLatestVersionCapped` helper and its ref'd-timer handling go away entirely.

- If that update fails (offline, no write permission), it can leave a CLI predating `init --agent` in place. Handing such an agent `tigris init --agent` just errors, so the handoff degrades to `npx`. Detected by probing (`--agent` only writes to stdout, captured and discarded) rather than comparing against a hardcoded `3.5.0`, so it stays correct as the recipe moves.

### `init --agent` picks the CLI step instead of delegating the decision

The recipe used to print both branches and let the agent evaluate them:

```
1. If `tigris` isn't on $PATH (`command -v tigris`), ask permission, then `npm install -g ...`.
2. If `tigris` is on $PATH, ensure it's latest version using `tigris update`.
3. Check if the user is already authenticated ...
```

`init` already knows which applies, so it now emits one unambiguous step and renumbers the rest:

```
tigris on PATH:   1. Ensure the CLI is on the latest version: `tigris update`.
not on PATH:      1. Ask permission, then install the CLI: `npm install -g @tigrisdata/cli --ignore-scripts`.
```

### New `tigris` package

An unscoped alias so the CLI is reachable without the scope:

```bash
npx tigris init
```

`bin.js` is one line — `import '@tigrisdata/cli'` — which runs the CLI in-process, so argv, stdio, signals and exit codes all pass through unchanged, and `--version`/help still report the real CLI (Commander takes its program name from `specs.yaml`, not the filename). Every command works, not just `init`.

`.changeset/config.json` gains `"fixed": [["@tigrisdata/cli", "tigris"]]` so the alias can never drift from the CLI it wraps.

## Testing

- `pnpm test` — 811 pass, 214 skipped. Added `test/lib/init/{plan,shared}.test.ts` (10 tests); `init` had none before.
- `pnpm lint`, `tsc --noEmit`, and the binary `tsconfig.binary.json` typecheck all clean. `publint` clean on both packages.
- Both recipe branches exercised against the built CLI, with and without `tigris` on PATH.
- Confirmed empirically that `init --agent` shipped in **3.5.0**: 3.4.3 and older exit 1 with `unknown option '--agent'`, which is what the handoff probe keys on.
- Wrapper installed from a publish-shaped tarball against the registry CLI — both `tigris` and `t3` bins work, including through `npx`.
- Dry-ran `changeset version` and reverted: both packages land on `3.7.0`.

## ⚠️ Before this releases

**npm trusted publishing must be configured for the `tigris` package name.** The release workflow publishes via OIDC with no `NODE_AUTH_TOKEN`, and `tigris` currently exists on npm as a `0.0.0` placeholder that predates this repo. If the trusted publisher isn't set up, `@tigrisdata/cli@3.7.0` will publish and `tigris` will fail — leaving `npx tigris` resolving to the placeholder, which the wizard's fallback handoff now points users at.

## Follow-up (not in this PR)

`init` isn't in the generated CLI README at all — #203 added the command without running `pnpm updatedocs`. Regenerating produces a large unrelated diff, so I left it out; happy to do it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Onboarding and global npm publish path change; mistaken PATH handling could mis-detect installs, and the new tigris package must publish correctly or npx handoffs break.
> 
> **Overview**
> **`tigris init`** now treats an on-PATH CLI as already installed: the Defaults hint omits **CLI - Global**, existing installs are refreshed via **`tigris update`** (not forced `npm install -g`), and the agent handoff uses **`npx tigris init --agent`** when update fails or the CLI is too old for **`init --agent`**.
> 
> When run via **`npx`/`pnpm dlx`**, **`PATH`** is scrubbed of throwaway runner **`.bin`** dirs so init does not mistake the ephemeral binary for a real install.
> 
> **`tigris init --agent`** prints one resolved first step (install *or* update) via **`buildAgentSetup`**, instead of both PATH branches for the agent to interpret.
> 
> Adds the unscoped **`tigris`** package (re-exports **`@tigrisdata/cli`**) so **`npx tigris`** works; changesets **fixed** **`@tigrisdata/cli`** and **`tigris`** together. New tests cover the agent recipe and PATH helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c49efff16e1c2a44e12e242c0b8d9d91b9d67e34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->