### PR TITLE
ci(repo): cancel superseded release runs for chore(deps) commits

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,22 @@ on:
         default: "beta"
         type: string
 
+# Renovate lands `chore(deps): …` commits on main in bursts (up to 4/hour, and
+# a whole batch after each weekend run), and every push to main starts a full
+# release pipeline. Bucket those into their own concurrency group with
+# cancel-in-progress so a burst leaves only the newest deps run alive.
+#
+# Everything else — feature merges and, critically, the `chore(release): …`
+# merge that actually runs `changeset publish` — gets a per-run group key
+# (`github.run_id` is unique), so those runs are never cancelled and never
+# queued behind one another. A deps merge landing mid-publish cannot kill it.
+#
+# `head_commit` is null for workflow_dispatch, so a manual beta run evaluates
+# to the non-deps branch of both expressions.
+concurrency:
+  group: release-${{ github.ref }}-${{ startsWith(github.event.head_commit.message, 'chore(deps)') && 'deps' || github.run_id }}
+  cancel-in-progress: ${{ startsWith(github.event.head_commit.message, 'chore(deps)') }}
+
 permissions:
   id-token: write
   contents: write


### PR DESCRIPTION
## Problem

`release.yaml` has no `concurrency` block, so every push to `main` starts a full release pipeline — install, lint, build, publint, and the live test suite against real Tigris credentials.

Renovate is configured to emit every dependency commit as `chore(deps): …` (`:semanticCommitScope(deps)` + `:semanticCommitTypeAll(chore)` in `renovate.json`), with `prHourlyLimit: 4` and a weekly lock-file-maintenance batch. 52 of the last 200 commits on `main` are `chore(deps)`. When a batch merges, those runs stack up — each one outdated the moment the next lands.

## Change

A workflow-level `concurrency` block:

```yaml
concurrency:
  group: release-${{ github.ref }}-${{ startsWith(github.event.head_commit.message, 'chore(deps)') && 'deps' || github.run_id }}
  cancel-in-progress: ${{ startsWith(github.event.head_commit.message, 'chore(deps)') }}
```

Both keys test the same predicate. `cancel-in-progress` wants a boolean, so it uses it raw; `group` wants a string, so it maps the boolean through the `&& … || …` ternary stand-in (Actions expressions have no `?:`).

| Push | Group | Cancels in-progress? |
| --- | --- | --- |
| `chore(deps): …` | `release-<ref>-deps` | yes — only the newest deps run survives |
| everything else | `release-<ref>-<run_id>` | no — unique per run |
| `workflow_dispatch` | `release-<ref>-<run_id>` | no |

### Why two group keys instead of one

A single shared group with a conditional `cancel-in-progress` would let an incoming deps merge cancel *whatever* was running — including the `chore(release): …` merge that runs `changeset publish`. Keying non-deps runs on `github.run_id` (unique per run) puts them each in their own group, so they are never cancelled and never queued behind one another. Behaviour for feature merges and publishes is unchanged; only deps runs are affected.

## Notes

- The `startsWith` check is duplicated deliberately. `concurrency` is evaluated before any job starts, so there is no `env` context or step output to hoist it into.
- `github.event.head_commit` is null for `workflow_dispatch`, which coerces to `''` — so manual beta runs take the non-deps branch of both expressions and are never cancelled.
- The `&& 'deps' || …` idiom is only safe because `'deps'` is a non-empty literal; a falsy middle operand would silently fall through to the right-hand side.
- A cancelled deps run can only interrupt `changesets/action` while it updates the Version Packages PR, which is idempotent — the next run recreates it. A `chore(deps)` commit never publishes, so cancellation cannot abort a release.

## Testing

YAML parse verified for all three workflow files. The gating itself only exercises on a real push to `main` — `concurrency` cannot be triggered from a PR run.

## Changeset

None — CI-only, nothing ships to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only concurrency tuning; publish and manual beta runs are explicitly excluded from cancellation.
> 
> **Overview**
> Adds a **workflow-level `concurrency` block** to `release.yaml` so Renovate’s `chore(deps): …` pushes on `main` share one group (`release-<ref>-deps`) with **`cancel-in-progress: true`**, leaving only the latest dependency-triggered release run.
> 
> **Non-deps pushes** (features, `chore(release): …` / publish, etc.) use a **per-run group** (`release-<ref>-<run_id>`) and are **not** cancelled, so an incoming deps merge cannot abort an in-flight publish. **`workflow_dispatch`** behaves like non-deps because `head_commit` is null.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e076b77f80fe505b0686b2e91b169bf2e532ac7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->