### PR TITLE
feat(cli): make migrate in-flight budget configurable, raise default to 50 GB

### DIFF
--- a/.changeset/cli-migrate-max-in-flight-gb.md
+++ b/.changeset/cli-migrate-max-in-flight-gb.md
@@ -1,0 +1,16 @@
+---
+'@tigrisdata/cli': minor
+'tigris': minor
+---
+
+`tigris buckets migrate` keeps more data in flight by default, and the budget is
+now tunable per run.
+
+- The in-flight byte budget — the total size of migrations scheduled
+  server-side but not yet confirmed — rises from 10 GB to 50 GB. A run made up
+  of multi-gigabyte objects can now keep several of them in flight at once
+  instead of serializing files that individually exceeded the old budget.
+- New `--max-in-flight-gb` overrides that budget, accepting 1 to 100 (default
+  50). Out-of-range and non-numeric values are rejected up front — before
+  discovery lists the bucket — rather than silently clamped, so the flag always
+  means what it says. The separate 1,000-object in-flight cap is unchanged.

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -33,6 +33,7 @@ Run `tigris help` to see all available commands, or `tigris <command> help` for 
 
 | Command | Description |
 |---------|-------------|
+| `tigris init` (start) | Connect Tigris to your AI coding agent — MCP server config and agent skills |
 | `tigris configure` (c) | Save access-key credentials to ~/.tigris/config.json for persistent use across all commands |
 | `tigris login` (l) | Start a session via OAuth (default) or temporary credentials. Session state is cleared on logout |
 | `tigris whoami` (w) | Print the currently authenticated user, organization, and auth method |
@@ -56,6 +57,25 @@ Run `tigris help` to see all available commands, or `tigris <command> help` for 
 | `tigris iam` | Identity and Access Management - manage policies, users, and permissions |
 
 ---
+
+### `tigris init` (start)
+
+Connect Tigris to your AI coding agent — MCP server config and agent skills
+
+```
+tigris init [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--agent` | Print a setup recipe for an AI coding agent to follow instead of running the interactive wizard |
+
+**Examples:**
+```bash
+tigris init
+npx tigris init
+tigris init --agent
+```
 
 ### `tigris configure` (c)
 
@@ -457,10 +477,12 @@ Create, inspect, update, and delete buckets. Buckets are top-level containers th
 |---------|-------------|
 | `tigris buckets list` (l) | List all buckets in the current organization |
 | `tigris buckets create` (c) | Create a new bucket with optional access, tier, and location settings |
+| `tigris buckets rebase` | Update a fork with the latest changes from its source bucket |
+| `tigris buckets merge` | Merge a fork's changes back into its source bucket |
 | `tigris buckets get` (g) | Show details for a bucket including access level, region, tier, and custom domain |
 | `tigris buckets delete` (d) | Delete one or more buckets by name. The bucket must be empty or delete-protection must be off |
 | `tigris buckets restore` | Restore a soft-deleted bucket within its retention window. List recoverable buckets with "tigris buckets list --deleted" |
-| `tigris buckets set` (s) | Update settings on an existing bucket such as access level, location, caching, or custom domain |
+| `tigris buckets set` (s) | Update settings on an existing bucket such as access level, default tier, location, caching, or custom domain |
 | `tigris buckets enable-snapshots` | Enable snapshots on an existing bucket, converting it to a snapshot bucket |
 | `tigris buckets disable-snapshots` | Disable snapshots on an existing bucket, converting it back to a regular bucket. Rejected while the bucket has dependent forks |
 | `tigris buckets set-locations` | Set the data locations for a bucket |
