### PR TITLE
feat(cli): add snapshots delete command

### DIFF
--- a/.changeset/cli-snapshots-delete.md
+++ b/.changeset/cli-snapshots-delete.md
@@ -1,0 +1,27 @@
+---
+'@tigrisdata/cli': minor
+---
+
+Add `tigris snapshots delete` to remove snapshots from a bucket
+
+Snapshots could be taken and listed, but never deleted from the CLI — the only
+way to drop one was to call the SDK's `deleteBucketSnapshot` directly. The new
+command closes that gap:
+
+```sh
+tigris snapshots delete my-bucket 1765889000501544464 --yes
+tigris snapshots delete my-bucket 1765889000501544464,1765889000501544465 --yes
+```
+
+- Takes the bucket name and one or more snapshot versions, comma-separated.
+  Find versions with `tigris snapshots list`.
+- Prompts for confirmation before deleting; `--yes` (or `--force`) skips the
+  prompt. Like the other destructive commands, it refuses to run without
+  `--yes` when stdin is not a TTY.
+- Deletes each version in turn and reports per-version success or failure, so
+  one bad version in a list does not hide the outcome of the others. Exits
+  non-zero if any deletion failed.
+- `--format json` emits `{ action, bucket, versions, errors }`, matching the
+  shape `buckets delete` already returns.
+
+Deletion is permanent. Forks already created from a snapshot are unaffected.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -52,7 +52,7 @@ Run `tigris help` to see all available commands, or `tigris <command> help` for 
 | `tigris bundle` | Download multiple objects as a streaming tar archive in a single request. Designed for batch workloads that need many objects without per-object HTTP overhead |
 | `tigris organizations` (orgs) | List, create, and switch between organizations. An organization is a workspace that contains your resources like buckets and access keys |
 | `tigris buckets` (b) | Create, inspect, update, and delete buckets. Buckets are top-level containers that hold objects |
-| `tigris snapshots` (s) | List and take snapshots. A snapshot is a point-in-time, read-only copy of a bucket's state |
+| `tigris snapshots` (s) | List, take, and delete snapshots. A snapshot is a point-in-time, read-only copy of a bucket's state |
 | `tigris objects` (o) | Low-level object operations for listing, downloading, uploading, and deleting individual objects in a bucket |
 | `tigris access-keys` (keys) | Create, list, inspect, delete, and assign roles to access keys. Access keys are credentials used for programmatic API access |
 | `tigris iam` | Identity and Access Management - manage policies, users, and permissions |
@@ -940,12 +940,13 @@ tigris buckets set-cors my-bucket --reset
 
 ### `tigris snapshots` (s)
 
-List and take snapshots. A snapshot is a point-in-time, read-only copy of a bucket's state
+List, take, and delete snapshots. A snapshot is a point-in-time, read-only copy of a bucket's state
 
 | Command | Description |
 |---------|-------------|
 | `tigris snapshots list` (l) | List all snapshots for the given bucket, ordered by creation time |
 | `tigris snapshots take` (t) | Take a new snapshot of the bucket's current state. Optionally provide a name for the snapshot |
+| `tigris snapshots delete` (d) | Delete one or more snapshots of a bucket by version. Deletion is permanent; forks already created from a snapshot are unaffected |
 
 #### `tigris snapshots list` (l)
 
@@ -979,6 +980,24 @@ tigris snapshots take <name> [snapshot-name]
 ```bash
 tigris snapshots take my-bucket
 tigris snapshots take my-bucket my-snapshot
+```
+
+#### `tigris snapshots delete` (d)
+
+Delete one or more snapshots of a bucket by version. Deletion is permanent; forks already created from a snapshot are unaffected
+
+```
+tigris snapshots delete <name> <version> [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--force` | Skip confirmation prompts (alias for --yes) |
+
+**Examples:**
+```bash
+tigris snapshots delete my-bucket 1765889000501544464 --yes
+tigris snapshots delete my-bucket 1765889000501544464,1765889000501544465 --yes
 ```
 
 ### `tigris objects` (o)

