### PR TITLE
feat(cli): add PostHog usage analytics with a persistent opt-out

### DIFF
--- a/.changeset/cli-posthog-usage-analytics.md
+++ b/.changeset/cli-posthog-usage-analytics.md
@@ -1,0 +1,23 @@
+---
+'@tigrisdata/cli': minor
+---
+
+Add PostHog usage analytics, reporting one `cli_command` event per invocation
+with the command name, its scrubbed arguments, flag names, CLI/OS/runtime
+versions, install method, and auth method. Signed-in runs are identified by
+account email so CLI activity joins the same person record as the console; runs
+with no session use a stable anonymous id that is linked to the account on the
+next `tigris login`.
+
+Credentials are never collected — access keys, secrets, tokens, passwords, and
+authorization headers are stripped whether they appear as a flag value or a
+positional argument, as are other people's email addresses. The machine hostname
+and working directory are never sent. Both telemetry surfaces now share a single
+scrubber (`src/utils/redact.ts`) so the guarantee cannot drift between usage
+analytics and error reports.
+
+Adds `tigris telemetry status | disable | enable` for a persistent opt-out, and
+prints a one-time disclosure notice on first use. The existing
+`TIGRIS_NO_TELEMETRY` and `DO_NOT_TRACK` environment variables now gate usage
+analytics as well as error reports, and are honored for any truthy value rather
+than only the literal `1` — `DO_NOT_TRACK=true` previously had no effect.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -40,6 +40,7 @@ Run `tigris help` to see all available commands, or `tigris <command> help` for 
 | `tigris update` | Update the CLI to the latest version |
 | `tigris logout` | End the current session and clear login state. Credentials saved via 'configure' are kept |
 | `tigris credentials` (creds) | Test whether your current credentials can reach Tigris and optionally verify access to a specific bucket |
+| `tigris telemetry` | Show or change whether the CLI sends usage analytics and error reports |
 | `tigris ls` (list) | List all buckets (no arguments) or objects under a bucket/prefix path. Accepts bare names or t3:// URIs |
 | `tigris mk` (create) | Create a bucket (bare name) or a folder inside a bucket (bucket/folder/ with trailing slash) |
 | `tigris touch` | Create an empty (zero-byte) object at the given bucket/key path |
@@ -210,6 +211,55 @@ tigris credentials test [flags]
 ```bash
 tigris credentials test
 tigris credentials test --bucket my-bucket
+```
+
+### `tigris telemetry`
+
+Show or change whether the CLI sends usage analytics and error reports
+
+| Command | Description |
+|---------|-------------|
+| `tigris telemetry status` | Show whether telemetry is enabled, what is collected, and which setting is in effect |
+| `tigris telemetry disable` | Turn off usage analytics and error reports on this machine |
+| `tigris telemetry enable` | Turn usage analytics and error reports back on for this machine |
+
+#### `tigris telemetry status`
+
+Show whether telemetry is enabled, what is collected, and which setting is in effect
+
+```
+tigris telemetry status
+```
+
+**Examples:**
+```bash
+tigris telemetry status
+```
+
+#### `tigris telemetry disable`
+
+Turn off usage analytics and error reports on this machine
+
+```
+tigris telemetry disable
+```
+
+**Examples:**
+```bash
+tigris telemetry disable
+```
+
+#### `tigris telemetry enable`
+
+Turn usage analytics and error reports back on for this machine
+
+```
+tigris telemetry enable
+```
+
+**Examples:**
+```bash
+tigris telemetry enable
 ```
 
 ### `tigris ls` (list)
