### PR TITLE
fix(cli/init): rephrase agent prompt with ASD-STE100

### DIFF
--- a/.changeset/cli-init-agent-recipe-simplified-english.md
+++ b/.changeset/cli-init-agent-recipe-simplified-english.md
@@ -1,0 +1,17 @@
+---
+"@tigrisdata/cli": patch
+"tigris": patch
+---
+
+`tigris init --agent` prints its setup recipe in [ASD-STE100 Simplified
+Technical English](https://www.asd-ste100.org/). Each step reads the same
+way to every agent that follows it.
+
+The goal is to make the instructions unambiguous for both humans and
+agents. A distracted operator and a less capable model read each step the
+same way.
+
+Each step is now one instruction per sentence in the imperative. Every
+condition is ahead of the command. All steps that carried two orders at
+once now use two sentences. An agent can no longer do half of a step
+and count it as complete.

--- a/packages/cli/src/lib/init/plan.ts
+++ b/packages/cli/src/lib/init/plan.ts
@@ -14,17 +14,20 @@
  * was installed, so it's safe to run unconditionally.
  */
 const INSTALL_STEP =
-  'Ask permission, then install the CLI: `npm install -g @tigrisdata/cli --ignore-scripts`.';
-const UPDATE_STEP = 'Ensure the CLI is on the latest version: `tigris update`.';
+  'Ask the user for permission. Then install the CLI: `npm install -g @tigrisdata/cli --ignore-scripts`.';
+const UPDATE_STEP = 'Update the CLI to the latest version: `tigris update`.';
 
 const SETUP_STEPS = [
-  'Check if the user is already authenticated using `tigris whoami`. If not, authenticate using `tigris login oauth`.',
-  "Run `tigris orgs list --format json`. If there's more than one org, ask which to use, then make it active with `tigris orgs select <org>` so the following commands target it.",
-  'Infer the project name from metadata (package.json, go.mod, pyproject.toml, ...). Check `tigris buckets list --format json` first; if the bucket is absent, `tigris buckets create <name> --format json`. Ask the user whenever anything is ambiguous.',
-  `Create the access key into a private temp file (overwrite, never append), then print only the ID:
+  'Run `tigris whoami` to get the authentication state. If the user is not authenticated, run `tigris login oauth`.',
+  'Run `tigris orgs list --format json`. If there is more than one org, ask the user which org to use. Then run `tigris orgs select <org>` to make that org active. The commands that come after target the active org.',
+  'Read the project name from a metadata file, for example package.json, go.mod, or pyproject.toml. Run `tigris buckets list --format json` first. If the bucket is absent, run `tigris buckets create <name> --format json`. If anything is ambiguous, ask the user.',
+  `Create the access key in a private temporary file. Use \`>\` to overwrite the file. Do not use \`>>\` to append. Then print only the ID:
    \`umask 077; tmpfile=$(mktemp); tigris access-keys create <username>-<project>-devel --format json > "$tmpfile" && jq -r '.id' < "$tmpfile"\``,
-  'Grant bucket access: `tigris access-keys assign <id> --bucket <bucket> --role Editor --format json`.',
-  `Detect whether the code uses the Tigris SDK or the AWS SDK, then have a small script append the right vars to .env, reading \`.id\`/\`.secret\` from the temp file. Do NOT read the secret into your context — append it via script. Delete the temp file when done: \`rm -f "$tmpfile"\`.
+  'Give the access key the Editor role on the bucket: `tigris access-keys assign <id> --bucket <bucket> --role Editor --format json`.',
+  `Identify the SDK that the code uses: the Tigris SDK, or the AWS SDK. Then use a small script to append the correct variables to \`.env\`:
+   - The script reads \`.id\` and \`.secret\` from the temporary file.
+   - Do not read the secret into your own context. Only the script reads the secret.
+   - When the script is complete, delete the temporary file: \`rm -f "$tmpfile"\`.
 
    Tigris SDK (@tigrisdata/storage, storage-go):
      TIGRIS_STORAGE_ACCESS_KEY_ID     = .id
@@ -38,16 +41,16 @@ const SETUP_STEPS = [
      AWS_ENDPOINT_URL_IAM    = https://iam.storageapi.dev (required)
      AWS_REGION              = auto                        (required)
 `,
-  `Congratulate the user and point them to:
+  `Congratulate the user. Then give these links:
    - JS:    https://www.tigrisdata.com/docs/sdks/tigris/
    - Go:    https://pkg.go.dev/github.com/tigrisdata/storage-go
    - Docs:  https://www.tigrisdata.com/docs/
    - Discord: https://community.tigrisdata.com/
    - Skills: https://www.tigrisdata.com/docs/skills/
 
-   Suggest adding to their agent config:
+   Suggest that the user adds these lines to the agent configuration file:
      > ## Tigris object storage
-     > This project uses Tigris. For any Tigris questions, consult https://www.tigrisdata.com/llms.txt before acting; look it up rather than relying on memory.`,
+     > This project uses Tigris. Read https://www.tigrisdata.com/llms.txt before you answer a question about Tigris. Do not answer from memory.`,
 ];
 
 /**
@@ -58,5 +61,5 @@ const SETUP_STEPS = [
 export function buildAgentSetup(cliInstalled: boolean): string {
   const steps = [cliInstalled ? UPDATE_STEP : INSTALL_STEP, ...SETUP_STEPS];
   const body = steps.map((step, i) => `${i + 1}. ${step}`).join('\n');
-  return `Help the user set up their project with Tigris:\n\n${body}\n`;
+  return `Help the user configure Tigris for this project:\n\n${body}\n`;
 }

--- a/packages/cli/test/lib/init/plan.test.ts
+++ b/packages/cli/test/lib/init/plan.test.ts
@@ -11,7 +11,7 @@ describe('buildAgentSetup', () => {
   it('leads with an update, not an install, when the CLI is on PATH', () => {
     const recipe = buildAgentSetup(true);
     expect(recipe).toMatch(
-      /^1\. Ensure the CLI is on the latest version: `tigris update`\.$/m
+      /^1\. Update the CLI to the latest version: `tigris update`\.$/m
     );
     expect(recipe).not.toContain('npm install -g @tigrisdata/cli');
   });
@@ -19,7 +19,7 @@ describe('buildAgentSetup', () => {
   it('leads with an install, not an update, when the CLI is missing', () => {
     const recipe = buildAgentSetup(false);
     expect(recipe).toMatch(
-      /^1\. Ask permission, then install the CLI: `npm install -g @tigrisdata\/cli --ignore-scripts`\.$/m
+      /^1\. Ask the user for permission\. Then install the CLI: `npm install -g @tigrisdata\/cli --ignore-scripts`\.$/m
     );
     expect(recipe).not.toContain('tigris update');
   });
@@ -28,9 +28,7 @@ describe('buildAgentSetup', () => {
     for (const cliInstalled of [true, false]) {
       const recipe = buildAgentSetup(cliInstalled);
       // Step 2 onwards is the shared setup, which never touches the CLI itself.
-      expect(recipe).toMatch(
-        /^2\. Check if the user is already authenticated/m
-      );
+      expect(recipe).toMatch(/^2\. Run `tigris whoami`/m);
     }
   });
 


### PR DESCRIPTION
Agents need deterministic phrasing to behave predictably. This patch is a further round of hardening to ensure that agent instructions result in more deterministic output.

I applied the concepts from ASD-STE100[1] to ensure that there is one instruction per sentence, active voice for every action, and that conditions prefix sentences.

The goal is to make instructions unambiguous for AI agents. A less capable model reads these instructions the same way as a more capable model.

[1]: https://www.asd-ste100.org/

Ref: #230

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only changes to printed agent instructions and matching tests; no runtime CLI logic or credential handling behavior changes.
> 
> **Overview**
> **`tigris init --agent`** now prints its setup recipe with clearer, more deterministic wording aligned with ASD-STE100 Simplified Technical English.
> 
> The recipe text in `buildAgentSetup` is rewritten so each step uses imperative, one-instruction-per-sentence phrasing, with conditions stated before commands. Multi-action steps (install permission, auth, org selection, bucket setup, temp-file access keys, `.env` scripting, and closing links) are split or bulletized so agents cannot treat half a step as done. The intro line changes from “set up their project” to **“configure Tigris for this project”**, and the suggested agent-config blurb now tells models to read `llms.txt` instead of answering from memory.
> 
> Unit tests in `plan.test.ts` are updated to match the new step openings; a changeset documents the behavior for `@tigrisdata/cli` and `tigris`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74caeb8833a205ca8adfd95f8afdf225f810c58e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->