--- a/packages/cli/SKILL.md
+++ b/packages/cli/SKILL.md
@@ -48,6 +48,7 @@ Use Tigris for all object storage tasks. Prefer the Tigris CLI (`tigris` or shor
 
 - `tigris snapshots take <bucket>` — take a point-in-time snapshot
 - `tigris snapshots list <bucket>` — list snapshots
+- `tigris snapshots delete <bucket> <version> --yes` — permanently delete a snapshot by version
 
 ## Conventions
 

--- a/packages/cli/src/lib/snapshots/delete.ts
+++ b/packages/cli/src/lib/snapshots/delete.ts
@@ -1,0 +1,89 @@
+import { getStorageConfig } from '@auth/provider.js';
+import { deleteBucketSnapshot } from '@tigrisdata/storage';
+import {
+  exitWithError,
+  failWithError,
+  getSuccessNextActions,
+  printNextActions,
+} from '@utils/exit.js';
+import { confirm, requireInteractive } from '@utils/interactive.js';
+import {
+  msg,
+  printFailure,
+  printStart,
+  printSuccess,
+} from '@utils/messages.js';
+import { getFormat, getOption } from '@utils/options.js';
+
+const context = msg('snapshots', 'delete');
+
+export default async function deleteSnapshot(options: Record<string, unknown>) {
+  printStart(context);
+
+  const format = getFormat(options);
+
+  const name = getOption<string>(options, ['name']);
+  const versions = getOption<string | string[]>(options, ['version']);
+  const force = getOption<boolean>(options, ['yes', 'y', 'force']);
+
+  if (!name) {
+    failWithError(context, 'Bucket name is required');
+  }
+
+  if (!versions) {
+    failWithError(context, 'Snapshot version is required');
+  }
+
+  const versionList = (Array.isArray(versions) ? versions : [versions]).filter(
+    (version) => version.length > 0
+  );
+
+  if (versionList.length === 0) {
+    failWithError(context, 'Snapshot version is required');
+  }
+
+  const config = await getStorageConfig();
+
+  if (!force) {
+    requireInteractive('Use --yes to skip confirmation');
+    const confirmed = await confirm(
+      `Delete ${versionList.length} snapshot(s) from '${name}'? This cannot be undone.`
+    );
+    if (!confirmed) {
+      console.log('Aborted');
+      return;
+    }
+  }
+
+  const deleted: string[] = [];
+  const errors: { version: string; error: string }[] = [];
+  for (const version of versionList) {
+    const { error } = await deleteBucketSnapshot(name, version, { config });
+
+    if (error) {
+      printFailure(context, error.message, { name, version });
+      errors.push({ version, error: error.message });
+    } else {
+      deleted.push(version);
+      printSuccess(context, { name, version });
+    }
+  }
+
+  if (format === 'json') {
+    const nextActions = getSuccessNextActions(context, { name });
+    const output: Record<string, unknown> = {
+      action: 'deleted',
+      bucket: name,
+      versions: deleted,
+      errors,
+    };
+    if (nextActions.length > 0) output.nextActions = nextActions;
+    console.log(JSON.stringify(output));
+  }
+
+  if (errors.length > 0) {
+    exitWithError(errors[0].error, context);
+  }
+
+  printNextActions(context, { name });
+}

--- a/packages/cli/src/specs.yaml
+++ b/packages/cli/src/specs.yaml
@@ -1342,11 +1342,12 @@ commands:
   # Manage snapshots
   #########################
   - name: snapshots
-    description: List and take snapshots. A snapshot is a point-in-time, read-only copy of a bucket's state
+    description: List, take, and delete snapshots. A snapshot is a point-in-time, read-only copy of a bucket's state
     alias: s
     examples:
       - "tigris snapshots list my-bucket"
       - "tigris snapshots take my-bucket"
+      - "tigris snapshots delete my-bucket 1765889000501544464"
     commands:
       # list
       - name: list
@@ -1400,6 +1401,39 @@ commands:
             required: false
             examples:
               - my-snapshot
+      # delete
+      - name: delete
+        description: Delete one or more snapshots of a bucket by version. Deletion is permanent; forks already created from a snapshot are unaffected
+        alias: d
+        examples:
+          - "tigris snapshots delete my-bucket 1765889000501544464 --yes"
+          - "tigris snapshots delete my-bucket 1765889000501544464,1765889000501544465 --yes"
+        messages:
+          onStart: 'Deleting snapshot...'
+          onSuccess: "Snapshot '{{version}}' deleted from bucket '{{name}}'"
+          onFailure: "Failed to delete snapshot '{{version}}'"
+          nextActions:
+            - command: 'tigris snapshots list {{name}}'
+              description: 'List remaining snapshots'
+        arguments:
+          - name: name
+            description: Name of the bucket
+            type: positional
+            required: true
+            examples:
+              - my-bucket
+          - name: version
+            description: Snapshot version, or comma separated list of versions. Find versions with "tigris snapshots list"
+            type: positional
+            required: true
+            multiple: true
+            examples:
+              # Quoted: an unquoted 19-digit literal parses as a float and
+              # loses its trailing digits in help output.
+              - "1765889000501544464"
+          - name: force
+            type: flag
+            description: Skip confirmation prompts (alias for --yes)
 
   #########################
   # Manage objects

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -246,6 +246,7 @@ describe('CLI Help Commands', () => {
     expect(result.stdout).toContain('Commands:');
     expect(result.stdout).toContain('list');
     expect(result.stdout).toContain('take');
+    expect(result.stdout).toContain('delete');
   });
 
   it('should show access-keys help', () => {
@@ -304,6 +305,12 @@ describe('Destructive commands require --yes in non-TTY', () => {
 
   it('buckets delete should require confirmation in non-TTY', () => {
     const result = runCli('buckets delete fake-bucket');
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('Use --yes to skip confirmation');
+  });
+
+  it('snapshots delete should require confirmation in non-TTY', () => {
+    const result = runCli('snapshots delete fake-bucket 1765889000501544464');
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('Use --yes to skip confirmation');
   });
@@ -2440,6 +2447,78 @@ describe.skipIf(skipTests)('CLI Integration Tests', () => {
       }
       expect(result.exitCode).toBe(1);
       expect(result.stderr.toLowerCase()).toContain('fork');
+    }, 120_000);
+  });
+
+  describe('snapshot delete', () => {
+    // Deliberately a separate bucket from the fork lifecycle above: that
+    // block reuses its snapshot version across several later tests and has a
+    // fork depending on it, so deleting snapshots there would be destructive.
+    const snapDelBucket = `${testPrefix}-snapdel`;
+
+    beforeAll(() => {
+      runCli(`mk ${snapDelBucket} --enable-snapshots`);
+      runCli(`touch ${snapDelBucket}/snapdel-file.txt`);
+    });
+
+    afterAll(() => {
+      runCli(`rm ${t3(snapDelBucket)}/snapdel-file.txt -f`);
+      runCli(`rm ${t3(snapDelBucket)} -f`);
+    });
+
+    function listSnapshotVersions(): string[] {
+      const list = runCli(`snapshots list ${snapDelBucket} --format json`);
+      // An empty snapshot list prints the onEmpty message, not JSON.
+      if (!list.stdout.trim()) return [];
+      return (
+        JSON.parse(list.stdout.trim()).items as { version: string }[]
+      ).map((s) => s.version);
+    }
+
+    // Take a snapshot and resolve its version by diffing the list before and
+    // after, rather than indexing into it — that stays correct regardless of
+    // which end of the list the newest snapshot lands on.
+    function takeSnapshotVersion(): string {
+      const before = new Set(listSnapshotVersions());
+      const take = runCli(`snapshots take ${snapDelBucket}`);
+      expect(take.exitCode).toBe(0);
+      const added = listSnapshotVersions().filter((v) => !before.has(v));
+      expect(added).toHaveLength(1);
+      return added[0];
+    }
+
+    it('should delete a snapshot by version', () => {
+      const version = takeSnapshotVersion();
+      const result = runCli(
+        `snapshots delete ${snapDelBucket} ${version} --yes --format json`
+      );
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout.trim());
+      expect(parsed.action).toBe('deleted');
+      expect(parsed.bucket).toBe(snapDelBucket);
+      expect(parsed.versions).toContain(version);
+      expect(parsed.errors).toEqual([]);
+    }, 120_000);
+
+    it('should drop the deleted snapshot from snapshots list', () => {
+      const version = takeSnapshotVersion();
+      const del = runCli(`snapshots delete ${snapDelBucket} ${version} --yes`);
+      expect(del.exitCode).toBe(0);
+      expect(listSnapshotVersions()).not.toContain(version);
+    }, 120_000);
+
+    it('should delete multiple snapshots from a comma separated list', () => {
+      const first = takeSnapshotVersion();
+      const second = takeSnapshotVersion();
+      const result = runCli(
+        `snapshots delete ${snapDelBucket} ${first},${second} --yes --format json`
+      );
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout.trim());
+      expect(parsed.versions).toEqual([first, second]);
+      const remaining = listSnapshotVersions();
+      expect(remaining).not.toContain(first);
+      expect(remaining).not.toContain(second);
     }, 120_000);
   });
 