@@ -1695,6 +1745,20 @@ tigris iam teams edit team_id --name platform
 tigris iam teams edit team_id --description 'Platform team'
 tigris iam teams edit team_id --members a@example.com,b@example.com
 ```
+
+## Telemetry
+
+The CLI reports usage analytics and error reports to improve quality.
+Credentials are never collected. You can opt out at any time:
+
+```bash
+tigris telemetry disable   # persists to ~/.tigris/telemetry.json
+tigris telemetry status    # current setting, and exactly what is collected
+tigris telemetry enable
+```
+
+`TIGRIS_NO_TELEMETRY=1` or `DO_NOT_TRACK=1` also disable it and take precedence
+over the stored setting. Telemetry is off in development builds and test runs.
 
 ## License
 

--- a/packages/cli/scripts/update-docs.ts
+++ b/packages/cli/scripts/update-docs.ts
@@ -175,19 +175,29 @@ function updateReadme(docsContent: string): void {
   const readmePath = join(__dirname, '..', 'README.md');
   const readmeContent = readFileSync(readmePath, 'utf-8');
 
-  const usageStart = readmeContent.indexOf('## Usage');
-  const licenseStart = readmeContent.indexOf('## License');
+  // Hand-written sections that trail the generated command reference. The
+  // generated block ends at whichever appears first, so adding a section here
+  // is all it takes to protect it — otherwise the next `pnpm updatedocs`
+  // silently deletes anything sitting between ## Usage and ## License.
+  const TRAILING_SECTIONS = ['## Telemetry', '## License'];
 
-  if (usageStart === -1 || licenseStart === -1) {
+  const usageStart = readmeContent.indexOf('## Usage');
+  const trailingStarts = TRAILING_SECTIONS.map((heading) =>
+    readmeContent.indexOf(heading)
+  ).filter((index) => index !== -1);
+
+  if (usageStart === -1 || trailingStarts.length === 0) {
     console.error('Could not find ## Usage or ## License section in README.md');
     process.exit(1);
   }
+
+  const trailingStart = Math.min(...trailingStarts);
 
   const newReadme =
     readmeContent.slice(0, usageStart) +
     docsContent +
     '\n' +
-    readmeContent.slice(licenseStart);
+    readmeContent.slice(trailingStart);
 
   writeFileSync(readmePath, newReadme);
   console.log('README.md updated successfully!');

--- a/packages/cli/src/cli-core.ts
+++ b/packages/cli/src/cli-core.ts
@@ -2,6 +2,7 @@
  * Shared CLI core functionality used by both cli.ts (npm) and cli-binary.ts (binary)
  */
 
+import { trackCommand } from '@utils/analytics.js';
 import { classifyError } from '@utils/errors.js';
 import { exitWithError } from '@utils/exit.js';
 import { printDeprecated } from '@utils/messages.js';
@@ -558,6 +559,12 @@ async function loadAndExecuteCommand(
     console.error(`Command not implemented: ${pathParts.join(' ')}`);
     process.exit(1);
   }
+
+  // Usage analytics, recorded at the start of the command so the request
+  // overlaps the command's own work and survives the synchronous exits that
+  // most commands take. Never awaited: it must add neither latency nor a
+  // failure mode to the command path.
+  trackCommand(pathParts);
 
   await commandFunction({ ...options, _positional: positionalArgs });
 }

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -11,3 +11,11 @@ export const UPDATE_NOTIFY_INTERVAL_MS = 1 * 60 * 60 * 1000; // Show update noti
 // is expected. Overridable via TIGRIS_SENTRY_DSN. Empty keeps telemetry inert.
 export const SENTRY_DSN =
   'https://c3a84c6a2811c557d70e42412cda4ffa@o4507410155896832.ingest.us.sentry.io/4511767771545600';
+
+// PostHog project for CLI usage analytics — the same project the console
+// reports to, so a user's CLI and web activity join on one person record. Like
+// a Sentry DSN, a PostHog project API key is write-only and not a secret.
+// Overridable via TIGRIS_POSTHOG_KEY / TIGRIS_POSTHOG_HOST. Empty key keeps
+// analytics inert.
+export const POSTHOG_KEY = 'phc_6a2zd9w9hGzIqYl527bL4dXk3Wz8J9pEHyXTwP1hHq4';
+export const POSTHOG_HOST = 'https://ph.tigrisdata.com';

--- a/packages/cli/src/lib/login/oauth.ts
+++ b/packages/cli/src/lib/login/oauth.ts
@@ -3,6 +3,7 @@ import {
   clearTemporaryCredentials,
   storeSelectedOrganization,
 } from '@auth/storage.js';
+import { identifyOnLogin } from '@utils/analytics.js';
 import { exitWithError, printNextActions } from '@utils/exit.js';
 import {
   msg,
@@ -60,6 +61,10 @@ export async function oauth(
       printSuccess(context, { org: 'none' });
       printNextActions(context);
     }
+
+    // Attach this machine's pre-login CLI activity to the user who just signed
+    // in. Not awaited — login must never wait on analytics.
+    void identifyOnLogin();
   } catch (error) {
     printFailure(context);
     exitWithError(error, context);

--- a/packages/cli/src/lib/telemetry/disable.ts
+++ b/packages/cli/src/lib/telemetry/disable.ts
@@ -1,0 +1,40 @@
+import { failWithError } from '@utils/exit.js';
+import { msg, printSuccess } from '@utils/messages.js';
+import { getFormat } from '@utils/options.js';
+import {
+  setTelemetryOptOut,
+  TELEMETRY_STATE_FILE,
+} from '@utils/telemetry-config.js';
+
+const context = msg('telemetry', 'disable');
+
+export default async function disable(
+  options: Record<string, unknown> = {}
+): Promise<void> {
+  try {
+    const format = getFormat(options);
+
+    // Never report success on a failed write. Telling someone telemetry is off
+    // and then tracking them on the next run is the one outcome this command
+    // exists to prevent, so an unwritable state file has to be an error with a
+    // working alternative rather than a silent no-op.
+    if (!setTelemetryOptOut(true)) {
+      failWithError(
+        context,
+        new Error(
+          `Could not save your preference to ${TELEMETRY_STATE_FILE}. ` +
+            'Set TIGRIS_NO_TELEMETRY=1 in your environment to disable telemetry instead.'
+        )
+      );
+    }
+
+    if (format === 'json') {
+      console.log(JSON.stringify({ enabled: false, action: 'disabled' }));
+      return;
+    }
+
+    printSuccess(context);
+  } catch (error) {
+    failWithError(context, error);
+  }
+}

--- a/packages/cli/src/lib/telemetry/enable.ts
+++ b/packages/cli/src/lib/telemetry/enable.ts
@@ -1,0 +1,55 @@
+import { failWithError } from '@utils/exit.js';
+import { msg, printSuccess } from '@utils/messages.js';
+import { getFormat } from '@utils/options.js';
+import {
+  setTelemetryOptOut,
+  TELEMETRY_STATE_FILE,
+  telemetryDisabledReason,
+} from '@utils/telemetry-config.js';
+
+const context = msg('telemetry', 'enable');
+
+export default async function enable(
+  options: Record<string, unknown> = {}
+): Promise<void> {
+  try {
+    const format = getFormat(options);
+
+    // Symmetric with `disable`: a preference that did not persist would silently
+    // revert on the next run, so report it instead of claiming success.
+    if (!setTelemetryOptOut(false)) {
+      failWithError(
+        context,
+        new Error(
+          `Could not save your preference to ${TELEMETRY_STATE_FILE}. ` +
+            'Check the permissions on that file and its directory.'
+        )
+      );
+    }
+
+    // Env vars outrank the stored setting. Clearing the opt-out while one is
+    // set would otherwise report success and change nothing observable.
+    const remaining = telemetryDisabledReason();
+
+    if (format === 'json') {
+      console.log(
+        JSON.stringify({
+          enabled: remaining === null,
+          action: 'enabled',
+          ...(remaining ? { stillDisabledBy: remaining } : {}),
+        })
+      );
+      return;
+    }
+
+    printSuccess(context);
+
+    if (remaining === 'TIGRIS_NO_TELEMETRY' || remaining === 'DO_NOT_TRACK') {
+      console.log(
+        `\nNote: ${remaining} is set in this environment, which still turns telemetry off.\nUnset it to let this setting take effect.`
+      );
+    }
+  } catch (error) {
+    failWithError(context, error);
+  }
+}

--- a/packages/cli/src/lib/telemetry/status.ts
+++ b/packages/cli/src/lib/telemetry/status.ts
@@ -1,0 +1,89 @@
+import { homedir } from 'node:os';
+
+import { failWithError } from '@utils/exit.js';
+import { msg } from '@utils/messages.js';
+import { getFormat } from '@utils/options.js';
+import {
+  TELEMETRY_STATE_FILE,
+  type TelemetryDisabledReason,
+  telemetryDisabledReason,
+} from '@utils/telemetry-config.js';
+
+const context = msg('telemetry', 'status');
+
+/** Human explanation of which switch is currently in effect. */
+const REASON_LABELS: Record<TelemetryDisabledReason, string> = {
+  TIGRIS_NO_TELEMETRY: 'the TIGRIS_NO_TELEMETRY environment variable is set',
+  DO_NOT_TRACK: 'the DO_NOT_TRACK environment variable is set',
+  'opt-out': 'you disabled it on this machine',
+  development: 'this is a development build',
+  test: 'this is a test environment',
+};
+
+/** Collapse the home directory to `~` so the path is short and portable. */
+function displayPath(path: string): string {
+  const home = homedir();
+  return path.startsWith(home) ? `~${path.slice(home.length)}` : path;
+}
+
+export default async function status(
+  options: Record<string, unknown> = {}
+): Promise<void> {
+  try {
+    const format = getFormat(options);
+    const reason = telemetryDisabledReason();
+    const enabled = reason === null;
+
+    if (format === 'json') {
+      console.log(
+        JSON.stringify({
+          enabled,
+          disabledReason: reason,
+          settingsFile: TELEMETRY_STATE_FILE,
+        })
+      );
+      return;
+    }
+
+    const lines: string[] = [
+      '',
+      `Telemetry: ${enabled ? 'enabled' : 'disabled'}`,
+    ];
+
+    if (!enabled) {
+      lines.push(`   Reason: ${REASON_LABELS[reason]}`);
+    }
+
+    lines.push(
+      '',
+      'What is collected:',
+      '   Usage analytics   which commands you run and their arguments, CLI',
+      '                     version, OS, install method, and whether you are in CI',
+      '   Error reports     crashes and unexpected failures',
+      '',
+      'Never collected:',
+      '   credentials of any kind — access keys, secrets, tokens, passwords —',
+      '   or your hostname. Both are stripped before anything is sent.',
+      '',
+      `Settings file: ${displayPath(TELEMETRY_STATE_FILE)}`,
+      ''
+    );
+
+    // An env var outranks the stored setting, so say so rather than suggesting a
+    // command that would appear to do nothing.
+    if (reason === 'TIGRIS_NO_TELEMETRY' || reason === 'DO_NOT_TRACK') {
+      lines.push(
+        `Unset ${reason} to re-enable, then run "tigris telemetry enable".`,
+        ''
+      );
+    } else if (enabled) {
+      lines.push('To disable: tigris telemetry disable', '');
+    } else if (reason === 'opt-out') {
+      lines.push('To re-enable: tigris telemetry enable', '');
+    }
+
+    console.log(lines.join('\n'));
+  } catch (error) {
+    failWithError(context, error);
+  }
+}

--- a/packages/cli/src/specs.yaml
+++ b/packages/cli/src/specs.yaml
@@ -272,6 +272,44 @@ commands:
 
 
   #########################
+  # Telemetry
+  #########################
+  # telemetry
+  - name: telemetry
+    description: Show or change whether the CLI sends usage analytics and error reports
+    default: status
+    examples:
+      - "tigris telemetry"
+      - "tigris telemetry status"
+      - "tigris telemetry disable"
+      - "tigris telemetry enable"
+    commands:
+      - name: status
+        description: Show whether telemetry is enabled, what is collected, and which setting is in effect
+        examples:
+          - "tigris telemetry status"
+        messages:
+          onStart: ''
+          onSuccess: ''
+          onFailure: 'Failed to read telemetry settings'
+      - name: disable
+        description: Turn off usage analytics and error reports on this machine
+        examples:
+          - "tigris telemetry disable"
+        messages:
+          onStart: ''
+          onSuccess: 'Telemetry disabled. The CLI will not send usage analytics or error reports.'
+          onFailure: 'Failed to disable telemetry'
+      - name: enable
+        description: Turn usage analytics and error reports back on for this machine
+        examples:
+          - "tigris telemetry enable"
+        messages:
+          onStart: ''
+          onSuccess: 'Telemetry enabled. Thanks for helping us improve the CLI.'
+          onFailure: 'Failed to enable telemetry'
+
+  #########################
   # Unix style commands
   #########################
   # ls

--- a/packages/cli/src/utils/analytics.ts
+++ b/packages/cli/src/utils/analytics.ts
@@ -1,0 +1,420 @@
+import { request as httpRequest } from 'node:http';
+import { request as httpsRequest } from 'node:https';
+
+import { version } from '../../package.json';
+import { POSTHOG_HOST, POSTHOG_KEY } from '../constants.js';
+import { getInstallMethod, isBinaryBuild } from './install-method.js';
+import { scrubArgv } from './redact.js';
+import {
+  getAnonymousId,
+  isTelemetryDisabled,
+  markNoticeShown,
+  shouldShowNotice,
+} from './telemetry-config.js';
+
+/**
+ * Usage analytics (PostHog) for the CLI.
+ *
+ * Scope is deliberately narrow: adoption and usage — which commands run, on
+ * what platform, by whom, how often. Failures are *not* tracked here; that is
+ * Sentry's job (utils/telemetry.ts), and the split keeps this path from needing
+ * to run at process exit (see "Why at command start" below).
+ *
+ * What is collected: the canonical command path, the scrubbed command arguments
+ * (bucket names, object keys, paths, and flag values are kept — they are what
+ * make a usage trend actionable), the names of flags used, CLI/runtime/OS
+ * versions, install method, auth method, and CI/TTY shape.
+ *
+ * What is never collected: credentials of any kind — access keys, secrets,
+ * tokens, passwords — nor the machine hostname or working directory. Arguments
+ * pass through the shared scrubber in redact.ts, the same one that guards error
+ * reports, so a redaction fix protects both surfaces at once. Third-party email
+ * addresses are redacted too; the one personal value deliberately sent is the
+ * signed-in user's own email as the PostHog `distinct_id`, so CLI activity joins
+ * the same person record the console creates.
+ *
+ * Analytics is a strict no-op without a project key, stays disabled in
+ * dev/test, and honors the shared opt-out. It must never change the CLI's
+ * behavior, add a failure mode, or throw into the command path.
+ *
+ * Why at command start: the CLI has no reliable place to flush at exit —
+ * `program.parse()` is not awaited and ~370 call sites exit synchronously
+ * through `exitWithError`. Firing when the command begins means the request
+ * overlaps the command's own work, so it usually costs no wall-clock at all and
+ * survives the synchronous exit that ends most commands. The trade is that we
+ * record invocations, not outcomes.
+ *
+ * Known gap: a command that hard-exits *faster* than the request completes
+ * (~200ms) still loses its event — `process.exit()` kills an in-flight socket
+ * regardless of refs. In practice that means local validation failures (bad
+ * arguments, a missing local file) are under-counted, while anything that does
+ * real network work reports reliably. Closing this would require funneling
+ * every exit through the top level; see the note on outcomes above.
+ */
+
+const CAPTURE_PATH = '/i/v0/e/';
+
+/**
+ * Upper bound on what analytics can cost a user, and deliberately tight.
+ *
+ * The socket is left ref'd, so a command that finishes before the request does
+ * will wait for it. That is what makes delivery reliable for fast commands, but
+ * it also means this timeout is the worst case a user pays when PostHog is
+ * *blackholed* — packets dropped with no RST, as on some restrictive corporate
+ * networks. Measured round-trip to the ingest host is ~200ms, so 1s leaves ~5x
+ * headroom for a slow connection while capping the pathological case at
+ * something a person barely notices. Ordinary offline failures (DNS failure,
+ * connection refused) error out immediately and never reach the timeout.
+ *
+ * `socket.unref()` is not used to shorten this: for a socket that is still
+ * connecting, unref does not release the event loop, so it would cap nothing.
+ */
+const REQUEST_TIMEOUT_MS = 1000;
+
+/** Project key and host. Env overrides exist for staging and local PostHog. */
+function resolveKey(): string {
+  return process.env.TIGRIS_POSTHOG_KEY?.trim() || POSTHOG_KEY;
+}
+
+function resolveHost(): string {
+  return process.env.TIGRIS_POSTHOG_HOST?.trim() || POSTHOG_HOST;
+}
+
+const CI_ENV_VARS = [
+  'CI',
+  'CONTINUOUS_INTEGRATION',
+  'BUILD_NUMBER',
+  'GITHUB_ACTIONS',
+  'GITLAB_CI',
+  'CIRCLECI',
+  'TRAVIS',
+  'JENKINS_URL',
+  'BUILDKITE',
+  'TEAMCITY_VERSION',
+  'TF_BUILD',
+];
+
+export function isCI(): boolean {
+  return CI_ENV_VARS.some((name) => {
+    const value = process.env[name];
+    return (
+      value !== undefined &&
+      value !== '' &&
+      value !== '0' &&
+      value.toLowerCase() !== 'false'
+    );
+  });
+}
+
+// A flag name is a fixed CLI keyword. Anything not matching this shape is
+// dropped, keeping this a clean low-cardinality dimension for aggregation
+// ("what share of runs pass --json") rather than a second copy of the args.
+const FLAG_NAME_RE = /^[a-z0-9][a-z0-9-]*$/i;
+
+/**
+ * The names of flags the user typed, with values dropped — the full arguments
+ * are reported separately by `scrubArgv`. Read from raw argv rather than the
+ * parsed options object on purpose: parsed options are populated with spec
+ * defaults, which would report flags nobody passed.
+ */
+export function usedFlags(argv: string[]): string[] {
+  const names = new Set<string>();
+  for (const arg of argv) {
+    // Stop at the end-of-options separator: everything after it is positional,
+    // and a positional may legitimately begin with a dash (object keys can).
+    // Scanning past `--` would file those values under the flags dimension.
+    if (arg === '--') {
+      break;
+    }
+    if (!arg.startsWith('-') || arg === '-') {
+      continue;
+    }
+    const name = arg.split('=')[0].replace(/^--?/, '');
+    if (FLAG_NAME_RE.test(name)) {
+      names.add(name);
+    }
+  }
+  return [...names].sort();
+}
+
+/**
+ * Read the `email` claim out of a stored ID token.
+ *
+ * Deliberately does not verify the signature: this only labels our own
+ * analytics, so it is not a security decision, and verification would cost a
+ * JWKS network round trip on every command. A user who forges this is
+ * mislabeling their own usage data.
+ */
+export function decodeTokenEmail(idToken: string): string | undefined {
+  try {
+    const payload = idToken.split('.')[1];
+    if (!payload) {
+      return undefined;
+    }
+    const claims: unknown = JSON.parse(
+      Buffer.from(payload, 'base64url').toString('utf8')
+    );
+    const email = (claims as { email?: unknown } | null)?.email;
+    return typeof email === 'string' && email.length > 0 ? email : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+interface Identity {
+  /** Email when signed in, otherwise the machine's anonymous id. */
+  distinctId: string;
+  anonymousId: string;
+  isIdentified: boolean;
+  authMethod: 'oauth' | 'credentials' | 'none';
+  organizationId?: string;
+}
+
+/**
+ * Resolve who this invocation belongs to.
+ *
+ * `@auth/storage.js` is imported dynamically to keep it (and its transitive
+ * deps) off the startup path of every command — this module is reachable from
+ * cli-core, which loads before anything is dispatched.
+ */
+async function resolveIdentity(): Promise<Identity> {
+  const anonymousId = getAnonymousId();
+  const fallback: Identity = {
+    distinctId: anonymousId,
+    anonymousId,
+    isIdentified: false,
+    authMethod: 'none',
+  };
+
+  try {
+    const storage = await import('@auth/storage.js');
+    const tokens = await storage.getTokens();
+    const email = tokens?.idToken
+      ? decodeTokenEmail(tokens.idToken)
+      : undefined;
+
+    return {
+      distinctId: email ?? anonymousId,
+      anonymousId,
+      isIdentified: email !== undefined,
+      authMethod: storage.getLoginMethod() ?? 'none',
+      organizationId: storage.getSelectedOrganization() ?? undefined,
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Properties describing the CLI itself. `$lib`/`$lib_version` follow PostHog
+ * convention so CLI events are filterable alongside the console's web events
+ * in the same project.
+ */
+function baseProperties(): Record<string, unknown> {
+  return {
+    $lib: 'tigris-cli',
+    $lib_version: version,
+    interface: 'cli',
+    cli_version: version,
+    runtime: isBinaryBuild() ? 'binary' : 'node',
+    install_method: getInstallMethod(),
+    node_version: process.version,
+    os: process.platform,
+    arch: process.arch,
+    is_ci: isCI(),
+    is_tty: process.stdout.isTTY === true,
+  };
+}
+
+/**
+ * POST a single event. Never rejects and never throws — every outcome
+ * (success, network error, timeout, malformed host) resolves quietly.
+ */
+function post(body: unknown): Promise<void> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = () => {
+      if (!settled) {
+        settled = true;
+        resolve();
+      }
+    };
+
+    try {
+      const url = new URL(CAPTURE_PATH, resolveHost());
+      const payload = JSON.stringify(body);
+      // http support exists only so a local PostHog can be pointed at via
+      // TIGRIS_POSTHOG_HOST; the shipped default is always https.
+      const request = url.protocol === 'http:' ? httpRequest : httpsRequest;
+
+      const req = request(
+        {
+          protocol: url.protocol,
+          hostname: url.hostname,
+          port: url.port || undefined,
+          path: url.pathname,
+          method: 'POST',
+          timeout: REQUEST_TIMEOUT_MS,
+          headers: {
+            'content-type': 'application/json',
+            'content-length': Buffer.byteLength(payload),
+            'user-agent': `tigris-cli/${version}`,
+          },
+        },
+        (res) => {
+          // Drain so the socket can close, then settle regardless of status —
+          // there is nothing useful to do about a rejected event.
+          res.resume();
+          res.on('end', done);
+          res.on('error', done);
+        }
+      );
+
+      req.on('error', done);
+      req.on('timeout', () => {
+        req.destroy();
+        done();
+      });
+      req.end(payload);
+    } catch {
+      done();
+    }
+  });
+}
+
+const NOTICE = `
+Tigris CLI collects usage analytics (which commands you run and their
+arguments, CLI version, OS) and error reports, to help us decide what to
+improve. Credentials — access keys, secrets, tokens — are never collected.
+
+Opt out any time:  tigris telemetry disable   (or set TIGRIS_NO_TELEMETRY=1)
+`;
+
+/**
+ * Commands excluded from analytics. Managing your telemetry preference is not
+ * product usage, and capturing it would mean sending one last event for the
+ * very command someone runs to opt out.
+ */
+const UNTRACKED_COMMANDS: ReadonlySet<string> = new Set(['telemetry']);
+
+/**
+ * Print the one-time disclosure notice, at most once per machine.
+ *
+ * Written to stderr so it can never corrupt piped stdout, and only in an
+ * interactive terminal — the notice is only marked shown when it was actually
+ * displayed, so a CI run doesn't consume the one chance a human has to read it.
+ */
+function printTelemetryNoticeOnce(): void {
+  if (isTelemetryDisabled()) {
+    return;
+  }
+  if (process.stderr.isTTY !== true || globalThis.__TIGRIS_JSON_MODE === true) {
+    return;
+  }
+  if (!shouldShowNotice()) {
+    return;
+  }
+  console.error(NOTICE);
+  markNoticeShown();
+}
+
+/**
+ * Record a command invocation. Fire-and-forget: callers should `void` this
+ * rather than await it, so the request overlaps the command's own work.
+ */
+export async function captureCommand(commandPath: string[]): Promise<void> {
+  try {
+    const apiKey = resolveKey();
+    if (!apiKey || isTelemetryDisabled()) {
+      return;
+    }
+
+    const identity = await resolveIdentity();
+    const argv = process.argv.slice(2);
+
+    await post({
+      api_key: apiKey,
+      event: 'cli_command',
+      distinct_id: identity.distinctId,
+      properties: {
+        ...baseProperties(),
+        // The canonical path from the command registry, never raw user input.
+        command: commandPath.join(' '),
+        command_root: commandPath[0],
+        // Full arguments with credentials and third-party PII stripped by the
+        // shared scrubber. High cardinality by nature — use `command` and
+        // `flags` for aggregation and this for looking at real invocations.
+        command_args: scrubArgv(argv).join(' '),
+        flags: usedFlags(argv),
+        auth_method: identity.authMethod,
+        json_mode: globalThis.__TIGRIS_JSON_MODE === true,
+        // Namespaced so CLI events never clobber console-owned person
+        // properties such as `email` and `name`.
+        $set: {
+          cli_version: version,
+          cli_install_method: getInstallMethod(),
+          cli_last_os: process.platform,
+        },
+        ...(identity.organizationId
+          ? { $groups: { company: identity.organizationId } }
+          : {}),
+      },
+    });
+  } catch {
+    // Analytics must never affect the CLI.
+  }
+}
+
+/**
+ * Single entry point for the command dispatcher: show the disclosure notice if
+ * it is owed, then record the invocation without waiting for it.
+ */
+export function trackCommand(commandPath: string[]): void {
+  if (UNTRACKED_COMMANDS.has(commandPath[0])) {
+    return;
+  }
+  printTelemetryNoticeOnce();
+  void captureCommand(commandPath);
+}
+
+/**
+ * Attach this machine's pre-login activity to the user who just signed in.
+ *
+ * `$anon_distinct_id` is what makes the install → first command → logged in
+ * funnel work: PostHog merges the anonymous person into the identified one.
+ * The identified id is the email, which is also what the console aliases to,
+ * so CLI and web activity land on a single person.
+ */
+export async function identifyOnLogin(): Promise<void> {
+  try {
+    const apiKey = resolveKey();
+    if (!apiKey || isTelemetryDisabled()) {
+      return;
+    }
+
+    const identity = await resolveIdentity();
+    if (!identity.isIdentified) {
+      return;
+    }
+
+    await post({
+      api_key: apiKey,
+      event: '$identify',
+      distinct_id: identity.distinctId,
+      properties: {
+        ...baseProperties(),
+        $anon_distinct_id: identity.anonymousId,
+        $set: {
+          email: identity.distinctId,
+          cli_version: version,
+          cli_install_method: getInstallMethod(),
+        },
+        ...(identity.organizationId
+          ? { $groups: { company: identity.organizationId } }
+          : {}),
+      },
+    });
+  } catch {
+    // Analytics must never affect the CLI.
+  }
+}

--- a/packages/cli/src/utils/install-method.ts
+++ b/packages/cli/src/utils/install-method.ts
@@ -1,0 +1,40 @@
+import { realpathSync } from 'node:fs';
+
+/**
+ * How this CLI was installed. Shared by the update notifier (to print the right
+ * upgrade command) and analytics (to see which channel users actually install
+ * through).
+ */
+export type InstallMethod = 'npm' | 'homebrew' | 'binary';
+
+/** True when running as a compiled standalone binary rather than under Node. */
+export function isBinaryBuild(): boolean {
+  return (globalThis as { __TIGRIS_BINARY?: boolean }).__TIGRIS_BINARY === true;
+}
+
+function isHomebrewInstall(): boolean {
+  if (process.platform === 'win32') {
+    return false;
+  }
+  try {
+    const resolved = realpathSync(process.execPath);
+    return resolved.includes('/Cellar/') || resolved.includes('/Caskroom/');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The npm check must come first: under an npm install `process.execPath` is
+ * Node itself, which is frequently Homebrew-installed and would otherwise be
+ * misread as a Homebrew CLI install.
+ */
+export function getInstallMethod(): InstallMethod {
+  if (!isBinaryBuild()) {
+    return 'npm';
+  }
+  if (isHomebrewInstall()) {
+    return 'homebrew';
+  }
+  return 'binary';
+}

--- a/packages/cli/src/utils/redact.ts
+++ b/packages/cli/src/utils/redact.ts
@@ -1,0 +1,108 @@
+/**
+ * Credential and PII redaction for anything the CLI reports about itself.
+ *
+ * This is the single redaction policy shared by both telemetry surfaces — error
+ * reports (utils/telemetry.ts) and usage analytics (utils/analytics.ts). It
+ * lives on its own so the two can never drift: a pattern added here to stop a
+ * leak has to protect both, and a gap found in one is a gap in the other.
+ *
+ * The policy is deliberately *not* "collect nothing". Command arguments —
+ * bucket names, object keys, paths, flag values — are kept, because they are
+ * what make a report or a usage trend actionable. What must never leave the
+ * machine is credentials: access keys, secrets, tokens, passwords. Third-party
+ * email addresses are redacted too, since an argv can name other people.
+ */
+
+// Patterns for sensitive VALUES that may appear anywhere in a captured command
+// — as a positional or a flag value — and are redacted wherever found.
+const SECRET_PATTERNS: RegExp[] = [
+  // Email addresses (PII).
+  /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g,
+  // Tigris access-key ids and secrets (tid_… / tsec_…).
+  /\bt(?:id|sec)_[A-Za-z0-9]+/gi,
+  // JWTs / opaque bearer tokens.
+  /eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{4,}/g,
+  /Bearer\s+[A-Za-z0-9._-]+/gi,
+  // AWS-style access key ids.
+  /AKIA[0-9A-Z]{16}/g,
+  // key=value / key: value where the key names a secret.
+  /((?:secret[-_ ]?access[-_ ]?key|secret|password|token|authorization)["']?\s*[:=]\s*["']?)([^\s"',]+)/gi,
+];
+
+export function redactSecrets(text: string): string {
+  let out = text;
+  for (const pattern of SECRET_PATTERNS) {
+    // Patterns with a leading capture group (e.g. `secret=`) preserve it and
+    // redact the value; patterns without one redact the whole match. The second
+    // replacer arg is the capture only when it's a string — for group-less
+    // patterns it's the match offset (a number), which must not be emitted.
+    out = out.replace(pattern, (_match, prefix?: string | number) =>
+      typeof prefix === 'string' ? `${prefix}[redacted]` : '[redacted]'
+    );
+  }
+  return out;
+}
+
+// Flag names whose VALUE is a credential or PII and must be redacted. Matched
+// loosely so we don't depend on an exact, drift-prone list. `key$` covers the
+// key family — `--key` (the CLI's alias for --access-key), `--access-key`,
+// `--secret-key` — without matching non-secret flags like `--key-marker`.
+// Object keys are positional args, so they never reach this flag check.
+const SENSITIVE_FLAG_RE =
+  /secret|password|token|credential|auth|user(name)?|e-?mail|owner|name|key$/i;
+
+// Sensitive flags too short to pattern-match. `-t` is the webhook `--token`
+// alias; it also aliases `--default-tier` on bucket commands, but redacting a
+// tier value is harmless. Extend this as new sensitive short aliases appear.
+const SENSITIVE_SHORT_FLAGS: ReadonlySet<string> = new Set(['-t']);
+
+function isSensitiveFlag(flag: string): boolean {
+  return SENSITIVE_FLAG_RE.test(flag) || SENSITIVE_SHORT_FLAGS.has(flag);
+}
+
+/**
+ * Scrub a captured argv. The command and its arguments are kept (bucket names,
+ * object keys, and paths are useful for debugging and for understanding usage),
+ * but the values of credential/PII flags are redacted, and any credential- or
+ * PII-shaped value (access keys, tokens, JWTs, emails) is redacted wherever it
+ * appears — including in positionals.
+ */
+export function scrubArgv(argv: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const eq = arg.indexOf('=');
+
+    // `--flag=value`: handled entirely here. Redact the value outright when the
+    // flag name is sensitive, otherwise still scrub any secret/PII-shaped value
+    // inside it. This must `continue` — falling through to the space-form branch
+    // (which tests the whole token) would let a sensitive substring in the value
+    // both skip redaction and mis-redact the next positional.
+    if (arg.startsWith('-') && eq !== -1) {
+      const name = arg.slice(0, eq);
+      out.push(
+        isSensitiveFlag(name)
+          ? `${name}=[redacted]`
+          : `${name}=${redactSecrets(arg.slice(eq + 1))}`
+      );
+      continue;
+    }
+
+    // `--flag value` (bare flag only — `--flag=value` already continued above):
+    // redact the following value when the flag name is sensitive.
+    if (
+      arg.startsWith('-') &&
+      isSensitiveFlag(arg) &&
+      i + 1 < argv.length &&
+      !argv[i + 1].startsWith('-')
+    ) {
+      out.push(arg, '[redacted]');
+      i++;
+      continue;
+    }
+
+    // Positional (or valueless bare flag): redact any secret/PII-shaped value.
+    out.push(redactSecrets(arg));
+  }
+  return out;
+}

--- a/packages/cli/src/utils/telemetry-config.ts
+++ b/packages/cli/src/utils/telemetry-config.ts
@@ -1,0 +1,166 @@
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Shared opt-out gate and persisted state for both CLI telemetry surfaces:
+ * error reports (Sentry — utils/telemetry.ts) and usage analytics (PostHog —
+ * utils/analytics.ts). Both read the gate here so there is exactly one opt-out
+ * for users to find, and turning it off turns off everything.
+ *
+ * State lives in ~/.tigris/telemetry.json rather than config.json on purpose:
+ * `logout` clears config.json wholesale, and neither the opt-out nor the
+ * anonymous id should come back to life because someone logged out.
+ */
+
+const STATE_DIR = join(homedir(), '.tigris');
+const STATE_FILE = join(STATE_DIR, 'telemetry.json');
+
+// Exported for tests and for `tigris telemetry status` to show the user.
+export { STATE_FILE as TELEMETRY_STATE_FILE };
+
+export interface TelemetryState {
+  /** Stable per-machine id used when no authenticated user is known. */
+  anonymousId?: string;
+  /** Persisted opt-out, set by `tigris telemetry disable`. */
+  optOut?: boolean;
+  /** When the one-time disclosure notice was printed (epoch ms). */
+  noticeShownAt?: number;
+}
+
+let cached: TelemetryState | null = null;
+
+/**
+ * Read persisted state, memoized for the life of the process. A missing,
+ * unreadable, or malformed file is treated as empty state — telemetry
+ * preferences must never be a reason the CLI fails to start.
+ */
+export function readTelemetryState(): TelemetryState {
+  if (cached) {
+    return cached;
+  }
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(STATE_FILE, 'utf8'));
+    cached =
+      parsed !== null && typeof parsed === 'object'
+        ? (parsed as TelemetryState)
+        : {};
+  } catch {
+    cached = {};
+  }
+  return cached;
+}
+
+/**
+ * Persist state. Returns false when it could not be written (read-only home,
+ * full disk). Callers recording a *user's explicit preference* must surface
+ * that; callers doing best-effort bookkeeping may ignore it.
+ */
+function writeTelemetryState(next: TelemetryState): boolean {
+  // Cache first: even when the write below fails, the in-memory value keeps
+  // this process internally consistent.
+  cached = next;
+  try {
+    mkdirSync(STATE_DIR, { recursive: true });
+    writeFileSync(STATE_FILE, JSON.stringify(next, null, 2), 'utf8');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Test seam: drop the memoized state so a fresh read hits the filesystem. */
+export function resetTelemetryStateCache(): void {
+  cached = null;
+}
+
+/**
+ * Truthiness for the opt-out env vars. `DO_NOT_TRACK`'s convention is that any
+ * value other than `0`/empty means opt out, so this deliberately accepts more
+ * than the literal `'1'` the CLI used to require — `DO_NOT_TRACK=true`
+ * previously did nothing at all. Broadening can only ever add opt-outs.
+ */
+function isEnvTruthy(raw: string | undefined): boolean {
+  if (raw === undefined) {
+    return false;
+  }
+  const value = raw.trim().toLowerCase();
+  return value !== '' && value !== '0' && value !== 'false' && value !== 'no';
+}
+
+export type TelemetryDisabledReason =
+  | 'TIGRIS_NO_TELEMETRY'
+  | 'DO_NOT_TRACK'
+  | 'opt-out'
+  | 'development'
+  | 'test';
+
+/**
+ * Why telemetry is off, or null when it is on. Surfaced by
+ * `tigris telemetry status` so users can see *which* switch is in effect —
+ * an env var set by their CI image explains a lot more than "disabled".
+ */
+export function telemetryDisabledReason(): TelemetryDisabledReason | null {
+  if (isEnvTruthy(process.env.TIGRIS_NO_TELEMETRY)) {
+    return 'TIGRIS_NO_TELEMETRY';
+  }
+  if (isEnvTruthy(process.env.DO_NOT_TRACK)) {
+    return 'DO_NOT_TRACK';
+  }
+  // Our own runs must never pollute production data. Customer CI is
+  // deliberately *not* excluded — that is real usage worth measuring.
+  if (process.env.NODE_ENV === 'test') {
+    return 'test';
+  }
+  if (process.env.TIGRIS_ENV === 'development') {
+    return 'development';
+  }
+  if (readTelemetryState().optOut === true) {
+    return 'opt-out';
+  }
+  return null;
+}
+
+export function isTelemetryDisabled(): boolean {
+  return telemetryDisabledReason() !== null;
+}
+
+/**
+ * Stable anonymous id for this machine, created on first use.
+ *
+ * If the state file cannot be written (read-only home), each run gets a fresh
+ * id and person counts inflate. That degrades gracefully rather than failing,
+ * and such runs are almost always CI, which the `is_ci` property lets us
+ * filter out downstream.
+ */
+export function getAnonymousId(): string {
+  const state = readTelemetryState();
+  if (state.anonymousId) {
+    return state.anonymousId;
+  }
+  const anonymousId = randomUUID();
+  writeTelemetryState({ ...state, anonymousId });
+  return anonymousId;
+}
+
+/**
+ * Record the user's telemetry preference.
+ *
+ * Returns false when the preference could not be persisted, which callers MUST
+ * surface rather than swallow: telling someone telemetry is off and then
+ * tracking them again on the next run — because the write silently failed — is
+ * exactly the outcome the opt-out exists to prevent.
+ */
+export function setTelemetryOptOut(optOut: boolean): boolean {
+  return writeTelemetryState({ ...readTelemetryState(), optOut });
+}
+
+/** True until the one-time disclosure notice has been recorded as shown. */
+export function shouldShowNotice(): boolean {
+  return readTelemetryState().noticeShownAt === undefined;
+}
+
+export function markNoticeShown(): void {
+  writeTelemetryState({ ...readTelemetryState(), noticeShownAt: Date.now() });
+}

--- a/packages/cli/src/utils/telemetry.ts
+++ b/packages/cli/src/utils/telemetry.ts
@@ -2,6 +2,8 @@ import * as Sentry from '@sentry/node';
 import { version } from '../../package.json';
 import { SENTRY_DSN } from '../constants.js';
 import type { ErrorCategory } from './errors.js';
+import { redactSecrets, scrubArgv } from './redact.js';
+import { isTelemetryDisabled } from './telemetry-config.js';
 
 /**
  * Error telemetry (Sentry) for the CLI.
@@ -12,8 +14,9 @@ import type { ErrorCategory } from './errors.js';
  * noise, not bugs.
  *
  * Telemetry is a strict no-op unless a DSN is configured, and stays disabled in
- * dev/test and whenever the user opts out. It must never change the CLI's
- * behavior or throw into the command path.
+ * dev/test and whenever the user opts out (the shared gate lives in
+ * telemetry-config.ts and covers usage analytics too). It must never change the
+ * CLI's behavior or throw into the command path.
  */
 
 // Categories worth reporting for a handled (failWithError) exit. Crashes are
@@ -34,118 +37,13 @@ function resolveDsn(): string {
   return process.env.TIGRIS_SENTRY_DSN?.trim() || SENTRY_DSN;
 }
 
-/**
- * Honor explicit opt-out and the community-standard DO_NOT_TRACK, and stay
- * silent in dev/test so our own runs never pollute production data. (Customer
- * CI is deliberately *not* excluded — that is real usage worth tracking.)
- */
-function telemetryDisabled(): boolean {
-  return (
-    // Product opt-out, matching the repo's TIGRIS_NO_* convention.
-    process.env.TIGRIS_NO_TELEMETRY === '1' ||
-    // Cross-tool standard
-    process.env.DO_NOT_TRACK === '1' ||
-    process.env.NODE_ENV === 'test' ||
-    process.env.TIGRIS_ENV === 'development'
-  );
-}
-
 const environment =
   process.env.TIGRIS_ENV === 'development' ? 'development' : 'production';
 
-// Patterns for sensitive VALUES that may appear anywhere in the captured
-// command — as a positional or a flag value — and are redacted wherever found.
-const SECRET_PATTERNS: RegExp[] = [
-  // Email addresses (PII).
-  /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g,
-  // Tigris access-key ids and secrets (tid_… / tsec_…).
-  /\bt(?:id|sec)_[A-Za-z0-9]+/gi,
-  // JWTs / opaque bearer tokens.
-  /eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{4,}/g,
-  /Bearer\s+[A-Za-z0-9._-]+/gi,
-  // AWS-style access key ids.
-  /AKIA[0-9A-Z]{16}/g,
-  // key=value / key: value where the key names a secret.
-  /((?:secret[-_ ]?access[-_ ]?key|secret|password|token|authorization)["']?\s*[:=]\s*["']?)([^\s"',]+)/gi,
-];
-
-export function redactSecrets(text: string): string {
-  let out = text;
-  for (const pattern of SECRET_PATTERNS) {
-    // Patterns with a leading capture group (e.g. `secret=`) preserve it and
-    // redact the value; patterns without one redact the whole match. The second
-    // replacer arg is the capture only when it's a string — for group-less
-    // patterns it's the match offset (a number), which must not be emitted.
-    out = out.replace(pattern, (_match, prefix?: string | number) =>
-      typeof prefix === 'string' ? `${prefix}[redacted]` : '[redacted]'
-    );
-  }
-  return out;
-}
-
-// Flag names whose VALUE is a credential or PII and must be redacted. Matched
-// loosely so we don't depend on an exact, drift-prone list. `key$` covers the
-// key family — `--key` (the CLI's alias for --access-key), `--access-key`,
-// `--secret-key` — without matching non-secret flags like `--key-marker`.
-// Object keys are positional args, so they never reach this flag check.
-const SENSITIVE_FLAG_RE =
-  /secret|password|token|credential|auth|user(name)?|e-?mail|owner|name|key$/i;
-
-// Sensitive flags too short to pattern-match. `-t` is the webhook `--token`
-// alias; it also aliases `--default-tier` on bucket commands, but redacting a
-// tier value is harmless. Extend this as new sensitive short aliases appear.
-const SENSITIVE_SHORT_FLAGS: ReadonlySet<string> = new Set(['-t']);
-
-function isSensitiveFlag(flag: string): boolean {
-  return SENSITIVE_FLAG_RE.test(flag) || SENSITIVE_SHORT_FLAGS.has(flag);
-}
-
-/**
- * Scrub a captured argv for telemetry. The command and its arguments are kept
- * (bucket names, object keys, and paths are useful for debugging), but the
- * values of credential/PII flags are redacted, and any credential- or
- * PII-shaped value (access keys, tokens, JWTs, emails) is redacted wherever it
- * appears — including in positionals.
- */
-export function scrubArgv(argv: string[]): string[] {
-  const out: string[] = [];
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
-    const eq = arg.indexOf('=');
-
-    // `--flag=value`: handled entirely here. Redact the value outright when the
-    // flag name is sensitive, otherwise still scrub any secret/PII-shaped value
-    // inside it. This must `continue` — falling through to the space-form branch
-    // (which tests the whole token) would let a sensitive substring in the value
-    // both skip redaction and mis-redact the next positional.
-    if (arg.startsWith('-') && eq !== -1) {
-      const name = arg.slice(0, eq);
-      out.push(
-        isSensitiveFlag(name)
-          ? `${name}=[redacted]`
-          : `${name}=${redactSecrets(arg.slice(eq + 1))}`
-      );
-      continue;
-    }
-
-    // `--flag value` (bare flag only — `--flag=value` already continued above):
-    // redact the following value when the flag name is sensitive.
-    if (
-      arg.startsWith('-') &&
-      isSensitiveFlag(arg) &&
-      i + 1 < argv.length &&
-      !argv[i + 1].startsWith('-')
-    ) {
-      out.push(arg, '[redacted]');
-      i++;
-      continue;
-    }
-
-    // Positional (or valueless bare flag): redact any secret/PII-shaped value.
-    out.push(redactSecrets(arg));
-  }
-  return out;
-}
+// The redaction policy lives in redact.ts so error reports and usage analytics
+// share exactly one implementation. Re-exported here because this module's
+// public surface (and its tests) have always exposed them.
+export { redactSecrets, scrubArgv };
 
 /** The top-level command name (first non-flag arg), used as a searchable tag. */
 export function invocationCommand(argv: string[]): string | undefined {
@@ -212,7 +110,7 @@ export function initTelemetry(): void {
   initialized = true;
 
   const dsn = resolveDsn();
-  if (!dsn || telemetryDisabled()) {
+  if (!dsn || isTelemetryDisabled()) {
     return;
   }
 

--- a/packages/cli/src/utils/update-check.ts
+++ b/packages/cli/src/utils/update-check.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import https from 'node:https';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
@@ -9,6 +9,7 @@ import {
   UPDATE_CHECK_INTERVAL_MS,
   UPDATE_NOTIFY_INTERVAL_MS,
 } from '../constants.js';
+import { getInstallMethod } from './install-method.js';
 
 interface UpdateCheckCache {
   latestVersion: string;
@@ -92,40 +93,20 @@ export function isNewerVersion(current: string, latest: string): boolean {
   return false;
 }
 
-function isHomebrewInstall(): boolean {
-  if (process.platform === 'win32') return false;
-  try {
-    const resolved = realpathSync(process.execPath);
-    return resolved.includes('/Cellar/') || resolved.includes('/Caskroom/');
-  } catch {
-    return false;
-  }
-}
-
 /**
  * Returns the platform-appropriate shell command for updating the CLI.
  */
 export function getUpdateCommand(): string {
-  const isBinary =
-    (globalThis as { __TIGRIS_BINARY?: boolean }).__TIGRIS_BINARY === true;
-
-  // npm install — process.execPath is Node, not our binary.
-  // Must come before isHomebrewInstall() to avoid false positives
-  // when Node itself was installed via Homebrew.
-  if (!isBinary) {
-    return 'npm install -g @tigrisdata/cli';
-  }
-  // Standalone binary installed via Homebrew (execPath resolves to /Cellar/ or /Caskroom/)
-  else if (isHomebrewInstall()) {
-    return 'brew upgrade tigris';
-  }
-  // Standalone binary on Windows
-  else if (process.platform === 'win32') {
-    return 'irm https://raw.githubusercontent.com/tigrisdata/storage/main/packages/cli/scripts/install.ps1 | iex';
-  }
-  // Standalone binary on macOS/Linux (installed via curl)
-  else {
-    return 'curl -fsSL https://raw.githubusercontent.com/tigrisdata/storage/main/packages/cli/scripts/install.sh | sh';
+  switch (getInstallMethod()) {
+    case 'npm':
+      return 'npm install -g @tigrisdata/cli';
+    case 'homebrew':
+      return 'brew upgrade tigris';
+    default:
+      // Standalone binary installed via the curl/irm script.
+      return process.platform === 'win32'
+        ? 'irm https://raw.githubusercontent.com/tigrisdata/storage/main/packages/cli/scripts/install.ps1 | iex'
+        : 'curl -fsSL https://raw.githubusercontent.com/tigrisdata/storage/main/packages/cli/scripts/install.sh | sh';
   }
 }
 

--- a/packages/cli/test/utils/analytics.test.ts
+++ b/packages/cli/test/utils/analytics.test.ts
@@ -1,0 +1,402 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { hostname, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+// Redirect HOME before importing anything that resolves ~/.tigris, so the
+// anonymous id is written to a temp dir instead of the developer's real config.
+const TEST_HOME = mkdtempSync(join(tmpdir(), 'tigris-analytics-'));
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_USERPROFILE = process.env.USERPROFILE;
+process.env.HOME = TEST_HOME;
+process.env.USERPROFILE = TEST_HOME;
+
+// Identity comes from the auth config on disk; mock it so these tests do not
+// depend on whether the developer running them happens to be logged in.
+const { identity } = vi.hoisted(() => ({
+  identity: {
+    idToken: undefined as string | undefined,
+    loginMethod: null as 'oauth' | 'credentials' | null,
+    organizationId: null as string | null,
+  },
+}));
+
+vi.mock('../../src/auth/storage.js', () => ({
+  getTokens: async () =>
+    identity.idToken ? { accessToken: 'a', idToken: identity.idToken } : null,
+  getLoginMethod: () => identity.loginMethod,
+  getSelectedOrganization: () => identity.organizationId,
+}));
+
+// Capture what would go over the wire instead of sending it.
+const { sentBodies, requestMock } = vi.hoisted(() => {
+  const sentBodies: string[] = [];
+  const requestMock = (
+    _options: unknown,
+    callback?: (res: unknown) => void
+  ) => {
+    const res = {
+      resume: () => {},
+      on: (event: string, handler: () => void) => {
+        if (event === 'end') {
+          setImmediate(handler);
+        }
+      },
+    };
+    if (callback) {
+      setImmediate(() => callback(res));
+    }
+    return {
+      on: () => {},
+      end: (payload: string) => {
+        sentBodies.push(payload);
+      },
+      destroy: () => {},
+    };
+  };
+  return { sentBodies, requestMock };
+});
+
+vi.mock('node:https', () => ({ request: requestMock }));
+vi.mock('node:http', () => ({ request: requestMock }));
+
+const {
+  captureCommand,
+  decodeTokenEmail,
+  identifyOnLogin,
+  isCI,
+  trackCommand,
+  usedFlags,
+} = await import('../../src/utils/analytics.js');
+
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+const ORIGINAL_ARGV = process.argv;
+
+const CI_VARS = [
+  'CI',
+  'CONTINUOUS_INTEGRATION',
+  'BUILD_NUMBER',
+  'GITHUB_ACTIONS',
+  'GITLAB_CI',
+  'CIRCLECI',
+  'TRAVIS',
+  'JENKINS_URL',
+  'BUILDKITE',
+  'TEAMCITY_VERSION',
+  'TF_BUILD',
+];
+
+/** Let the mocked request's setImmediate callbacks settle. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 20));
+
+beforeEach(() => {
+  sentBodies.length = 0;
+  // The suite runs with NODE_ENV=test, which disables telemetry outright.
+  process.env.NODE_ENV = 'production';
+  process.env.TIGRIS_POSTHOG_KEY = 'phc_test_key';
+  delete process.env.TIGRIS_NO_TELEMETRY;
+  delete process.env.DO_NOT_TRACK;
+  delete process.env.TIGRIS_ENV;
+  for (const name of CI_VARS) {
+    delete process.env[name];
+  }
+  identity.idToken = undefined;
+  identity.loginMethod = null;
+  identity.organizationId = null;
+});
+
+afterEach(() => {
+  process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+  delete process.env.TIGRIS_POSTHOG_KEY;
+  process.argv = ORIGINAL_ARGV;
+});
+
+afterAll(() => {
+  process.env.HOME = ORIGINAL_HOME;
+  process.env.USERPROFILE = ORIGINAL_USERPROFILE;
+  rmSync(TEST_HOME, { recursive: true, force: true });
+});
+
+describe('usedFlags', () => {
+  it('keeps flag names and drops their values', () => {
+    expect(
+      usedFlags(['cp', './local.txt', 't3://bucket/key', '--json', '-y'])
+    ).toEqual(['json', 'y']);
+  });
+
+  it('drops the value from --flag=value form', () => {
+    expect(usedFlags(['--region=iad', '--format=json'])).toEqual([
+      'format',
+      'region',
+    ]);
+  });
+
+  it('deduplicates and sorts for stable grouping in PostHog', () => {
+    expect(usedFlags(['--json', '--region', 'iad', '--json'])).toEqual([
+      'json',
+      'region',
+    ]);
+  });
+
+  it('ignores bare separators', () => {
+    expect(usedFlags(['-', '--', 'bucket'])).toEqual([]);
+  });
+
+  // Object keys may legitimately begin with a dash, and `--` is how they get
+  // past the parser. Scanning further would report the key itself as a flag.
+  it('stops at the end-of-options separator so positionals cannot leak', () => {
+    expect(usedFlags(['rm', '--json', '--', '-my-secret-object'])).toEqual([
+      'json',
+    ]);
+    expect(usedFlags(['rm', '--', '-a', '--bucket-name'])).toEqual([]);
+  });
+
+  it('drops anything that is not a plain flag name', () => {
+    // A value that happens to start with a dash must not be reported as a flag.
+    expect(usedFlags(['--key', '-----', '--a b', '--x/y'])).toEqual(['key']);
+  });
+});
+
+describe('decodeTokenEmail', () => {
+  const encode = (claims: unknown) =>
+    `header.${Buffer.from(JSON.stringify(claims)).toString('base64url')}.sig`;
+
+  it('reads the email claim', () => {
+    expect(decodeTokenEmail(encode({ email: 'alice@example.com' }))).toBe(
+      'alice@example.com'
+    );
+  });
+
+  it('returns undefined when there is no email claim', () => {
+    expect(decodeTokenEmail(encode({ sub: 'user_123' }))).toBeUndefined();
+  });
+
+  it('returns undefined for an empty email claim', () => {
+    expect(decodeTokenEmail(encode({ email: '' }))).toBeUndefined();
+  });
+
+  it('returns undefined rather than throwing on malformed input', () => {
+    expect(decodeTokenEmail('not-a-jwt')).toBeUndefined();
+    expect(decodeTokenEmail('')).toBeUndefined();
+    expect(decodeTokenEmail('header..sig')).toBeUndefined();
+    expect(decodeTokenEmail('header.@@@not-base64@@@.sig')).toBeUndefined();
+  });
+});
+
+describe('isCI', () => {
+  it('is false with no CI variables set', () => {
+    expect(isCI()).toBe(false);
+  });
+
+  it.each(['CI', 'GITHUB_ACTIONS', 'BUILDKITE'])('detects %s', (name) => {
+    process.env[name] = 'true';
+    expect(isCI()).toBe(true);
+  });
+
+  it.each(['false', '0', ''])('ignores CI=%s', (value) => {
+    process.env.CI = value;
+    expect(isCI()).toBe(false);
+  });
+});
+
+describe('captureCommand', () => {
+  it('sends a cli_command event with the canonical command path', async () => {
+    process.argv = ['node', 'tigris', 'buckets', 'create', 'x', '--json'];
+    await captureCommand(['buckets', 'create']);
+
+    expect(sentBodies).toHaveLength(1);
+    const body = JSON.parse(sentBodies[0]);
+    expect(body.event).toBe('cli_command');
+    expect(body.api_key).toBe('phc_test_key');
+    expect(body.properties.command).toBe('buckets create');
+    expect(body.properties.command_root).toBe('buckets');
+    expect(body.properties.flags).toEqual(['json']);
+    expect(body.properties.$lib).toBe('tigris-cli');
+    expect(body.properties.auth_method).toBe('none');
+    expect(typeof body.distinct_id).toBe('string');
+    expect(body.distinct_id.length).toBeGreaterThan(0);
+  });
+
+  // Bucket names, object keys, paths and flag values are intentionally kept —
+  // they are what make a usage trend actionable.
+  it('sends command arguments, including bucket names, keys, and paths', async () => {
+    process.argv = [
+      'node',
+      'tigris',
+      'cp',
+      './invoices/q3.pdf',
+      't3://acme-bucket/reports/q3.pdf',
+      '--region=iad',
+    ];
+    await captureCommand(['cp']);
+
+    const props = JSON.parse(sentBodies[0]).properties;
+    expect(props.command_args).toBe(
+      'cp ./invoices/q3.pdf t3://acme-bucket/reports/q3.pdf --region=iad'
+    );
+    expect(props.flags).toEqual(['region']);
+  });
+
+  // The hard guarantee. Asserted against the whole serialized payload so no
+  // property — present or added later — can carry a credential.
+  it.each([
+    [
+      '--access-key flag value',
+      ['configure', '--access-key', 'tid_LIVEKEY123'],
+    ],
+    [
+      '--access-secret flag value',
+      ['configure', '--access-secret', 'supersecretvalue'],
+    ],
+    ['--secret= inline form', ['configure', '--secret=supersecretvalue']],
+    ['a Tigris secret in a positional', ['ls', 'tsec_LIVESECRET456']],
+    ['an AWS access key id', ['cp', 'AKIAIOSFODNN7EXAMPLE', 't3://b/k']],
+    [
+      'a JWT',
+      [
+        'ls',
+        'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U',
+      ],
+    ],
+    ['a bearer token', ['ls', '--token', 'Bearer abc123def456']],
+  ])('never sends credentials: %s', async (_label, args) => {
+    process.argv = ['node', 'tigris', ...args];
+    await captureCommand([args[0]]);
+
+    const serialized = sentBodies[0];
+    for (const secret of [
+      'tid_LIVEKEY123',
+      'supersecretvalue',
+      'tsec_LIVESECRET456',
+      'AKIAIOSFODNN7EXAMPLE',
+      'dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U',
+      'abc123def456',
+    ]) {
+      expect(serialized).not.toContain(secret);
+    }
+    expect(serialized).toContain('[redacted]');
+  });
+
+  it("redacts other people's email addresses from arguments", async () => {
+    process.argv = ['node', 'tigris', 'iam', 'users', 'invite', 'bob@corp.io'];
+    await captureCommand(['iam', 'users', 'invite']);
+
+    const serialized = sentBodies[0];
+    expect(serialized).not.toContain('bob@corp.io');
+    expect(JSON.parse(serialized).properties.command_args).toContain(
+      '[redacted]'
+    );
+  });
+
+  it('never sends the machine hostname or working directory', async () => {
+    process.argv = ['node', 'tigris', 'ls'];
+    await captureCommand(['ls']);
+
+    const serialized = sentBodies[0];
+    expect(serialized).not.toContain(hostname());
+    expect(serialized).not.toContain(process.cwd());
+  });
+
+  it.each([
+    ['TIGRIS_NO_TELEMETRY', '1'],
+    ['DO_NOT_TRACK', '1'],
+    ['TIGRIS_ENV', 'development'],
+  ])('sends nothing when %s=%s', async (name, value) => {
+    process.env[name] = value;
+    await captureCommand(['ls']);
+    expect(sentBodies).toHaveLength(0);
+  });
+
+  it('uses an anonymous uuid as distinct_id when not signed in', async () => {
+    await captureCommand(['ls']);
+
+    const body = JSON.parse(sentBodies[0]);
+    expect(body.distinct_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+    expect(body.properties.auth_method).toBe('none');
+    expect(body.properties.$groups).toBeUndefined();
+  });
+
+  // Email as distinct_id is deliberate: it is what the console aliases to, so
+  // CLI and web activity land on one person record.
+  it('uses the signed-in email as distinct_id and groups by organization', async () => {
+    identity.idToken = `header.${Buffer.from(
+      JSON.stringify({ email: 'alice@example.com' })
+    ).toString('base64url')}.sig`;
+    identity.loginMethod = 'oauth';
+    identity.organizationId = 'org_123';
+
+    await captureCommand(['ls']);
+
+    const body = JSON.parse(sentBodies[0]);
+    expect(body.distinct_id).toBe('alice@example.com');
+    expect(body.properties.auth_method).toBe('oauth');
+    expect(body.properties.$groups).toEqual({ company: 'org_123' });
+    // Person properties stay namespaced so CLI events never clobber the
+    // console-owned `email` / `name` fields.
+    expect(
+      Object.keys(body.properties.$set).every((k) => k.startsWith('cli_'))
+    ).toBe(true);
+  });
+
+  it('falls back to anonymous when the stored token carries no email', async () => {
+    identity.idToken = 'garbage-not-a-jwt';
+    identity.loginMethod = 'credentials';
+
+    await captureCommand(['ls']);
+
+    const body = JSON.parse(sentBodies[0]);
+    expect(body.distinct_id).not.toContain('@');
+    expect(body.properties.auth_method).toBe('credentials');
+  });
+});
+
+describe('identifyOnLogin', () => {
+  it('merges the anonymous machine id into the signed-in person', async () => {
+    identity.idToken = `header.${Buffer.from(
+      JSON.stringify({ email: 'alice@example.com' })
+    ).toString('base64url')}.sig`;
+    identity.loginMethod = 'oauth';
+
+    await identifyOnLogin();
+
+    expect(sentBodies).toHaveLength(1);
+    const body = JSON.parse(sentBodies[0]);
+    expect(body.event).toBe('$identify');
+    expect(body.distinct_id).toBe('alice@example.com');
+    // This is what stitches pre-login CLI activity to the user.
+    expect(body.properties.$anon_distinct_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-/
+    );
+    expect(body.properties.$set.email).toBe('alice@example.com');
+  });
+
+  it('does nothing when there is no signed-in identity to link', async () => {
+    await identifyOnLogin();
+    expect(sentBodies).toHaveLength(0);
+  });
+});
+
+describe('trackCommand', () => {
+  it('does not report the telemetry command itself', async () => {
+    trackCommand(['telemetry', 'disable']);
+    await flush();
+    expect(sentBodies).toHaveLength(0);
+
+    // Positive control: an ordinary command on the same path does report, so
+    // the assertion above cannot pass vacuously.
+    trackCommand(['ls']);
+    await flush();
+    expect(sentBodies).toHaveLength(1);
+    expect(JSON.parse(sentBodies[0]).properties.command).toBe('ls');
+  });
+});

--- a/packages/cli/test/utils/install-method.test.ts
+++ b/packages/cli/test/utils/install-method.test.ts
@@ -1,0 +1,84 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, afterEach, describe, expect, it } from 'vitest';
+
+import {
+  getInstallMethod,
+  isBinaryBuild,
+} from '../../src/utils/install-method.js';
+
+const SCRATCH = mkdtempSync(join(tmpdir(), 'tigris-install-method-'));
+const ORIGINAL_EXEC_PATH = process.execPath;
+
+/** Point process.execPath at a real file so realpathSync() can resolve it. */
+function setExecPath(...segments: string[]): void {
+  const dir = join(SCRATCH, ...segments);
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, 'tigris');
+  writeFileSync(file, '', 'utf8');
+  Object.defineProperty(process, 'execPath', {
+    value: file,
+    configurable: true,
+  });
+}
+
+function setBinaryBuild(value: boolean): void {
+  (globalThis as { __TIGRIS_BINARY?: boolean }).__TIGRIS_BINARY = value;
+}
+
+afterEach(() => {
+  Object.defineProperty(process, 'execPath', {
+    value: ORIGINAL_EXEC_PATH,
+    configurable: true,
+  });
+  delete (globalThis as { __TIGRIS_BINARY?: boolean }).__TIGRIS_BINARY;
+});
+
+afterAll(() => {
+  rmSync(SCRATCH, { recursive: true, force: true });
+});
+
+describe('isBinaryBuild', () => {
+  it('is false under Node and true in a compiled binary', () => {
+    expect(isBinaryBuild()).toBe(false);
+    setBinaryBuild(true);
+    expect(isBinaryBuild()).toBe(true);
+  });
+});
+
+describe('getInstallMethod', () => {
+  it('reports npm when running under Node', () => {
+    expect(getInstallMethod()).toBe('npm');
+  });
+
+  // Regression guard: under npm, execPath is Node itself, which is very often
+  // Homebrew-installed. The npm check must win or every Homebrew-Node user is
+  // misreported as a Homebrew CLI install.
+  it('reports npm even when Node itself lives in a Homebrew prefix', () => {
+    setExecPath('Cellar', 'node', '22.0.0', 'bin');
+    expect(getInstallMethod()).toBe('npm');
+  });
+
+  it('reports homebrew for a binary under a Homebrew Cellar prefix', () => {
+    setBinaryBuild(true);
+    setExecPath('Cellar', 'tigris', '3.7.0', 'bin');
+    expect(getInstallMethod()).toBe(
+      process.platform === 'win32' ? 'binary' : 'homebrew'
+    );
+  });
+
+  it('reports homebrew for a binary under a Homebrew Caskroom prefix', () => {
+    setBinaryBuild(true);
+    setExecPath('Caskroom', 'tigris', '3.7.0', 'bin');
+    expect(getInstallMethod()).toBe(
+      process.platform === 'win32' ? 'binary' : 'homebrew'
+    );
+  });
+
+  it('reports binary for a standalone install elsewhere', () => {
+    setBinaryBuild(true);
+    setExecPath('usr', 'local', 'bin');
+    expect(getInstallMethod()).toBe('binary');
+  });
+});

--- a/packages/cli/test/utils/telemetry-config.test.ts
+++ b/packages/cli/test/utils/telemetry-config.test.ts
@@ -1,0 +1,193 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// os.homedir() honors $HOME (and $USERPROFILE on Windows), and the module under
+// test resolves ~/.tigris/telemetry.json once at load. Redirect HOME to a temp
+// dir *before* importing it so no test ever touches the real config.
+const TEST_HOME = mkdtempSync(join(tmpdir(), 'tigris-telemetry-config-'));
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_USERPROFILE = process.env.USERPROFILE;
+process.env.HOME = TEST_HOME;
+process.env.USERPROFILE = TEST_HOME;
+
+const {
+  TELEMETRY_STATE_FILE,
+  getAnonymousId,
+  isTelemetryDisabled,
+  markNoticeShown,
+  readTelemetryState,
+  resetTelemetryStateCache,
+  setTelemetryOptOut,
+  shouldShowNotice,
+  telemetryDisabledReason,
+} = await import('../../src/utils/telemetry-config.js');
+
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+function clearState(): void {
+  rmSync(TELEMETRY_STATE_FILE, { force: true });
+  resetTelemetryStateCache();
+}
+
+beforeEach(() => {
+  // The suite runs with NODE_ENV=test, which disables telemetry outright.
+  // 'production' is the only mode where the other switches are observable.
+  process.env.NODE_ENV = 'production';
+  delete process.env.TIGRIS_NO_TELEMETRY;
+  delete process.env.DO_NOT_TRACK;
+  delete process.env.TIGRIS_ENV;
+  clearState();
+});
+
+afterEach(() => {
+  process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+});
+
+afterAll(() => {
+  process.env.HOME = ORIGINAL_HOME;
+  process.env.USERPROFILE = ORIGINAL_USERPROFILE;
+  rmSync(TEST_HOME, { recursive: true, force: true });
+});
+
+describe('telemetry state file location', () => {
+  it('lives outside config.json so logout cannot resurrect preferences', () => {
+    expect(TELEMETRY_STATE_FILE).toBe(
+      join(TEST_HOME, '.tigris', 'telemetry.json')
+    );
+  });
+});
+
+describe('telemetryDisabledReason', () => {
+  it('returns null when nothing opts the user out', () => {
+    expect(telemetryDisabledReason()).toBeNull();
+    expect(isTelemetryDisabled()).toBe(false);
+  });
+
+  it.each(['1', 'true', 'yes', 'TRUE', 'on'])(
+    'treats TIGRIS_NO_TELEMETRY=%s as opt-out',
+    (value) => {
+      process.env.TIGRIS_NO_TELEMETRY = value;
+      expect(telemetryDisabledReason()).toBe('TIGRIS_NO_TELEMETRY');
+    }
+  );
+
+  // Regression: the previous `=== '1'` check silently ignored these, so
+  // DO_NOT_TRACK=true did nothing at all.
+  it.each(['true', 'yes', '2'])(
+    'honors the DO_NOT_TRACK convention for value %s',
+    (value) => {
+      process.env.DO_NOT_TRACK = value;
+      expect(telemetryDisabledReason()).toBe('DO_NOT_TRACK');
+    }
+  );
+
+  it.each(['0', 'false', 'no', '', '   '])(
+    'does not opt out for falsy value %s',
+    (value) => {
+      process.env.TIGRIS_NO_TELEMETRY = value;
+      process.env.DO_NOT_TRACK = value;
+      expect(telemetryDisabledReason()).toBeNull();
+    }
+  );
+
+  it('reports the test environment', () => {
+    process.env.NODE_ENV = 'test';
+    expect(telemetryDisabledReason()).toBe('test');
+  });
+
+  it('reports development builds', () => {
+    process.env.TIGRIS_ENV = 'development';
+    expect(telemetryDisabledReason()).toBe('development');
+  });
+
+  it('reports a persisted opt-out', () => {
+    setTelemetryOptOut(true);
+    expect(telemetryDisabledReason()).toBe('opt-out');
+    expect(isTelemetryDisabled()).toBe(true);
+  });
+
+  it('reports the env var ahead of a persisted opt-out', () => {
+    setTelemetryOptOut(true);
+    process.env.DO_NOT_TRACK = '1';
+    expect(telemetryDisabledReason()).toBe('DO_NOT_TRACK');
+  });
+});
+
+describe('setTelemetryOptOut', () => {
+  it('reports success when the preference was persisted', () => {
+    expect(setTelemetryOptOut(true)).toBe(true);
+  });
+
+  // A silent write failure would tell the user telemetry is off and then track
+  // them again on the next run, so the caller has to be able to see it.
+  it('reports failure when the state file cannot be written', () => {
+    // A directory where the state file should be makes writeFileSync fail
+    // without needing to manipulate permissions (which root would bypass).
+    rmSync(TELEMETRY_STATE_FILE, { force: true });
+    mkdirSync(TELEMETRY_STATE_FILE, { recursive: true });
+    resetTelemetryStateCache();
+
+    expect(setTelemetryOptOut(true)).toBe(false);
+
+    rmSync(TELEMETRY_STATE_FILE, { recursive: true, force: true });
+  });
+
+  it('round-trips through the state file', () => {
+    setTelemetryOptOut(true);
+    resetTelemetryStateCache();
+    expect(readTelemetryState().optOut).toBe(true);
+
+    setTelemetryOptOut(false);
+    resetTelemetryStateCache();
+    expect(readTelemetryState().optOut).toBe(false);
+    expect(isTelemetryDisabled()).toBe(false);
+  });
+
+  it('preserves the anonymous id when toggling', () => {
+    const id = getAnonymousId();
+    setTelemetryOptOut(true);
+    resetTelemetryStateCache();
+    expect(readTelemetryState().anonymousId).toBe(id);
+  });
+});
+
+describe('getAnonymousId', () => {
+  it('is stable across calls and persists to disk', () => {
+    const first = getAnonymousId();
+    expect(first).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+    expect(getAnonymousId()).toBe(first);
+
+    resetTelemetryStateCache();
+    expect(getAnonymousId()).toBe(first);
+  });
+});
+
+describe('readTelemetryState', () => {
+  it('treats a malformed state file as empty rather than throwing', () => {
+    writeFileSync(TELEMETRY_STATE_FILE, 'not json at all', 'utf8');
+    resetTelemetryStateCache();
+    expect(readTelemetryState()).toEqual({});
+    expect(isTelemetryDisabled()).toBe(false);
+  });
+
+  it('treats a non-object state file as empty', () => {
+    writeFileSync(TELEMETRY_STATE_FILE, '"a string"', 'utf8');
+    resetTelemetryStateCache();
+    expect(readTelemetryState()).toEqual({});
+  });
+});
+
+describe('one-time notice', () => {
+  it('is owed until marked shown, then never again', () => {
+    expect(shouldShowNotice()).toBe(true);
+    markNoticeShown();
+    expect(shouldShowNotice()).toBe(false);
+
+    resetTelemetryStateCache();
+    expect(shouldShowNotice()).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds PostHog usage analytics to the CLI. It already reported errors to Sentry but nothing about usage, so there was no way to see which commands matter or how adoption follows a console signup.

One `cli_command` event per invocation, reported to the **same PostHog project as the console** so CLI and web activity join on one person record.

## Privacy model

**Credentials are never collected.** Access keys, secret keys, tokens, passwords, and authorization headers are stripped whether they appear as a flag value or a bare positional. Third-party email addresses are redacted too. The machine hostname and working directory are never sent.

Both telemetry surfaces now share **one scrubber** (`src/utils/redact.ts`, extracted from `utils/telemetry.ts`), so the guarantee can't drift apart between usage analytics and error reports — a redaction fix protects both or neither.

Command arguments **are** collected, scrubbed: bucket names, object keys, paths and flag values are what make a usage trend actionable. Verified end-to-end against the built CLI:

```
configure  args="configure --access-key [redacted] --access-secret [redacted] --endpoint https://t3.storage.dev"
ls         args="ls [redacted]"                     # AKIA… positional
ls         args="ls my-public-bucket/photos/2026/"  # bucket + prefix kept
```

Tests assert against the whole serialized payload rather than individual fields, so a property added later can't reintroduce a leak. Note one consequence of collecting paths: `tigris cp ~/x.pdf …` sends `/Users/alice/x.pdf`, so OS usernames will appear in path arguments.

## Decisions worth a look

**Email as `distinct_id`.** Signed-in runs are identified by account email — what the console's `posthog.alias()` already resolves to, so the two surfaces land on one person. Flagging it as the one personal value we deliberately send.

**Fired at command start, not completion.** `program.parse()` isn't awaited and ~370 call sites exit synchronously through `exitWithError`, so there's no reliable place to flush at exit. Firing early overlaps the request with the command's own work. The trade: we record **invocations, not outcomes** — failure rates stay Sentry's job.

**No `posthog-node` dependency.** The SDK batches behind its own timers, which fights those synchronous exits, and this package also compiles to standalone binaries. Raw `node:https` instead.

**State in `~/.tigris/telemetry.json`, not `config.json`.** `logout` clears the latter wholesale, and neither the opt-out nor the anonymous id should come back to life because someone logged out. A write failure is a hard error, not a silent no-op — otherwise `telemetry disable` would report success and resume sending on the next run.

## Opt-out

```bash
tigris telemetry status    # shows which switch is in effect, and what is collected
tigris telemetry disable   # persists
tigris telemetry enable
```

Plus `TIGRIS_NO_TELEMETRY` / `DO_NOT_TRACK`, which take precedence over the stored setting, and a one-time disclosure notice on first interactive use. One gate covers both analytics and error reports.

⚠️ **Behavior change to existing telemetry:** both env vars were compared against the literal `'1'`, so the common `DO_NOT_TRACK=true` **silently did nothing**. Both now honor any truthy value per the [DO_NOT_TRACK](https://consoledonottrack.com/) convention. This newly gates error reporting for anyone who set a non-`1` value expecting it to work.

## Measured cost

Round trip to the ingest host is ~170–220ms.

| Scenario | Overhead |
|---|---|
| Typical command (real network work) | ~0ms — request overlaps the command |
| Fastest local commands | ~100ms |
| Blackholed host (dropped packets, no RST) | ~1.1s worst case |

The timeout is sized to 1s against that measurement. An earlier 2s value cost **2.35s on every command** when the host was blackholed. `socket.unref()` was tried to cap it and does **not** work: for a socket still connecting, unref doesn't release the event loop, even called synchronously.

## Known gaps

A command that hard-exits *faster* than the ~200ms request loses its event — `process.exit()` kills an in-flight socket regardless of refs. Verified both ways: a `cp` failing at 480ms delivered, one failing at 220ms didn't. Local validation failures are under-counted; anything doing real network work reports reliably. Closing it needs a `parseAsync` refactor, which would also fix the identical latent flush gap in Sentry.

**Separately, unverified:** `update-check.ts` relies on the same ineffective `socket.unref()` with a 10s timeout, so a blackholed npm registry may hold the CLI longer than intended. Not touched here — flagging for follow-up.

## Also in here

`pnpm updatedocs` was silently deleting any hand-written README section between `## Usage` and `## License` — it wiped the Telemetry section on the first regenerate. The generated block now ends at the first hand-written trailing section instead of hardcoding `## License`.

## Verification

- `tsc --noEmit` clean on both the npm and binary targets; `biome check` clean
- **910 tests pass**, up from 840 (70 new)
- Drove the built CLI end-to-end against a local capture server: credential redaction in flag and positional form, argument retention, disable/enable round trip, `--json` output, env-var precedence, opt-out write failure exiting non-zero, and the first-run notice firing exactly once in a real TTY

Changeset included (`minor` for `@tigrisdata/cli`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