@@ -525,6 +547,41 @@ tigris buckets create my-fork --fork-of my-bucket
 tigris buckets create my-fork --fork-of my-bucket --source-snapshot 1765889000501544464
 ```
 
+#### `tigris buckets rebase`
+
+Update a fork with the latest changes from its source bucket
+
+```
+tigris buckets rebase <fork>
+```
+
+**Examples:**
+```bash
+tigris buckets rebase my-fork
+tigris buckets rebase my-fork --yes
+```
+
+#### `tigris buckets merge`
+
+Merge a fork's changes back into its source bucket
+
+```
+tigris buckets merge <fork> [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `-source, --into` | Source bucket to merge into. Defaults to the fork's parent source bucket |
+| `-from-snap, --from-snapshot` | Merge from a specific snapshot of the fork rather than its current state. Accepts a snapshot version string or any UNIX nanosecond-precision timestamp (e.g. 1765889000501544464) |
+
+**Examples:**
+```bash
+tigris buckets merge my-fork
+tigris buckets merge my-fork --into my-bucket
+tigris buckets merge my-fork --from-snapshot 1765889000501544464
+tigris buckets merge my-fork --yes
+```
+
 #### `tigris buckets get` (g)
 
 Show details for a bucket including access level, region, tier, and custom domain
@@ -575,7 +632,7 @@ tigris buckets restore my-bucket
 
 #### `tigris buckets set` (s)
 
-Update settings on an existing bucket such as access level, location, caching, or custom domain
+Update settings on an existing bucket such as access level, default tier, location, caching, or custom domain
 
 ```
 tigris buckets set <name> [flags]
@@ -584,6 +641,7 @@ tigris buckets set <name> [flags]
 | Flag | Description |
 |------|-------------|
 | `--access` | Bucket access level |
+| `--default-tier` | Change the default storage tier for objects uploaded to the bucket |
 | `--locations` | Bucket location (see https://www.tigrisdata.com/docs/buckets/locations/ for more details) |
 | `--allow-object-acl` | Enable object-level ACL |
 | `--disable-directory-listing` | Disable directory listing |
@@ -597,6 +655,7 @@ tigris buckets set <name> [flags]
 **Examples:**
 ```bash
 tigris buckets set my-bucket --access public
+tigris buckets set my-bucket --default-tier GLACIER
 tigris buckets set my-bucket --locations iad,fra --cache-control 'max-age=3600'
 tigris buckets set my-bucket --custom-domain assets.example.com
 tigris buckets set my-bucket --soft-delete enable --retention-days 30
@@ -881,7 +940,7 @@ Low-level object operations for listing, downloading, uploading, and deleting in
 | `tigris objects list` (l) | List objects in a bucket, optionally filtered by a key prefix |
 | `tigris objects list-versions` (lv) | List object versions and delete markers in a bucket (requires bucket versioning). Returns both arrays separately to match the S3 ListObjectVersions response |
 | `tigris objects get` (g) | Download an object by key. Prints to stdout by default, or saves to a file with --output |
-| `tigris objects put` (p) | Upload a local file as an object. Content-type is auto-detected from extension unless overridden |
+| `tigris objects put` (p) | Upload a local file — or data piped via stdin — as an object. Content-type is auto-detected from the file extension unless overridden |
 | `tigris objects delete` (d) | Delete one or more objects by key from the given bucket. On a versioned bucket, the default creates a delete marker; use --version-id or --all-versions to hard-delete versions |
 | `tigris objects set` (s) | (Deprecated) Update settings on an existing object such as access level. Use `tigris objects set-access` for ACL changes and `tigris mv` to rename |
 | `tigris objects set-access` (sa) | Set the access level (public or private) on an existing object |
@@ -964,7 +1023,7 @@ tigris objects get my-bucket archive.zip --output ./archive.zip --mode stream
 
 #### `tigris objects put` (p)
 
-Upload a local file as an object. Content-type is auto-detected from extension unless overridden
+Upload a local file — or data piped via stdin — as an object. Content-type is auto-detected from the file extension unless overridden
 
 ```
 tigris objects put <bucket> [key] [file] [flags]
@@ -981,6 +1040,8 @@ tigris objects put <bucket> [key] [file] [flags]
 tigris objects put my-bucket report.pdf ./report.pdf
 tigris objects put t3://my-bucket/report.pdf ./report.pdf
 tigris objects put my-bucket logo.png ./logo.png --access public --content-type image/png
+echo 'hello' | tigris objects put t3://my-bucket/hello.txt
+cat report.pdf | tigris objects put my-bucket report.pdf --content-type application/pdf
 ```
 
 #### `tigris objects delete` (d)
@@ -1078,6 +1139,7 @@ tigris objects restore <bucket> [key] [flags]
 |------|-------------|
 | `-d, --days` | How many days the restored copy stays available before reverting to its archived tier (default: 1) |
 | `--version-id` | Restore a specific object version (requires bucket versioning). Omit to restore the current version |
+| `-snapshot, --snapshot-version` | Restore the object as of a specific bucket snapshot. Accepts a snapshot version string or any UNIX nanosecond-precision timestamp (e.g. 1765889000501544464) |
 | `--format` | Output format (default: table) |
 
 **Examples:**
@@ -1085,6 +1147,7 @@ tigris objects restore <bucket> [key] [flags]
 tigris objects restore my-bucket archived.bin
 tigris objects restore my-bucket archived.bin --days 3
 tigris objects restore t3://my-bucket/archived.bin --days 7
+tigris objects restore my-bucket archived.bin --snapshot-version 1765889000501544464
 ```
 
 #### `tigris objects restore-info` (ri)
@@ -1098,12 +1161,14 @@ tigris objects restore-info <bucket> [key] [flags]
 | Flag | Description |
 |------|-------------|
 | `--version-id` | Inspect a specific object version (requires bucket versioning). Omit to read the current version |
+| `-snapshot, --snapshot-version` | Inspect the object as of a specific bucket snapshot. Accepts a snapshot version string or any UNIX nanosecond-precision timestamp (e.g. 1765889000501544464) |
 | `--format` | Output format (default: table) |
 
 **Examples:**
 ```bash
 tigris objects restore-info my-bucket archived.bin
 tigris objects restore-info t3://my-bucket/archived.bin --format json
+tigris objects restore-info my-bucket archived.bin --snapshot-version 1765889000501544464
 ```
 
 ### `tigris access-keys` (keys)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -678,14 +678,19 @@ tigris buckets set-migration my-bucket --disable
 Actively migrate all objects from a shadow bucket to Tigris by scheduling server-side migration for unmigrated objects
 
 ```
-tigris buckets migrate <path>
+tigris buckets migrate <path> [flags]
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--max-in-flight-gb` | Max total gigabytes of scheduled-but-unconfirmed migrations to keep in flight. Accepts 1-100 (default: 50) |
 
 **Examples:**
 ```bash
 tigris buckets migrate my-bucket
 tigris buckets migrate my-bucket/images/
 tigris buckets migrate t3://my-bucket/prefix/
+tigris buckets migrate my-bucket --max-in-flight-gb 100
 ```
 
 #### `tigris buckets lifecycle` (lc)

--- a/packages/cli/src/lib/buckets/migrate.ts
+++ b/packages/cli/src/lib/buckets/migrate.ts
@@ -14,8 +14,17 @@ import { parseAnyPath } from '@utils/path.js';
 
 const context = msg('buckets', 'migrate');
 
-/** Max total bytes of in-flight (scheduled but not confirmed) migrations */
-const MAX_IN_FLIGHT_BYTES = 10 * 1024 * 1024 * 1024; // 10 GB
+const BYTES_PER_GB = 1024 * 1024 * 1024;
+
+/**
+ * Default cap on total bytes of in-flight (scheduled but not confirmed)
+ * migrations. Overridable per run with --max-in-flight-gb.
+ */
+const DEFAULT_MAX_IN_FLIGHT_GB = 50;
+
+/** Bounds accepted for the --max-in-flight-gb override. */
+const MIN_MAX_IN_FLIGHT_GB = 1;
+const MAX_MAX_IN_FLIGHT_GB = 100;
 
 /**
  * Max number of in-flight objects, independent of size. Keeps the poll set
@@ -76,6 +85,13 @@ export interface MigrationState {
   failed: number;
   inFlight: InFlightItem[];
   inFlightBytes: number;
+  /**
+   * Byte budget for the in-flight set — DEFAULT_MAX_IN_FLIGHT_GB unless the run
+   * overrode it with --max-in-flight-gb. Lives on the state (not a module
+   * constant) because it is per-run configuration that both capacity checks
+   * read.
+   */
+  maxInFlightBytes: number;
   /** Rotating cursor into inFlight so drainCompleted sweeps the whole set. */
   drainOffset: number;
   /** In-flight items checked since the last completion (for backoff). */
@@ -100,6 +116,45 @@ export function orderForMigration(items: MigrationItem[]): MigrationItem[] {
 }
 
 /**
+ * Resolve the in-flight byte budget from a raw --max-in-flight-gb value.
+ * Absent → the default. Values outside [MIN_MAX_IN_FLIGHT_GB,
+ * MAX_MAX_IN_FLIGHT_GB] are rejected rather than clamped: a run silently using
+ * a budget the user didn't ask for would keep far more or far less data queued
+ * than the flag says. Note the flag registers as `[value]` (commander makes the
+ * value optional), so a bare `--max-in-flight-gb` arrives as `true` — that is
+ * an error, not 1 GB.
+ */
+export function parseMaxInFlightBytes(
+  raw: unknown
+): { ok: true; bytes: number } | { ok: false; error: string } {
+  if (raw === undefined || raw === null || raw === '') {
+    return { ok: true, bytes: DEFAULT_MAX_IN_FLIGHT_GB * BYTES_PER_GB };
+  }
+
+  const gb =
+    typeof raw === 'number'
+      ? raw
+      : typeof raw === 'string'
+        ? Number(raw.trim())
+        : Number.NaN;
+
+  if (!Number.isFinite(gb)) {
+    return {
+      ok: false,
+      error: '--max-in-flight-gb must be a number of gigabytes',
+    };
+  }
+  if (gb < MIN_MAX_IN_FLIGHT_GB || gb > MAX_MAX_IN_FLIGHT_GB) {
+    return {
+      ok: false,
+      error: `--max-in-flight-gb must be between ${MIN_MAX_IN_FLIGHT_GB} and ${MAX_MAX_IN_FLIGHT_GB} (got ${gb})`,
+    };
+  }
+
+  return { ok: true, bytes: Math.round(gb * BYTES_PER_GB) };
+}
+
+/**
  * Whether scheduling `itemSize` more bytes should wait for the in-flight set to
  * drain. Blocks when the object-count cap is hit, or when the byte budget would
  * be exceeded and there is something to drain. A single file larger than the
@@ -111,7 +166,7 @@ export function atCapacity(state: MigrationState, itemSize: number): boolean {
     return true;
   }
   return (
-    state.inFlightBytes + itemSize > MAX_IN_FLIGHT_BYTES &&
+    state.inFlightBytes + itemSize > state.maxInFlightBytes &&
     state.inFlight.length > 0
   );
 }
@@ -134,7 +189,7 @@ export function shouldFlushBatch(
   return (
     batchLength >= SCHEDULE_BATCH_SIZE ||
     state.inFlight.length + batchLength >= MAX_IN_FLIGHT_OBJECTS ||
-    state.inFlightBytes + batchBytes + itemSize > MAX_IN_FLIGHT_BYTES
+    state.inFlightBytes + batchBytes + itemSize > state.maxInFlightBytes
   );
 }
 
@@ -599,6 +654,15 @@ export default async function migrate(
     failWithError(context, 'Invalid path');
   }
 
+  // Validate before touching the network so a bad flag fails immediately
+  // instead of after discovery has listed the whole bucket.
+  const maxInFlight = parseMaxInFlightBytes(
+    getOption(options, ['max-in-flight-gb', 'maxInFlightGb'])
+  );
+  if (!maxInFlight.ok) {
+    failWithError(context, maxInFlight.error);
+  }
+
   const config = await getStorageConfig();
 
   // Handle SIGINT: the first Ctrl-C stops scheduling and polling, prints a
@@ -697,6 +761,7 @@ export default async function migrate(
       failed: 0,
       inFlight: [],
       inFlightBytes: 0,
+      maxInFlightBytes: maxInFlight.bytes,
       drainOffset: 0,
       drainSweepMisses: 0,
       checkBackoffMs: CHECK_INTERVAL_MS,

--- a/packages/cli/src/specs.yaml
+++ b/packages/cli/src/specs.yaml
@@ -1075,6 +1075,7 @@ commands:
           - "tigris buckets migrate my-bucket"
           - "tigris buckets migrate my-bucket/images/"
           - "tigris buckets migrate t3://my-bucket/prefix/"
+          - "tigris buckets migrate my-bucket --max-in-flight-gb 100"
         messages:
           onStart: ''
           onSuccess: ''
@@ -1088,6 +1089,9 @@ commands:
               - my-bucket
               - my-bucket/images/
               - t3://my-bucket/prefix/
+          - name: max-in-flight-gb
+            description: Max total gigabytes of scheduled-but-unconfirmed migrations to keep in flight. Accepts 1-100
+            default: '50'
       # set-transition
       - name: set-transition
         removed: true

--- a/packages/cli/test/lib/buckets/migrate.test.ts
+++ b/packages/cli/test/lib/buckets/migrate.test.ts
@@ -1,4 +1,7 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
+import * as YAML from 'yaml';
 
 // Mock the SDK so drainCompleted's isMigrated() calls are controllable.
 vi.mock('@tigrisdata/storage', () => ({
@@ -17,10 +20,22 @@ import {
   type MigrationState,
   orderForDisplay,
   orderForMigration,
+  parseMaxInFlightBytes,
   shouldFlushBatch,
 } from '../../../src/lib/buckets/migrate.js';
+import type { Specs } from '../../../src/types.js';
+import { getArgumentSpec, setSpecs } from '../../../src/utils/specs.js';
 
-function makeState(items: { name: string; size: number }[]): MigrationState {
+const GB = 1024 * 1024 * 1024;
+const MB = 1024 * 1024;
+
+/** The default in-flight byte budget (50 GB) unless a test overrides it. */
+const DEFAULT_BUDGET = 50 * GB;
+
+function makeState(
+  items: { name: string; size: number }[],
+  maxInFlightBytes: number = DEFAULT_BUDGET
+): MigrationState {
   const bytes = items.reduce((s, i) => s + i.size, 0);
   return {
     total: items.length,
@@ -31,6 +46,7 @@ function makeState(items: { name: string; size: number }[]): MigrationState {
     failed: 0,
     inFlight: items.map((i) => ({ ...i, checkFailures: 0, scheduledAt: 0 })),
     inFlightBytes: bytes,
+    maxInFlightBytes,
     drainOffset: 0,
     drainSweepMisses: 0,
     checkBackoffMs: 5_000,
@@ -40,18 +56,33 @@ function makeState(items: { name: string; size: number }[]): MigrationState {
   };
 }
 
-const GB = 1024 * 1024 * 1024;
-const MB = 1024 * 1024;
-
 describe('shouldFlushBatch', () => {
   it('never flushes an empty batch', () => {
     expect(shouldFlushBatch(makeState([]), 0, 0, 20 * GB)).toBe(false);
   });
 
   it('flushes before a large item would blow the byte budget', () => {
-    // The exact 2-object case from the bug report: an 877 MB batch, then a
-    // ~21.9 GB file would push in-flight to 22.8 GB — flush the 877 MB first.
-    expect(shouldFlushBatch(makeState([]), 1, 877 * MB, 21.9 * GB)).toBe(true);
+    // The exact 2-object case from the bug report, against a 10 GB budget: an
+    // 877 MB batch, then a ~21.9 GB file would push in-flight to 22.8 GB —
+    // flush the 877 MB first.
+    expect(
+      shouldFlushBatch(makeState([], 10 * GB), 1, 877 * MB, 21.9 * GB)
+    ).toBe(true);
+  });
+
+  it('keeps batching that same pair under the raised 50 GB default', () => {
+    // Same shapes as above: 22.8 GB fits the default budget, so there is no
+    // reason to flush early — this is what raising the default buys.
+    expect(shouldFlushBatch(makeState([]), 1, 877 * MB, 21.9 * GB)).toBe(false);
+  });
+
+  it('respects a lowered budget from --max-in-flight-gb', () => {
+    const budget = parseMaxInFlightBytes('1');
+    expect(budget.ok).toBe(true);
+    if (!budget.ok) return;
+    expect(
+      shouldFlushBatch(makeState([], budget.bytes), 1, 600 * MB, 600 * MB)
+    ).toBe(true);
   });
 
   it('keeps batching small items until the batch is full', () => {
@@ -124,11 +155,97 @@ describe('atCapacity', () => {
   });
 
   it('blocks when the byte budget would be exceeded with items in flight', () => {
-    expect(atCapacity(makeState([{ name: 'a', size: 10 * GB }]), 1)).toBe(true);
+    // 50 GB already queued against the 50 GB default: one more byte must wait.
+    expect(atCapacity(makeState([{ name: 'a', size: 50 * GB }]), 1)).toBe(true);
+  });
+
+  it('still admits 10 GB in flight now that the default is 50 GB', () => {
+    expect(atCapacity(makeState([{ name: 'a', size: 10 * GB }]), 1)).toBe(
+      false
+    );
   });
 
   it('admits a single file larger than the whole budget once the queue is empty', () => {
-    expect(atCapacity(makeState([]), 20 * GB)).toBe(false);
+    expect(atCapacity(makeState([]), 120 * GB)).toBe(false);
+  });
+
+  it('blocks against a lowered budget from --max-in-flight-gb', () => {
+    const budget = parseMaxInFlightBytes('1');
+    expect(budget.ok).toBe(true);
+    if (!budget.ok) return;
+    expect(
+      atCapacity(makeState([{ name: 'a', size: 1 * GB }], budget.bytes), 1)
+    ).toBe(true);
+  });
+});
+
+describe('parseMaxInFlightBytes', () => {
+  it('defaults to 50 GB when the flag is absent', () => {
+    expect(parseMaxInFlightBytes(undefined)).toEqual({
+      ok: true,
+      bytes: 50 * GB,
+    });
+  });
+
+  it('accepts the bounds themselves', () => {
+    expect(parseMaxInFlightBytes('1')).toEqual({ ok: true, bytes: 1 * GB });
+    expect(parseMaxInFlightBytes('100')).toEqual({ ok: true, bytes: 100 * GB });
+  });
+
+  it('accepts a fractional value inside the range', () => {
+    expect(parseMaxInFlightBytes('2.5')).toEqual({ ok: true, bytes: 2.5 * GB });
+  });
+
+  it('rejects values below the 1 GB minimum', () => {
+    for (const raw of ['0', '0.5', '-5']) {
+      const result = parseMaxInFlightBytes(raw);
+      expect(result.ok).toBe(false);
+      expect(result.ok === false && result.error).toContain(
+        'between 1 and 100'
+      );
+    }
+  });
+
+  it('rejects values above the 100 GB maximum', () => {
+    const result = parseMaxInFlightBytes('101');
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toContain('between 1 and 100');
+  });
+
+  it('rejects non-numeric values', () => {
+    for (const raw of ['abc', '50GB']) {
+      expect(parseMaxInFlightBytes(raw).ok).toBe(false);
+    }
+  });
+
+  it('treats an empty value as absent', () => {
+    // commander can hand back an empty string; falling through to the default
+    // beats reading it as Number('') === 0.
+    expect(parseMaxInFlightBytes('')).toEqual({ ok: true, bytes: 50 * GB });
+  });
+
+  it('rejects a bare flag with no value', () => {
+    // The option registers as `[value]`, so `--max-in-flight-gb` alone arrives
+    // as boolean true. Number(true) is 1, which would silently mean 1 GB.
+    const result = parseMaxInFlightBytes(true);
+    expect(result.ok).toBe(false);
+  });
+
+  it('keeps the spec default in step with the in-code default', () => {
+    // The spec default is what commander actually supplies at runtime, so if it
+    // drifts from DEFAULT_MAX_IN_FLIGHT_GB the constant becomes dead code and
+    // the CLI quietly runs the spec's number instead.
+    setSpecs(
+      YAML.parse(
+        readFileSync(join(process.cwd(), 'src', 'specs.yaml'), 'utf8'),
+        { schema: 'core' }
+      ) as Specs
+    );
+    const arg = getArgumentSpec('buckets', 'max-in-flight-gb', 'migrate');
+    expect(arg).not.toBeNull();
+    expect(parseMaxInFlightBytes(arg?.default)).toEqual(
+      parseMaxInFlightBytes(undefined)
+    );
   });
 });
 


### PR DESCRIPTION
## What

`tigris buckets migrate` capped in-flight migrations — objects scheduled server-side but not yet confirmed — at a fixed 10 GB. Any single object larger than that could only run once the queue had drained, so a bucket of multi-gigabyte files migrated close to serially.

- Default in-flight byte budget raised **10 GB → 50 GB**, so several large objects can transfer concurrently.
- New **`--max-in-flight-gb`** overrides it per run, accepting **1–100** (default 50). Out-of-range and non-numeric values are rejected *before* discovery lists the bucket rather than silently clamped, so the flag always means what it says. The option registers as `[value]`, so a bare `--max-in-flight-gb` arrives as boolean `true` — that is an error, not `Number(true)` = 1 GB.
- The budget moved from a module constant onto `MigrationState.maxInFlightBytes`, since it is now per-run configuration that both capacity checks read. `atCapacity` and `shouldFlushBatch` keep their signatures.

`MAX_IN_FLIGHT_OBJECTS` (1,000) and `SCHEDULE_BATCH_SIZE` (50) are unchanged.

## Commits

| Commit | Change |
|---|---|
| `7a36d89` | `feat(cli)` — the change described above. |
| `ef4690f` | `chore(repo)` — `biome.json` `$schema` 2.5.4 → 2.5.6 via `biome migrate --write`. The `@biomejs/biome` devDep floats on `^2.4.13`, so the binary had moved ahead of the pin and every `biome check` printed a migration notice. The schema URL was the only change; no deprecated config to migrate. |
| `ffb8b14` | `docs(cli)` — regenerated `packages/cli/README.md`. It is generated from `specs.yaml` by `pnpm updatedocs` and had gone stale, so this also picks up `tigris init`, `buckets rebase`, `buckets merge`, `--default-tier`, stdin input for `objects put`, and `--snapshot-version` on `objects restore`/`restore-info`. The `buckets migrate` section came out byte-identical to the version hand-written in `7a36d89`, confirming those docs were already correct. |

## Notes for reviewers

**This raise only helps large-object runs.** The byte cap and the object cap cross over at `budget / 1000`, so the crossover moved from 10 MB to 50 MB average object size. Below that, `MAX_IN_FLIGHT_OBJECTS = 1000` is still the binding constraint and this change has no effect there. If we later want to lift the object cap too, `CONCURRENCY` should move with it — `drainCompleted` polls in windows of `CONCURRENCY`, so a larger in-flight set stretches a full sweep proportionally.

**Spec/code default drift guard.** The spec's `default: '50'` is what commander actually supplies at runtime, so if it drifted from `DEFAULT_MAX_IN_FLIGHT_GB` the constant would become dead code and the CLI would quietly run the spec's number instead. A test asserts the two resolve to the same budget.

## Test plan

- `tsc --noEmit` clean
- 36 tests in `test/lib/buckets/migrate.test.ts` pass — 12 new (parse bounds, fractional values, bare flag, budget overrides changing capacity decisions, spec-default drift guard). Two existing byte-budget cases were retargeted, since 22.8 GB no longer exceeds the budget: the original bug-report scenario is kept against an explicit 10 GB budget, with a new counterpart proving the same pair now batches freely at 50 GB.
- Full CLI suite: **834 passed, 214 skipped** (integration tests, no credentials)
- Biome clean across 342 files
- Smoke-tested the built CLI: `--help` renders the flag; `500`, `0.5`, `abc` and a bare `--max-in-flight-gb` each fail with the right message and exit 1, before any network or auth call

## Release

Changeset included — `minor` for `@tigrisdata/cli` and `tigris` (kept in lockstep by the Changesets `fixed` group). The regenerated README ships with that release; the biome bump is repo tooling and never reaches npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