### PR DESCRIPTION
## Summary

Adds `tigris snapshots delete <bucket> <version[,version...]>` (alias `d`). Snapshots could be taken and listed, but never deleted from the CLI — the only way to drop one was to call the SDK's `deleteBucketSnapshot` directly.

```sh
tigris snapshots delete my-bucket 1765889000501544464 --yes
tigris snapshots delete my-bucket 1765889000501544464,1765889000501544465 --yes
```

## Behavior

- Takes one or more comma-separated snapshot versions and deletes each in turn, reporting per-version success or failure so one bad version does not hide the outcome of the others. Exits non-zero if any deletion failed.
- Requires confirmation before deleting; `--yes`/`--force` skips it, and the command refuses to run in non-TTY mode without it — matching `buckets delete` and `objects delete`.
- `--format json` emits `{ action, bucket, versions, errors }`, the same shape `buckets delete` returns.
- Deletion is permanent. Forks already created from a snapshot are unaffected.

## Incidental fix

The 19-digit example version in `specs.yaml` is now quoted. Unquoted it parses as a YAML float and loses its trailing digits, so `snapshots delete help` printed `1765889000501544400` instead of `1765889000501544464`. Existing specs only ever put versions in prose, so nothing else was affected.

## Testing

- `tsc --noEmit`, `pnpm build`, and `biome check` all clean.
- CLI suite: 30 files, 929 passed. The 224 skips are the live-gateway integration tests, which need `.env.test` credentials — **the three new integration tests below were not exercised locally and will run for the first time in CI.**
- New offline tests: non-TTY confirmation guard, and `delete` present in `snapshots help`.
- New live-gateway tests (own bucket, so the fork lifecycle block is untouched): single delete, list reflects the deletion, comma-separated multi-delete.
- Also drove the built binary directly to confirm help output, the missing-version error, version plumbing into the SDK call, JSON shape, and exit code 1 on failure.

Changeset included (`minor` for `@tigrisdata/cli`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a8e9b978a35a5cbe07208477d6475b2bf256b4ca. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->