### PR TITLE
fix(cli): exclude folder markers from cp/mv/rm object counts

### DIFF
--- a/.changeset/cli-cp-mv-rm-object-counts.md
+++ b/.changeset/cli-cp-mv-rm-object-counts.md
@@ -14,8 +14,9 @@ always agree.
 - `mv` and `rm` no longer count the folder's own marker, or the markers of any
   nested subfolders, as objects. The markers are still moved and deleted as
   before; they're just not counted or printed.
-- A folder holding nothing but markers still reports `1`, so moving or deleting
-  an empty folder doesn't read as a no-op.
+- An operation whose scope is nothing but markers reports the folders it
+  handled, so an empty folder counts as `1` rather than reading as a no-op, and
+  clearing three sibling empty folders reports `3` rather than `1`.
 - `cp` remote-to-remote no longer counts nested folder markers, and a run whose
   object copies all failed now reports `0` instead of `No objects to copy`.
 

--- a/.changeset/cli-cp-mv-rm-object-counts.md
+++ b/.changeset/cli-cp-mv-rm-object-counts.md
@@ -1,0 +1,33 @@
+---
+'@tigrisdata/cli': patch
+---
+
+Fix object counts reported by `cp`, `mv`, and `rm`
+
+Folder markers (the zero-byte `folder/` keys that make an empty prefix show up
+as a folder) were being counted as objects, so `mv -r` on a folder of 10 files
+asked "Are you sure you want to move 11 object(s)?" and then reported "Moved 10
+object(s)". `ls` hides those markers, so the counts now do too — the
+confirmation prompt and the final tally are derived from the same rule and
+always agree.
+
+- `mv` and `rm` no longer count the folder's own marker, or the markers of any
+  nested subfolders, as objects. The markers are still moved and deleted as
+  before; they're just not counted or printed.
+- A folder holding nothing but markers still reports `1`, so moving or deleting
+  an empty folder doesn't read as a no-op.
+- `cp` remote-to-remote no longer counts nested folder markers, and a run whose
+  object copies all failed now reports `0` instead of `No objects to copy`.
+
+The `count` field in `--format json` output for these commands follows the same
+rule and may be lower than before for folders that contain markers.
+
+Wildcards also no longer operate on the folder they match inside. A wildcard
+names files within a folder, not the folder itself, so:
+
+- `mv 'folder/*.zip'` with nothing matching now reports `No objects to move`
+  instead of `Moved 1 object(s)`. It previously moved the source folder's
+  marker to the destination, which removed `folder/` itself.
+- `cp 'folder/*'` no longer creates a folder marker at the destination.
+- `rm 'folder/*'` empties the folder without deleting it, matching how
+  `rm dir/*` behaves in a shell. Use `rm -r folder` to remove the folder too.

--- a/packages/cli/src/lib/cp.ts
+++ b/packages/cli/src/lib/cp.ts
@@ -18,7 +18,9 @@ import { formatSize } from '@utils/format.js';
 import { getContentType } from '@utils/mime.js';
 import { getFormat, getOption } from '@utils/options.js';
 import {
+  countObjects,
   globToRegex,
+  isFolderMarker,
   isPathFolder,
   isRemotePath,
   listAllItems,
@@ -706,21 +708,22 @@ async function copyRemoteToRemote(
 
       if (copyResult.error) {
         console.error(`Failed to copy ${item.name}: ${copyResult.error}`);
-        return false;
+        return null;
       } else {
-        if (!_jsonMode)
+        // Nested folder markers copy with the data but aren't listed.
+        if (!_jsonMode && !isFolderMarker(item.name))
           console.log(
             `Copied t3://${srcParsed.bucket}/${item.name} -> t3://${destParsed.bucket}/${destKey}`
           );
-        return true;
+        return item.name;
       }
     });
     const copyResults = await executeWithConcurrency(copyTasks, 8);
-    let copied = copyResults.filter(Boolean).length;
+    const copiedKeys = copyResults.filter((key) => key !== null);
 
