### PR TITLE
feat(iam): implement deleteTeam method

### DIFF
--- a/.changeset/feat-iam-delete-teams.md
+++ b/.changeset/feat-iam-delete-teams.md
@@ -1,0 +1,5 @@
+---
+"@tigrisdata/iam": minor
+---
+
+Introduces deleteTeam method in iam package

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.8/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/packages/iam/src/index.ts
+++ b/packages/iam/src/index.ts
@@ -72,6 +72,11 @@ export {
   createTeam,
 } from './lib/team/create';
 export {
+  type DeleteTeamOptions,
+  type DeleteTeamResponse,
+  deleteTeam,
+} from './lib/team/delete';
+export {
   type EditTeamOptions,
   type EditTeamResponse,
   editTeam,

--- a/packages/iam/src/lib/team/delete.ts
+++ b/packages/iam/src/lib/team/delete.ts
@@ -1,0 +1,41 @@
+import { createIAMClient, IAM_ENDPOINTS } from '../http-client';
+import type { TigrisIAMConfig } from '../types';
+
+export type DeleteTeamOptions = {
+  config?: TigrisIAMConfig;
+};
+
+export type DeleteTeamResponse = {
+  teamId: string;
+};
+
+type DeleteTeamApiResponse = {
+  status: 'success' | 'error';
+  message?: string;
+  result: unknown;
+};
+
+export async function deleteTeam(teamId: string, options?: DeleteTeamOptions) {
+  const { data: client, error: clientError } = createIAMClient(options?.config);
+
+  if (clientError || !client) {
+    return { error: clientError };
+  }
+
+  const response = await client.request<unknown, DeleteTeamApiResponse>({
+    method: 'DELETE',
+    path: `${IAM_ENDPOINTS.teams}/${teamId}`,
+  });
+
+  if (response.error) {
+    return { error: response.error };
+  }
+
+  if (response.data.status === 'error') {
+    return {
+      error: new Error(response.data.message ?? 'Failed to delete team'),
+    };
+  }
+
+  return { data: { teamId } };
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Destructive IAM team deletion is a sensitive operation; the change is small and follows existing team API patterns but callers can permanently remove teams if misused.
> 
> **Overview**
> Adds **`deleteTeam`** to `@tigrisdata/iam`, completing team lifecycle support alongside existing create/edit/list helpers.
> 
> The new API issues a **DELETE** to `teams/{teamId}`, mirrors other team methods for client setup and `status: 'error'` handling, and returns `{ data: { teamId } }` on success. Types and the function are re-exported from the package entrypoint. A **minor** changeset documents the release; Biome’s JSON schema URL is bumped to **2.5.8**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af43f966eb875ba497e8a16bc64a82197efa2bc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->