-    // Copy folder marker if exists
-    let copiedMarker = false;
-    if (effectiveDestPrefix && prefix) {
+    // Copy folder marker if exists. Skipped for wildcards, which name files
+    // inside the folder rather than the folder itself.
+    if (effectiveDestPrefix && prefix && !isWildcard) {
       const { data: markerData } = await list({
         prefix,
         limit: 1,
@@ -742,16 +745,19 @@ async function copyRemoteToRemote(
         if (markerResult.error) {
           console.error(`Failed to copy folder marker: ${markerResult.error}`);
         } else {
-          copiedMarker = true;
+          copiedKeys.push(prefix);
         }
       }
     }
 
-    if (copied === 0 && copiedMarker) {
-      copied = 1;
-    }
+    const copied = countObjects(
+      itemsToCopy.map((item) => item.name),
+      copiedKeys
+    );
 
-    if (copied === 0) {
+    // Nothing matched at all. When items matched but every copy failed, fall
+    // through and report `0` — the per-object errors are already on stderr.
+    if (itemsToCopy.length === 0 && copiedKeys.length === 0) {
       if (_jsonMode) {
         console.log(
           JSON.stringify({

--- a/packages/cli/src/lib/mv.ts
+++ b/packages/cli/src/lib/mv.ts
@@ -4,7 +4,9 @@ import { exitWithError } from '@utils/exit.js';
 import { confirm, requireInteractive } from '@utils/interactive.js';
 import { getFormat, getOption } from '@utils/options.js';
 import {
+  countObjects,
   globToRegex,
+  isFolderMarker,
   isPathFolder,
   isRemotePath,
   listAllItems,
@@ -110,7 +112,8 @@ export default async function mv(options: Record<string, unknown>) {
       exitWithError(error);
     }
 
-    // Filter out folder markers - they're handled separately below
+    // Filter out the folder's own marker - it's handled separately below.
+    // Nested markers stay in the list so empty subfolders move with it.
     let itemsToMove = items.filter((item) => item.name !== prefix);
 
     if (isWildcard) {
@@ -123,18 +126,22 @@ export default async function mv(options: Record<string, unknown>) {
       });
     }
 
-    // Check if folder marker exists
-    const { data: markerData } = await list({
-      prefix,
-      limit: 1,
-      config: {
-        ...config,
-        bucket: srcPath.bucket,
-      },
-    });
-    const hasFolderMarker = prefix
-      ? markerData?.items?.some((item) => item.name === prefix)
-      : false;
+    // Check if folder marker exists. A wildcard names files inside the folder,
+    // not the folder itself, so its marker stays put - `rm` works this way too.
+    let hasFolderMarker = false;
+    if (prefix && !isWildcard) {
+      const { data: markerData } = await list({
+        prefix,
+        limit: 1,
+        config: {
+          ...config,
+          bucket: srcPath.bucket,
+        },
+      });
+      hasFolderMarker = !!markerData?.items?.some(
+        (item) => item.name === prefix
+      );
+    }
 
     if (itemsToMove.length === 0 && !hasFolderMarker) {
       if (_jsonMode) {
@@ -145,7 +152,11 @@ export default async function mv(options: Record<string, unknown>) {
       return;
     }
 
-    const totalToMove = itemsToMove.length + (hasFolderMarker ? 1 : 0);
+    const keysToMove = [
+      ...itemsToMove.map((item) => item.name),
+      ...(hasFolderMarker ? [prefix] : []),
+    ];
+    const totalToMove = countObjects(keysToMove);
     if (!force) {
       requireInteractive('Use --yes to skip confirmation');
       const confirmed = await confirm(
@@ -157,7 +168,7 @@ export default async function mv(options: Record<string, unknown>) {
       }
     }
 
-    let moved = 0;
+    const movedKeys: string[] = [];
     for (const item of itemsToMove) {
       const relativePath = prefix ? item.name.slice(prefix.length) : item.name;
       const destKey = effectiveDestPrefix
@@ -175,16 +186,16 @@ export default async function mv(options: Record<string, unknown>) {
       if (moveResult.error) {
         console.error(`Failed to move ${item.name}: ${moveResult.error}`);
       } else {
-        if (!_jsonMode)
+        // Nested folder markers move with the data but aren't listed.
+        if (!_jsonMode && !isFolderMarker(item.name))
           console.log(
             `Moved t3://${srcPath.bucket}/${item.name} -> t3://${destPath.bucket}/${destKey}`
           );
-        moved++;
+        movedKeys.push(item.name);
       }
     }
 
     // Also move the folder marker if it exists (already checked above)
-    let movedMarker = false;
     if (hasFolderMarker) {
       if (effectiveDestPrefix) {
         // Move folder marker to destination folder
@@ -199,7 +210,7 @@ export default async function mv(options: Record<string, unknown>) {
         if (markerResult.error) {
           console.error(`Failed to move folder marker: ${markerResult.error}`);
         } else {
-          movedMarker = true;
+          movedKeys.push(prefix);
         }
       } else {
         // Moving to root - just delete source folder marker, no marker at root
@@ -214,15 +225,12 @@ export default async function mv(options: Record<string, unknown>) {
             `Failed to remove source folder marker: ${removeError.message}`
           );
         } else {
-          movedMarker = true;
+          movedKeys.push(prefix);
         }
       }
     }
 
-    // Only count folder marker if no regular files were moved (empty folder case)
-    if (moved === 0 && movedMarker) {
-      moved = 1;
-    }
+    const moved = countObjects(keysToMove, movedKeys);
 
     if (_jsonMode) {
       console.log(JSON.stringify({ action: 'moved', count: moved }));

--- a/packages/cli/src/lib/rm.ts
+++ b/packages/cli/src/lib/rm.ts
@@ -4,7 +4,9 @@ import { exitWithError } from '@utils/exit.js';
 import { confirm, requireInteractive } from '@utils/interactive.js';
 import { getFormat, getOption } from '@utils/options.js';
 import {
+  countObjects,
   globToRegex,
+  isFolderMarker,
   isPathFolder,
   isRemotePath,
   listAllItems,
@@ -106,6 +108,9 @@ export default async function rm(options: Record<string, unknown>) {
       const filePattern = path.split('/').pop()!;
       const regex = globToRegex(filePattern);
       itemsToRemove = itemsToRemove.filter((item) => {
+        // The folder's own marker is not a file inside the folder, so a
+        // wildcard never matches it - `rm folder/*` leaves `folder/` behind.
+        if (item.name === prefix) return false;
         const rel = prefix ? item.name.slice(prefix.length) : item.name;
         if (!recursive && rel.includes('/')) return false;
         return regex.test(rel.split('/').pop()!);
@@ -133,9 +138,12 @@ export default async function rm(options: Record<string, unknown>) {
         markerData?.items?.some((item) => item.name === folderMarker) || false;
     }
 
-    const totalItems = itemsToRemove.length + (hasSeparateFolderMarker ? 1 : 0);
+    const keysToRemove = [
+      ...itemsToRemove.map((item) => item.name),
+      ...(hasSeparateFolderMarker ? [folderMarker] : []),
+    ];
 
-    if (totalItems === 0) {
+    if (keysToRemove.length === 0) {
       if (_jsonMode) {
         console.log(JSON.stringify({ action: 'removed', count: 0 }));
       } else {
@@ -143,6 +151,8 @@ export default async function rm(options: Record<string, unknown>) {
       }
       return;
     }
+
+    const totalItems = countObjects(keysToRemove);
 
     if (!force) {
       requireInteractive('Use --yes to skip confirmation');
@@ -155,7 +165,7 @@ export default async function rm(options: Record<string, unknown>) {
       }
     }
 
-    let removed = 0;
+    const removedKeys: string[] = [];
 
     // Remove all items (including folder marker if in list)
     for (const item of itemsToRemove) {
@@ -169,8 +179,10 @@ export default async function rm(options: Record<string, unknown>) {
       if (removeError) {
         console.error(`Failed to remove ${item.name}: ${removeError.message}`);
       } else {
-        if (!_jsonMode) console.log(`Removed t3://${bucket}/${item.name}`);
-        removed++;
+        // Folder markers go away with the folder but aren't listed.
+        if (!_jsonMode && !isFolderMarker(item.name))
+          console.log(`Removed t3://${bucket}/${item.name}`);
+        removedKeys.push(item.name);
       }
     }
 
@@ -188,10 +200,11 @@ export default async function rm(options: Record<string, unknown>) {
           `Failed to remove ${folderMarker}: ${removeError.message}`
         );
       } else {
-        if (!_jsonMode) console.log(`Removed t3://${bucket}/${folderMarker}`);
-        removed++;
+        removedKeys.push(folderMarker);
       }
     }
+
+    const removed = countObjects(keysToRemove, removedKeys);
 
     if (_jsonMode) {
       console.log(JSON.stringify({ action: 'removed', count: removed }));

--- a/packages/cli/src/utils/path.ts
+++ b/packages/cli/src/utils/path.ts
@@ -108,6 +108,38 @@ export function resolveObjectArgs(
   return { bucket: parsed.bucket, key: parsed.path };
 }
 
+/**
+ * Folder markers are zero-byte keys ending in `/`. They exist so an
+ * otherwise-empty prefix still shows up as a folder; `ls` hides them, so
+ * cp/mv/rm carry them along without ever listing them as objects.
+ */
+export function isFolderMarker(key: string): boolean {
+  return key.endsWith('/');
+}
+
+/**
+ * User-facing object count for a bulk cp/mv/rm.
+ *
+ * Folder markers never count as objects — `ls` hides them, so counting them
+ * would report more than the user can see. The exception is a prefix holding
+ * nothing but markers: operating on an empty folder still does something, so
+ * it reports as one rather than zero.
+ *
+ * @param scope every key the command set out to handle
+ * @param done the keys it actually handled. Defaults to `scope`, which is what
+ * the confirmation prompt wants; running the prompt and the final tally through
+ * this same function keeps the two numbers from disagreeing. Passing `done`
+ * separately means a run whose objects all failed reports `0` even if the
+ * folder marker happened to succeed.
+ */
+export function countObjects(scope: string[], done: string[] = scope): number {
+  const scopeHasObjects = scope.some((key) => !isFolderMarker(key));
+  if (!scopeHasObjects) {
+    return done.length > 0 ? 1 : 0;
+  }
+  return done.filter((key) => !isFolderMarker(key)).length;
+}
+
 export type ListItem = {
   id: string;
   name: string;

--- a/packages/cli/src/utils/path.ts
+++ b/packages/cli/src/utils/path.ts
@@ -121,9 +121,10 @@ export function isFolderMarker(key: string): boolean {
  * User-facing object count for a bulk cp/mv/rm.
  *
  * Folder markers never count as objects — `ls` hides them, so counting them
- * would report more than the user can see. The exception is a prefix holding
- * nothing but markers: operating on an empty folder still does something, so
- * it reports as one rather than zero.
+ * would report more than the user can see. The exception is a scope holding
+ * nothing but markers: those runs operate on folders rather than objects, so
+ * they report the folders handled rather than a bare zero, which would read as
+ * a no-op.
  *
  * @param scope every key the command set out to handle
  * @param done the keys it actually handled. Defaults to `scope`, which is what
@@ -135,7 +136,8 @@ export function isFolderMarker(key: string): boolean {
 export function countObjects(scope: string[], done: string[] = scope): number {
   const scopeHasObjects = scope.some((key) => !isFolderMarker(key));
   if (!scopeHasObjects) {
-    return done.length > 0 ? 1 : 0;
+    // Folders-only run: one empty folder reports 1, three siblings report 3.
+    return done.length;
   }
   return done.filter((key) => !isFolderMarker(key)).length;
 }

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -709,8 +709,9 @@ describe.skipIf(skipTests)('CLI Integration Tests', () => {
       );
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('Moved');
-      // cp nests: autodetect → copied/autodetect/ (marker + 2 files = 3)
-      expect(result.stdout).toContain('3 object(s)');
+      // cp nests: autodetect → copied/autodetect/. The nested folder marker
+      // moves with the files but isn't an object, so 2 rather than 3.
+      expect(result.stdout).toContain('2 object(s)');
     });
 
     it('should auto-detect folder for rm without trailing slash', () => {

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -932,6 +932,71 @@ describe.skipIf(skipTests)('CLI Integration Tests', () => {
     });
   });
 
+  // A wildcard names files inside a folder, not the folder itself, so the
+  // folder's own marker has to survive it. `stat` on a trailing-slash path is
+  // the only way to observe a marker directly: `ls` reports the prefix whenever
+  // objects still sit under it, whether or not a marker exists.
+  describe('wildcard folder marker preservation', () => {
+    const wcmFolder = 'wcm-folder';
+    const wcmCopied = 'wcm-copied';
+
+    beforeAll(() => {
+      runCli(`mk ${testBucket}/${wcmFolder}/`);
+      runCli(`touch ${testBucket}/${wcmFolder}/keep.jpg`);
+      runCli(`touch ${testBucket}/${wcmFolder}/one.txt`);
+      runCli(`touch ${testBucket}/${wcmFolder}/two.txt`);
+    });
+
+    it('should count only matched files when copying with a wildcard', () => {
+      const result = runCli(
+        `cp '${t3(testBucket)}/${wcmFolder}/*.txt' ${t3(testBucket)}/${wcmCopied}/`
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('2 object(s)');
+    });
+
+    it('should not create a folder marker at the wildcard destination', () => {
+      const result = runCli(`stat ${t3(testBucket)}/${wcmCopied}/`);
+      expect(result.exitCode).not.toBe(0);
+    });
+
+    it('should report nothing to move when a wildcard matches no files', () => {
+      const result = runCli(
+        `mv '${t3(testBucket)}/${wcmFolder}/*.zip' ${t3(testBucket)}/wcm-moved/ -f`
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('No objects to move');
+    });
+
+    it('should keep the source marker after a zero-match wildcard move', () => {
+      const result = runCli(`stat ${t3(testBucket)}/${wcmFolder}/`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('should empty a folder with a wildcard without deleting the folder', () => {
+      const result = runCli(`rm '${t3(testBucket)}/${wcmFolder}/*' -f`);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('3 object(s)');
+    });
+
+    it('should leave the emptied folder in place', () => {
+      const result = runCli(`stat ${t3(testBucket)}/${wcmFolder}/`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('should remove the folder itself when no wildcard is used', () => {
+      const result = runCli(`rm ${t3(testBucket)}/${wcmFolder}/ -r -f`);
+      expect(result.exitCode).toBe(0);
+
+      const stat = runCli(`stat ${t3(testBucket)}/${wcmFolder}/`);
+      expect(stat.exitCode).not.toBe(0);
+    });
+
+    afterAll(() => {
+      runCli(`rm ${t3(testBucket)}/${wcmCopied}/ -r -f`);
+    });
+  });
+
   // ─── Section A: Missing branches in already-tested commands ───
 
   describe('mk command - bucket creation variants', () => {

--- a/packages/cli/test/utils/path.test.ts
+++ b/packages/cli/test/utils/path.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  countObjects,
   globToRegex,
+  isFolderMarker,
   isRemotePath,
   parseAnyPath,
   parsePath,
@@ -165,6 +167,14 @@ describe('globToRegex', () => {
   it('should not match across slashes', () => {
     const regex = globToRegex('*');
     expect(regex.test('folder/file.txt')).toBe(false);
+  });
+
+  it('matches the empty string, which is why cp/mv/rm exclude the marker', () => {
+    // A folder marker's name relative to its own prefix is '', so `*` matches
+    // the folder itself. The commands filter that key out explicitly so
+    // `rm folder/*` empties the folder without deleting it.
+    expect(globToRegex('*').test('')).toBe(true);
+    expect(globToRegex('*.txt').test('')).toBe(false);
   });
 
   it('should match wildcard with extension', () => {
@@ -333,6 +343,70 @@ describe('resolveObjectArgs', () => {
         key: '',
       });
     });
+  });
+});
+
+describe('isFolderMarker', () => {
+  it('treats keys ending in a slash as markers', () => {
+    expect(isFolderMarker('folder/')).toBe(true);
+    expect(isFolderMarker('folder/sub/')).toBe(true);
+  });
+
+  it('treats regular keys as objects', () => {
+    expect(isFolderMarker('folder/file.txt')).toBe(false);
+    expect(isFolderMarker('file.txt')).toBe(false);
+  });
+});
+
+describe('countObjects', () => {
+  it('does not count the folder marker alongside objects', () => {
+    const keys = [
+      'test-folder/',
+      'test-folder/file_1.txt',
+      'test-folder/file_2.txt',
+    ];
+    expect(countObjects(keys)).toBe(2);
+  });
+
+  it('does not count nested folder markers', () => {
+    const keys = [
+      'test-folder/',
+      'test-folder/file_1.txt',
+      'test-folder/sub/',
+      'test-folder/sub/file_2.txt',
+    ];
+    expect(countObjects(keys)).toBe(2);
+  });
+
+  it('counts an empty folder as a single object', () => {
+    expect(countObjects(['test-folder/'])).toBe(1);
+    expect(countObjects(['test-folder/', 'test-folder/sub/'])).toBe(1);
+  });
+
+  it('returns zero when there is nothing at all', () => {
+    expect(countObjects([])).toBe(0);
+  });
+
+  it('counts flat objects with no markers involved', () => {
+    expect(countObjects(['a.txt', 'b.txt', 'c.txt'])).toBe(3);
+  });
+
+  it('counts only what succeeded when done is passed', () => {
+    const scope = ['folder/', 'folder/a.txt', 'folder/b.txt'];
+    expect(countObjects(scope, ['folder/', 'folder/a.txt'])).toBe(1);
+  });
+
+  it('reports zero when every object failed but the marker succeeded', () => {
+    const scope = ['folder/', 'folder/a.txt', 'folder/b.txt'];
+    expect(countObjects(scope, ['folder/'])).toBe(0);
+  });
+
+  it('still reports one for an empty folder that succeeded', () => {
+    expect(countObjects(['folder/'], ['folder/'])).toBe(1);
+  });
+
+  it('reports zero for an empty folder that failed', () => {
+    expect(countObjects(['folder/'], [])).toBe(0);
   });
 });
 

--- a/packages/cli/test/utils/path.test.ts
+++ b/packages/cli/test/utils/path.test.ts
@@ -380,7 +380,13 @@ describe('countObjects', () => {
 
   it('counts an empty folder as a single object', () => {
     expect(countObjects(['test-folder/'])).toBe(1);
-    expect(countObjects(['test-folder/', 'test-folder/sub/'])).toBe(1);
+  });
+
+  it('counts every folder when the scope holds only markers', () => {
+    // Sibling empty folders have no shared parent in scope, so reporting 1
+    // would undercount a run that removes all three.
+    expect(countObjects(['a/', 'b/', 'c/'])).toBe(3);
+    expect(countObjects(['test-folder/', 'test-folder/sub/'])).toBe(2);
   });
 
   it('returns zero when there is nothing at all', () => {


### PR DESCRIPTION
## Summary

`tigris mv -r` asked to move 11 objects and then reported moving 10:

```
$ tigris mv t3://snapshot-copy/test-folder t3://snapshot-copy/my-folder -r
Are you sure you want to move 11 object(s)? (y/N): Y
... 10 lines ...
Moved 10 object(s)
```

The 11th was the folder marker — the zero-byte `test-folder/` key that makes an
otherwise-empty prefix show up as a folder. `ls` hides those markers, so 11 was never a number
the user could see anywhere.

The same defect ran through all three bulk commands in different ways:

| | before | after |
|---|---|---|
| `mv` prompt vs tally | 11 vs 10 | 10 vs 10 |
| `mv` / `cp` nested subfolder markers | counted as objects | not counted |
| `rm` | consistently counted markers (11/11) | 10/10, matching `ls` |
| `cp` when every copy failed | `No objects to copy` | `Copied 0 object(s)` |

Both the confirmation prompt and the final tally now derive from a single `countObjects()`
helper, so they cannot drift apart again. Markers are still moved, copied, and deleted exactly
as before — they are just no longer counted or printed.

Two edge cases the shared rule preserves:

- A prefix holding only markers still reports `1`, so moving or deleting an empty folder does
  not read as a no-op.
- A run whose objects all failed reports `0` rather than crediting a folder marker that
  happened to succeed. This one was caught by testing against a real bucket, where an
  unrelated `Forbidden` on remote-to-remote copy made every object copy fail.

## Wildcards

Reviewing the wildcard paths surfaced a second, pre-existing bug. A wildcard was treating the
folder's own marker as in scope:

```
$ tigris mv 't3://bucket/folder/*.zip' t3://bucket/dest   # nothing matches
Moved 1 object(s)
```

That "1 object" was the `folder/` marker: `mv` **deleted the source folder's marker** and
created a `dest/` one. If `folder/` held no matching files, the folder itself vanished from
`ls`. The three commands disagreed here — `rm` guarded its marker check with `!isWildcard`,
`mv` and `cp` did not, and `rm` had a separate hole where the marker's name relative to its own
prefix is the empty string, which `globToRegex('*')` matches.

All three now apply one principle: **a wildcard names files inside a folder, not the folder
itself.**

- `mv 'folder/*.zip'` with no matches reports `No objects to move` and leaves the marker alone.
- `cp 'folder/*'` no longer creates a stray marker at the destination.
- `rm 'folder/*'` empties the folder without deleting it, matching `rm dir/*` in a shell.
  `rm -r folder` still removes the folder itself.

## Breaking-ish note

The `count` field in `--format json` for these commands follows the same rule and may be lower
than before for folders that contain markers. `rm 'folder/*'` also no longer deletes the folder
itself. Both are called out in the changeset.

## Test plan

- [x] `pnpm --filter @tigrisdata/cli test` — 922 passing (10 new tests covering `countObjects`,
      `isFolderMarker`, and the `*`-matches-empty-string behavior that made the marker match)
- [x] `pnpm lint` and `tsc --noEmit` clean
- [x] Verified end-to-end against a real bucket, since the counting depends on what the gateway
      actually returns for a prefix listing:
  - 10 files + marker: prompt 10 → moved 10; marker confirmed moved to the destination and gone
    from the source
  - `rm -r` on that folder: 10/10, marker deleted
  - empty folder: `mv` and `rm` both report 1
  - folder with a subfolder: reports 3, not 5
  - all copies failing: reports 0
  - `mv 'folder/*.txt'` → 2, `mv -r 'folder/*'` → 4, `rm -r 'folder/*'` → 2 with `folder/`
    surviving and the nested `sub/` marker removed
  - `rm -r folder` (no wildcard) still removes the folder entirely
- [x] Scratch test data cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible CLI semantics (counts, wildcard rm/mv/cp) and JSON `count` fields; storage operations are otherwise the same but scripts relying on old counts or wildcard folder deletion may differ.
> 
> **Overview**
> **`cp`, `mv`, and `rm`** now report object counts the same way **`ls`** does: zero-byte keys ending in `/` (folder markers) are still copied, moved, or deleted, but they are not counted in prompts, summaries, per-object log lines, or `--format json` **`count`**. A shared **`countObjects`** helper drives both confirmation and final tallies so those numbers cannot disagree; marker-only work still reports how many folders were handled (e.g. one empty folder → `1`), and failed object operations no longer inflate the count when only a marker succeeded.
> 
> **Wildcards** are treated as naming files *inside* a folder, not the folder itself: **`mv`/`cp`** skip moving/copying the source folder marker for wildcard paths; **`rm`** excludes the prefix marker from wildcard matches (because `*` matches the empty relative name). That fixes cases like **`mv 'folder/*.zip'`** with no matches incorrectly moving the folder marker, **`cp 'folder/*'`** creating a stray destination marker, and **`rm 'folder/*'`** removing the folder when shell users expect the directory to remain (use **`rm -r folder`** to remove it).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70102bc3d40b8dc695c448d6f6cbd352f937e282. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->