### PR TITLE
feat(shared): add opt-in retry and error hooks to the HTTP client

### DIFF
--- a/.changeset/http-client-retry-and-error-hooks.md
+++ b/.changeset/http-client-retry-and-error-hooks.md
@@ -1,0 +1,49 @@
+---
+"@tigrisdata/storage": minor
+"@tigrisdata/iam": minor
+---
+
+Add opt-in request retry and injectable error hooks to the HTTP client.
+
+`retry` can be set on any `config` option, or per request. It is opt-in —
+omitted or `false` performs a single attempt, matching existing behavior. When
+enabled it defaults to 3 attempts with exponential backoff and full jitter,
+honors `Retry-After`, and retries only `408`, `429`, and `5xx`; `400` and `403`
+are deliberately excluded because they are deterministic for this client.
+`shouldRetry` overrides the decision entirely.
+
+Transport failures — where the request never produced a response — are treated
+separately from status codes, because the outcome is unknown and a write may
+already have landed. They are retried only when the request method is safe to
+re-send (`GET` and `HEAD`); enabling `retry` on a `POST`, `PUT`, `PATCH`, or
+`DELETE` retries retryable statuses but not transport failures. Set
+`retryNetworkErrors: true` to opt a known-safe operation back in. Status-code
+retries are unaffected by the method.
+
+```ts
+await updateBucket('my-bucket', {
+  access: 'public',
+  config: { retry: { attempts: 5 } },
+});
+```
+
+`setTigrisHttpHooks({ onError, onRetry })` registers process-wide observability
+callbacks so telemetry (Sentry, logging, metrics) can be wired in without this
+SDK taking on the dependency. Hooks are observational: a throwing or rejecting
+hook can never fail a request, and none are awaited. A single registration
+covers every Tigris SDK package in the process, so registering through
+`@tigrisdata/storage` also reports `@tigrisdata/iam` failures.
+
+The hook context reports `origin` and `path` separately, so a consumer can use
+the host-independent `path` as an identifier or recompose the absolute URL as
+`${origin}${path}` to match what another HTTP client would report for the same
+endpoint. The `shouldRetry` predicate receives the same pair.
+
+Both `retry` and the hooks cover requests made through the Tigris HTTP client —
+the bucket, fork, and IAM operations. Object data-plane calls (`put`, `get`,
+`list`, multipart) go through the AWS SDK's S3 client, which applies its own
+retry policy and is not covered by the hooks.
+
+Also fixes a latent crash where a 2xx response carrying a JSON content-type but
+an empty body — as `POST ?restore` returns — threw a parse error out of
+`request()` instead of resolving.

--- a/packages/iam/src/index.ts
+++ b/packages/iam/src/index.ts
@@ -1,3 +1,13 @@
+export {
+  type HttpErrorContext,
+  type HttpErrorSource,
+  type RetryConfig,
+  type RetryContext,
+  type RetryHookContext,
+  type RetryOptions,
+  setTigrisHttpHooks,
+  type TigrisHttpHooks,
+} from '@shared/index';
 export type { TigrisConfig } from '@shared/types';
 export {
   type AssignBucketRolesOptions,

--- a/packages/iam/src/lib/http-client.ts
+++ b/packages/iam/src/lib/http-client.ts
@@ -79,5 +79,6 @@ export function createIAMClient(
     organizationId,
     accessKeyId,
     secretAccessKey,
+    retry: options?.retry ?? config.retry,
   });
 }

--- a/packages/storage/src/lib/http-client.ts
+++ b/packages/storage/src/lib/http-client.ts
@@ -33,5 +33,6 @@ export function createStorageClient(
     organizationId,
     accessKeyId,
     secretAccessKey,
+    retry: options?.retry ?? config.retry,
   });
 }

--- a/packages/storage/src/server.ts
+++ b/packages/storage/src/server.ts
@@ -1,3 +1,13 @@
+export {
+  type HttpErrorContext,
+  type HttpErrorSource,
+  type RetryConfig,
+  type RetryContext,
+  type RetryHookContext,
+  type RetryOptions,
+  setTigrisHttpHooks,
+  type TigrisHttpHooks,
+} from '@shared/index';
 export type { TigrisConfig } from '@shared/types';
 export {
   type CreateBucketOptions,

--- a/shared/hooks.test.ts
+++ b/shared/hooks.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { emitHook, getTigrisHttpHooks, setTigrisHttpHooks } from './hooks';
+
+afterEach(() => {
+  setTigrisHttpHooks(undefined);
+});
+
+describe('the hook registry', () => {
+  it('starts empty', () => {
+    expect(getTigrisHttpHooks()).toBeUndefined();
+  });
+
+  it('round-trips registered hooks', () => {
+    const hooks = { onError: vi.fn() };
+    setTigrisHttpHooks(hooks);
+
+    expect(getTigrisHttpHooks()).toBe(hooks);
+  });
+
+  it('clears on undefined', () => {
+    setTigrisHttpHooks({ onError: vi.fn() });
+    setTigrisHttpHooks(undefined);
+
+    expect(getTigrisHttpHooks()).toBeUndefined();
+  });
+
+  /**
+   * `shared/` is bundled into every package rather than published once, so a
+   * module-level registry would give `@tigrisdata/storage` and
+   * `@tigrisdata/iam` a private copy each and silently drop the other
+   * package's telemetry. These pin the registry to the shared global that
+   * makes one registration cover them all.
+   */
+  it('stores hooks on a shared global rather than in module state', () => {
+    const hooks = { onError: vi.fn() };
+    setTigrisHttpHooks(hooks);
+
+    const slot = (
+      globalThis as Record<symbol, { hooks?: unknown } | undefined>
+    )[Symbol.for('@tigrisdata/http-hooks.v1')];
+
+    expect(slot?.hooks).toBe(hooks);
+  });
+
+  it('reads hooks a separate bundle copy registered', () => {
+    // Stands in for another package's inlined copy of this module writing to
+    // the same global slot.
+    const hooks = { onError: vi.fn() };
+    (globalThis as Record<symbol, { hooks?: unknown }>)[
+      Symbol.for('@tigrisdata/http-hooks.v1')
+    ] = { hooks };
+
+    expect(getTigrisHttpHooks()).toBe(hooks);
+  });
+
+  it('keeps the registry key off enumerable global listings', () => {
+    setTigrisHttpHooks({ onError: vi.fn() });
+
+    const key = Symbol.for('@tigrisdata/http-hooks.v1');
+    expect(Object.getOwnPropertySymbols(globalThis)).toContain(key);
+    expect(Object.getOwnPropertyDescriptor(globalThis, key)?.enumerable).toBe(
+      false
+    );
+  });
+});
+
+describe('emitHook', () => {
+  it('passes the context through', () => {
+    const hook = vi.fn();
+    emitHook(hook, { source: 'http_error' });
+
+    expect(hook).toHaveBeenCalledWith({ source: 'http_error' });
+  });
+
+  it('is a no-op when no hook is registered', () => {
+    expect(() => emitHook(undefined, {})).not.toThrow();
+  });
+
+  it('swallows a synchronous throw so telemetry cannot fail a request', () => {
+    const hook = vi.fn(() => {
+      throw new Error('sentry is down');
+    });
+
+    expect(() => emitHook(hook, {})).not.toThrow();
+    expect(hook).toHaveBeenCalled();
+  });
+
+  it('swallows a rejected promise without an unhandled rejection', async () => {
+    const hook = vi.fn(() => Promise.reject(new Error('flush failed')));
+
+    expect(() => emitHook(hook, {})).not.toThrow();
+    await Promise.resolve();
+    expect(hook).toHaveBeenCalled();
+  });
+
+  it('does not wait on a slow hook', async () => {
+    let settled = false;
+    emitHook(
+      () =>
+        new Promise<void>((resolve) => {
+          setTimeout(() => {
+            settled = true;
+            resolve();
+          }, 50);
+        }),
+      {}
+    );
+
+    // Returned synchronously, long before the hook's promise settles.
+    expect(settled).toBe(false);
+  });
+});

--- a/shared/hooks.ts
+++ b/shared/hooks.ts
@@ -1,0 +1,154 @@
+/**
+ * Where an error surfaced, so a consumer can tell a one-shot failure from one
+ * that survived every retry.
+ *
+ * - `http_error` — the server answered with a non-2xx that was not retried.
+ * - `retries_exhausted` — retried up to the attempt ceiling and still failed.
+ * - `network_error` — the request never produced a response.
+ */
+export type HttpErrorSource =
+  | 'http_error'
+  | 'retries_exhausted'
+  | 'network_error';
+
+export interface HttpErrorContext {
+  source: HttpErrorSource;
+  method: string;
+  /**
+   * Scheme, host, and port the request went to. Split from `path` so a consumer
+   * can reconstruct the absolute URL as `${origin}${path}` while keeping the
+   * default identifier host-independent.
+   */
+  origin: string;
+  /**
+   * Request path including query string. Carries no auth material: this client
+   * signs via headers, never via query parameters.
+   */
+  path: string;
+  organizationId?: string;
+  status?: number;
+  /** 1-based index of the attempt that produced this error. */
+  attempt: number;
+  /** Total attempts allowed for the request. */
+  attempts: number;
+  message: string;
+  error: Error;
+}
+
+export interface RetryHookContext extends HttpErrorContext {
+  /** Backoff applied before the next attempt, in ms. */
+  delayMs: number;
+}
+
+export interface TigrisHttpHooks {
+  onError?: (context: HttpErrorContext) => void | Promise<void>;
+  onRetry?: (context: RetryHookContext) => void | Promise<void>;
+}
+
+/**
+ * The registry lives on `globalThis`, not in a module-level variable.
+ *
+ * `shared/` is bundled into each package at build time rather than published
+ * as its own module, so a module-level `let` here is duplicated per bundle:
+ * `@tigrisdata/storage` and `@tigrisdata/iam` would each hold a private
+ * registry, and a consumer registering through one would silently get no
+ * telemetry from the other. The CJS and ESM builds of a single package split
+ * the same way. A shared global is what makes one `setTigrisHttpHooks` call
+ * cover every Tigris SDK package in the process.
+ *
+ * The key is versioned so a future breaking change to `TigrisHttpHooks` can
+ * take a new slot instead of handing an old-shaped object to new code, which
+ * matters when two different SDK versions coexist in one dependency tree.
+ */
+const REGISTRY_KEY = Symbol.for('@tigrisdata/http-hooks.v1');
+
+type HookRegistry = { hooks?: TigrisHttpHooks };
+
+function registry(): HookRegistry {
+  const container = globalThis as typeof globalThis & {
+    [REGISTRY_KEY]?: HookRegistry;
+  };
+
+  let existing = container[REGISTRY_KEY];
+  if (!existing) {
+    existing = {};
+    Object.defineProperty(container, REGISTRY_KEY, {
+      value: existing,
+      // Non-enumerable so the key stays out of logs and object dumps; still
+      // writable/configurable so tooling can reset it if it must.
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  return existing;
+}
+
+/**
+ * Register process-wide observability hooks for the Tigris HTTP client.
+ *
+ * One call covers every Tigris SDK package in the process — registering
+ * through `@tigrisdata/storage` also reports `@tigrisdata/iam` failures.
+ *
+ * Read at request time rather than captured at client construction, which
+ * keeps the client cache in `http-client.ts` intact: a function cannot go into
+ * a cache key, so binding hooks per client would mean either skipping the
+ * cache or silently serving the first caller's hooks to everyone.
+ *
+ * Covers requests made through `createTigrisHttpClient` — the bucket, fork,
+ * and IAM operations. Object data-plane calls (`put`, `get`, `list`,
+ * multipart) go through the AWS SDK's S3 client and are not reported here.
+ *
+ * Pass `undefined` to clear.
+ *
+ * @example
+ * ```ts
+ * import * as Sentry from '@sentry/node';
+ *
+ * setTigrisHttpHooks({
+ *   onError: ({ source, method, origin, path, status, message }) => {
+ *     Sentry.captureException(
+ *       new Error(`Tigris ${status ?? ''} ${origin}${path}`),
+ *       {
+ *         tags: { api_error_source: source, api_method: method },
+ *         contexts: { error_detail: { message } },
+ *       }
+ *     );
+ *   },
+ * });
+ * ```
+ */
+export function setTigrisHttpHooks(hooks: TigrisHttpHooks | undefined): void {
+  registry().hooks = hooks;
+}
+
+export function getTigrisHttpHooks(): TigrisHttpHooks | undefined {
+  return registry().hooks;
+}
+
+/**
+ * Invoke a hook without letting it affect the request.
+ *
+ * Hooks are observational, so a consumer's telemetry callback must never be
+ * able to fail an otherwise-fine call. Sync throws and rejected promises are
+ * both swallowed, and the result is never awaited — a slow reporter should not
+ * add latency to the request path.
+ */
+export function emitHook<T>(
+  hook: ((context: T) => void | Promise<void>) | undefined,
+  context: T
+): void {
+  if (!hook) {
+    return;
+  }
+
+  try {
+    const result = hook(context);
+    if (result && typeof result.then === 'function') {
+      result.then(undefined, () => {});
+    }
+  } catch {
+    // Swallowed by design: see above.
+  }
+}

--- a/shared/http-client.test.ts
+++ b/shared/http-client.test.ts
@@ -1,0 +1,671 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setTigrisHttpHooks } from './hooks';
+import { createTigrisHttpClient, type TigrisHttpClient } from './http-client';
+
+let fetchMock: ReturnType<typeof vi.fn>;
+let uniqueSuffix = 0;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  setTigrisHttpHooks(undefined);
+});
+
+/**
+ * Clients are cached module-wide by endpoint and credentials, so each test
+ * takes a fresh endpoint to avoid inheriting another test's client.
+ */
+function makeClient(
+  overrides: Partial<Parameters<typeof createTigrisHttpClient>[0]> = {}
+): TigrisHttpClient {
+  const { data, error } = createTigrisHttpClient({
+    baseUrl: `https://t${uniqueSuffix++}.example.com`,
+    accessKeyId: 'AKIAEXAMPLE',
+    secretAccessKey: 'secret',
+    ...overrides,
+  });
+
+  if (error || !data) {
+    throw error ?? new Error('client was not created');
+  }
+
+  return data;
+}
+
+function json(
+  status: number,
+  body: unknown,
+  init: { statusText?: string; headers?: Record<string, string> } = {}
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    statusText: init.statusText ?? '',
+    headers: { 'content-type': 'application/json', ...init.headers },
+  });
+}
+
+function headerOf(call: unknown[], name: string): string | undefined {
+  const headers = (call[1] as { headers: Record<string, string> }).headers;
+  const match = Object.keys(headers).find(
+    (key) => key.toLowerCase() === name.toLowerCase()
+  );
+  return match ? headers[match] : undefined;
+}
+
+describe('retry', () => {
+  it('is off by default — a 500 returns after a single attempt', async () => {
+    fetchMock.mockImplementation(() => json(500, { Message: 'boom' }));
+
+    const response = await makeClient().request({ method: 'GET', path: '/x' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(response.error?.message).toBe('boom');
+  });
+
+  it('retries up to the attempt ceiling when enabled', async () => {
+    fetchMock.mockImplementation(() => json(503, { Message: 'unavailable' }));
+
+    const client = makeClient({ retry: { attempts: 3, baseDelayMs: 0 } });
+    const response = await client.request({ method: 'GET', path: '/x' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(response.error?.message).toBe('unavailable');
+  });
+
+  it('stops retrying as soon as an attempt succeeds', async () => {
+    fetchMock
+      .mockImplementationOnce(() => json(503, { Message: 'unavailable' }))
+      .mockImplementationOnce(() => json(200, { ok: true }));
+
+    const client = makeClient({ retry: { attempts: 3, baseDelayMs: 0 } });
+    const response = await client.request({ method: 'GET', path: '/x' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(response.data).toEqual({ ok: true });
+  });
+
+  it('does not retry 403, which is how SignatureDoesNotMatch surfaces', async () => {
+    fetchMock.mockImplementation(() =>
+      json(403, { Message: 'SignatureDoesNotMatch' })
+    );
+
+    const client = makeClient({ retry: { attempts: 3, baseDelayMs: 0 } });
+    const response = await client.request({ method: 'GET', path: '/x' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(response.error?.message).toBe('SignatureDoesNotMatch');
+  });
+
+  it('does not retry 400', async () => {
+    fetchMock.mockImplementation(() => json(400, { Message: 'bad request' }));
+
+    const client = makeClient({ retry: { attempts: 3, baseDelayMs: 0 } });
+    await client.request({ method: 'GET', path: '/x' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets a per-request false override a retrying client', async () => {
+    fetchMock.mockImplementation(() => json(500, { Message: 'boom' }));
+
+    const client = makeClient({ retry: { attempts: 3, baseDelayMs: 0 } });
+    await client.request({ method: 'GET', path: '/x', retry: false });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets a per-request policy override a non-retrying client', async () => {
+    fetchMock.mockImplementation(() => json(500, { Message: 'boom' }));
+
+    await makeClient().request({
+      method: 'GET',
+      path: '/x',
+      retry: { attempts: 2, baseDelayMs: 0 },
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('honors a custom shouldRetry predicate', async () => {
+    fetchMock.mockImplementation(() => json(403, { Message: 'expired' }));
+
+    const client = makeClient({
+      retry: {
+        attempts: 2,
+        baseDelayMs: 0,
+        shouldRetry: (ctx) => ctx.status === 403,
+      },
+    });
+    await client.request({ method: 'GET', path: '/x' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('gives shouldRetry the same origin/path pair the hooks get', async () => {
+    fetchMock.mockImplementation(() => json(500, { Message: 'boom' }));
+    const seen: Array<{ origin: string; path: string }> = [];
+
+    const client = makeClient({
+      retry: {
+        attempts: 2,
+        baseDelayMs: 0,
+        shouldRetry: (ctx) => {
+          seen.push({ origin: ctx.origin, path: ctx.path });
+          return true;
+        },
+      },
+    });
+    await client.request({ method: 'GET', path: '/bucket' });
+
+    expect(seen).toHaveLength(1);
+    expect(`${seen[0].origin}${seen[0].path}`).toBe(fetchMock.mock.calls[0][0]);
+  });
+
+  it('re-signs every attempt so x-amz-date stays inside its window', async () => {
+    fetchMock.mockImplementation(() => json(503, { Message: 'unavailable' }));
+
+    const client = makeClient({ retry: { attempts: 2, baseDelayMs: 0 } });
+    await client.request({ method: 'GET', path: '/x' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    for (const call of fetchMock.mock.calls) {
+      expect(headerOf(call, 'authorization')).toBeTruthy();
+      expect(headerOf(call, 'x-amz-date')).toBeTruthy();
+    }
+  });
+
+  it('re-sends identical bytes on retry, preserving server-side dedup keys', async () => {
+    fetchMock.mockImplementation(() => json(503, { Message: 'unavailable' }));
+
+    const client = makeClient({ retry: { attempts: 3, baseDelayMs: 0 } });
+    await client.request({
+      method: 'POST',
+      path: '/x',
+      body: { req_uuid: 'fixed-uuid', name: 'ci' },
+    });
+
+    const bodies = fetchMock.mock.calls.map(
+      (call) => (call[1] as { body?: string }).body
+    );
+    expect(bodies).toHaveLength(3);
+    expect(new Set(bodies).size).toBe(1);
+    expect(bodies[0]).toContain('fixed-uuid');
+  });
+
+  it('waits the Retry-After the server asked for', async () => {
+    fetchMock
+      .mockImplementationOnce(() =>
+        json(429, { Message: 'slow down' }, { headers: { 'retry-after': '1' } })
+      )
+      .mockImplementationOnce(() => json(200, { ok: true }));
+
+    const client = makeClient({
+      retry: { attempts: 2, baseDelayMs: 5, maxDelayMs: 10_000 },
+    });
+
+    const started = Date.now();
+    await client.request({ method: 'GET', path: '/x' });
+    const elapsed = Date.now() - started;
+
+    // 1s from the header, not the 5ms the backoff would have produced.
+    expect(elapsed).toBeGreaterThanOrEqual(900);
+  });
+});
+
+describe('transport failures', () => {
+  it('propagates as a throw, preserving the pre-retry contract', async () => {
+    fetchMock.mockRejectedValue(new TypeError('fetch failed'));
+
+    await expect(
+      makeClient().request({ method: 'GET', path: '/x' })
+    ).rejects.toThrow('fetch failed');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('still throws after exhausting retries', async () => {
+    fetchMock.mockRejectedValue(new TypeError('fetch failed'));
+
+    const client = makeClient({ retry: { attempts: 3, baseDelayMs: 0 } });
+
+    await expect(client.request({ method: 'GET', path: '/x' })).rejects.toThrow(
+      'fetch failed'
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('never retries an abort — that is the caller cancelling', async () => {
+    fetchMock.mockRejectedValue(
+      Object.assign(new Error('aborted'), { name: 'AbortError' })
+    );
+
+    const client = makeClient({ retry: { attempts: 3, baseDelayMs: 0 } });
+
+    await expect(client.request({ method: 'GET', path: '/x' })).rejects.toThrow(
+      'aborted'
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('never retries once the caller signal is aborted, whatever the error shape', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    // A runtime whose abort rejection is not an `Error` subclass at all.
+    fetchMock.mockRejectedValue({ name: 'AbortError', message: 'aborted' });
+
+    const client = makeClient({ retry: { attempts: 3, baseDelayMs: 0 } });
+
+    await expect(
+      client.request({ method: 'GET', path: '/x', signal: controller.signal })
+    ).rejects.toEqual({ name: 'AbortError', message: 'aborted' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rethrows the original error object so callers can match on its fields', async () => {
+    const original = Object.assign(new TypeError('fetch failed'), {
+      code: 'ECONNRESET',
+    });
+    fetchMock.mockRejectedValue(original);
+
+    const client = makeClient({ retry: { attempts: 2, baseDelayMs: 0 } });
+
+    await expect(client.request({ method: 'GET', path: '/x' })).rejects.toBe(
+      original
+    );
+  });
+
+  it('forwards an AbortSignal to fetch', async () => {
+    fetchMock.mockImplementation(() => json(200, { ok: true }));
+    const controller = new AbortController();
+
+    await makeClient().request({
+      method: 'GET',
+      path: '/x',
+      signal: controller.signal,
+    });
+
+    expect((fetchMock.mock.calls[0][1] as RequestInit).signal).toBe(
+      controller.signal
+    );
+  });
+
+  it('retries a GET transport failure under retry: true', async () => {
+    fetchMock.mockRejectedValue(new TypeError('fetch failed'));
+
+    const client = makeClient({ retry: { attempts: 3, baseDelayMs: 0 } });
+
+    await expect(
+      client.request({ method: 'GET', path: '/x' })
+    ).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry a non-idempotent transport failure under retry: true', async () => {
+    // The write may already have landed on the server, so re-sending could
+    // double-apply it. Status-code retries still apply to these methods.
+    for (const method of ['POST', 'PUT', 'PATCH', 'DELETE'] as const) {
+      fetchMock.mockClear();
+      fetchMock.mockRejectedValue(new TypeError('fetch failed'));
+
+      const client = makeClient({ retry: { attempts: 3, baseDelayMs: 0 } });
+
+      await expect(client.request({ method, path: '/x' })).rejects.toThrow();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('retries a POST transport failure when explicitly opted in', async () => {
+    fetchMock.mockRejectedValue(new TypeError('fetch failed'));
+
+    const client = makeClient({
+      retry: { attempts: 3, baseDelayMs: 0, retryNetworkErrors: true },
+    });
+
+    await expect(
+      client.request({ method: 'POST', path: '/x' })
+    ).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('still retries a POST on a retryable status', async () => {
+    fetchMock.mockImplementation(() => json(503, { Message: 'unavailable' }));
+
+    const client = makeClient({ retry: { attempts: 3, baseDelayMs: 0 } });
+    await client.request({ method: 'POST', path: '/x' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry transport errors when retryNetworkErrors is off', async () => {
+    fetchMock.mockRejectedValue(new TypeError('fetch failed'));
+
+    const client = makeClient({
+      retry: { attempts: 3, baseDelayMs: 0, retryNetworkErrors: false },
+    });
+
+    await expect(
+      client.request({ method: 'GET', path: '/x' })
+    ).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('body parsing', () => {
+  it('treats an empty JSON body as {} instead of throwing', async () => {
+    // `POST ?restore` answers 200 with no payload while still advertising JSON.
+    fetchMock.mockImplementation(
+      () =>
+        new Response('', {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+    );
+
+    const response = await makeClient().request({
+      method: 'POST',
+      path: '/bucket?restore',
+    });
+
+    expect(response.error).toBeUndefined();
+    expect(response.data).toEqual({});
+  });
+
+  it('returns non-JSON bodies as text', async () => {
+    fetchMock.mockImplementation(
+      () =>
+        new Response('<xml/>', {
+          status: 200,
+          headers: { 'content-type': 'application/xml' },
+        })
+    );
+
+    const response = await makeClient().request({ method: 'GET', path: '/x' });
+
+    expect(response.data).toBe('<xml/>');
+  });
+
+  it('falls back to status text when an error body is not JSON', async () => {
+    fetchMock.mockImplementation(
+      () =>
+        new Response('gateway exploded', {
+          status: 502,
+          statusText: 'Bad Gateway',
+        })
+    );
+
+    const response = await makeClient().request({ method: 'GET', path: '/x' });
+
+    expect(response.error?.message).toBe('Bad Gateway');
+  });
+
+  it('never constructs an error with an empty message', async () => {
+    fetchMock.mockImplementation(() => new Response('', { status: 500 }));
+
+    const response = await makeClient().request({ method: 'GET', path: '/x' });
+
+    expect(response.error?.message).toBe('Unknown error');
+  });
+
+  it('falls through a JSON body with no usable message', async () => {
+    // HTTP/2 has no reason phrase, so `statusText` is empty there — with a
+    // JSON error body that carries no `Message`, there is nothing to report
+    // but the fallback.
+    fetchMock.mockImplementation(
+      () =>
+        new Response(JSON.stringify({ foo: 1 }), {
+          status: 500,
+          statusText: '',
+          headers: { 'content-type': 'application/json' },
+        })
+    );
+
+    const response = await makeClient().request({ method: 'GET', path: '/x' });
+
+    expect(response.error?.message).toBe('Unknown error');
+  });
+
+  it('prefers statusText when the JSON body has an empty message', async () => {
+    fetchMock.mockImplementation(
+      () =>
+        new Response(JSON.stringify({ Message: '' }), {
+          status: 502,
+          statusText: 'Bad Gateway',
+          headers: { 'content-type': 'application/json' },
+        })
+    );
+
+    const response = await makeClient().request({ method: 'GET', path: '/x' });
+
+    expect(response.error?.message).toBe('Bad Gateway');
+  });
+});
+
+describe('hooks', () => {
+  it('reports a non-retried failure as http_error', async () => {
+    fetchMock.mockImplementation(() =>
+      json(404, { Message: 'no such bucket' })
+    );
+    const onError = vi.fn();
+    setTigrisHttpHooks({ onError });
+
+    await makeClient().request({ method: 'GET', path: '/missing' });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toMatchObject({
+      source: 'http_error',
+      method: 'GET',
+      path: '/missing',
+      status: 404,
+      attempt: 1,
+      message: 'no such bucket',
+    });
+  });
+
+  it('reports an exhausted retry budget as retries_exhausted', async () => {
+    fetchMock.mockImplementation(() => json(500, { Message: 'boom' }));
+    const onError = vi.fn();
+    const onRetry = vi.fn();
+    setTigrisHttpHooks({ onError, onRetry });
+
+    const client = makeClient({ retry: { attempts: 3, baseDelayMs: 0 } });
+    await client.request({ method: 'GET', path: '/x' });
+
+    expect(onRetry).toHaveBeenCalledTimes(2);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toMatchObject({
+      source: 'retries_exhausted',
+      attempt: 3,
+      attempts: 3,
+      status: 500,
+    });
+  });
+
+  it('reports a transport failure as network_error', async () => {
+    fetchMock.mockRejectedValue(new TypeError('fetch failed'));
+    const onError = vi.fn();
+    setTigrisHttpHooks({ onError });
+
+    await expect(
+      makeClient().request({ method: 'GET', path: '/x' })
+    ).rejects.toThrow();
+
+    expect(onError.mock.calls[0][0]).toMatchObject({
+      source: 'network_error',
+    });
+    // A request that never reached the server has no status to report.
+    expect(onError.mock.calls[0][0].status).toBeUndefined();
+  });
+
+  it('passes the backoff it is about to wait to onRetry', async () => {
+    fetchMock
+      .mockImplementationOnce(() => json(503, { Message: 'unavailable' }))
+      .mockImplementationOnce(() => json(200, { ok: true }));
+    const onRetry = vi.fn();
+    setTigrisHttpHooks({ onRetry });
+
+    const client = makeClient({ retry: { attempts: 2, baseDelayMs: 0 } });
+    await client.request({ method: 'GET', path: '/x' });
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry.mock.calls[0][0]).toMatchObject({ delayMs: 0, attempt: 1 });
+  });
+
+  it('stays quiet when a retry recovers the request', async () => {
+    fetchMock
+      .mockImplementationOnce(() => json(503, { Message: 'unavailable' }))
+      .mockImplementationOnce(() => json(200, { ok: true }));
+    const onError = vi.fn();
+    setTigrisHttpHooks({ onError });
+
+    const client = makeClient({ retry: { attempts: 2, baseDelayMs: 0 } });
+    await client.request({ method: 'GET', path: '/x' });
+
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('reports an origin that recomposes into the URL fetch received', async () => {
+    fetchMock.mockImplementation(() => json(500, { Message: 'boom' }));
+    const onError = vi.fn();
+    setTigrisHttpHooks({ onError });
+
+    await makeClient().request({
+      method: 'GET',
+      path: '/bucket',
+      query: { prefix: 'a/b' },
+    });
+
+    const { origin, path } = onError.mock.calls[0][0];
+    expect(origin).toMatch(/^https:\/\/t\d+\.example\.com$/);
+    // The contract consumers rely on: `${origin}${path}` is the absolute URL.
+    expect(`${origin}${path}`).toBe(fetchMock.mock.calls[0][0]);
+  });
+
+  it('reports the same origin on the onRetry path', async () => {
+    fetchMock
+      .mockImplementationOnce(() => json(503, { Message: 'unavailable' }))
+      .mockImplementationOnce(() => json(200, { ok: true }));
+    const onRetry = vi.fn();
+    setTigrisHttpHooks({ onRetry });
+
+    const client = makeClient({ retry: { attempts: 2, baseDelayMs: 0 } });
+    await client.request({ method: 'GET', path: '/x' });
+
+    const { origin, path } = onRetry.mock.calls[0][0];
+    expect(origin).toBeTruthy();
+    expect(`${origin}${path}`).toBe(fetchMock.mock.calls[0][0]);
+  });
+
+  it('keeps the port in the origin', async () => {
+    fetchMock.mockImplementation(() => json(500, { Message: 'boom' }));
+    const onError = vi.fn();
+    setTigrisHttpHooks({ onError });
+
+    const client = makeClient({ baseUrl: 'http://localhost:9000' });
+    await client.request({ method: 'GET', path: '/bucket' });
+
+    expect(onError.mock.calls[0][0]).toMatchObject({
+      origin: 'http://localhost:9000',
+      path: '/bucket',
+    });
+    expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:9000/bucket');
+  });
+
+  it('includes the organization id when the client has one', async () => {
+    fetchMock.mockImplementation(() => json(500, { Message: 'boom' }));
+    const onError = vi.fn();
+    setTigrisHttpHooks({ onError });
+
+    const client = makeClient({
+      accessKeyId: undefined,
+      secretAccessKey: undefined,
+      sessionToken: 'token',
+      organizationId: 'org_123',
+    });
+    await client.request({ method: 'GET', path: '/x' });
+
+    expect(onError.mock.calls[0][0]).toMatchObject({
+      organizationId: 'org_123',
+    });
+  });
+
+  it('carries the query string on the reported path', async () => {
+    fetchMock.mockImplementation(() => json(500, { Message: 'boom' }));
+    const onError = vi.fn();
+    setTigrisHttpHooks({ onError });
+
+    await makeClient().request({
+      method: 'GET',
+      path: '/bucket',
+      query: { prefix: 'a/b' },
+    });
+
+    expect(onError.mock.calls[0][0].path).toBe('/bucket?prefix=a%2Fb');
+  });
+
+  it('does not let a throwing hook fail the request', async () => {
+    fetchMock.mockImplementation(() => json(500, { Message: 'boom' }));
+    setTigrisHttpHooks({
+      onError: () => {
+        throw new Error('sentry is down');
+      },
+    });
+
+    const response = await makeClient().request({ method: 'GET', path: '/x' });
+
+    expect(response.error?.message).toBe('boom');
+  });
+});
+
+describe('client caching', () => {
+  const base = 'https://cache-test.example.com';
+
+  it('reuses a client for identical options', () => {
+    const first = createTigrisHttpClient({
+      baseUrl: base,
+      accessKeyId: 'AKIA',
+      secretAccessKey: 'secret',
+      retry: { attempts: 4 },
+    });
+    const second = createTigrisHttpClient({
+      baseUrl: base,
+      accessKeyId: 'AKIA',
+      secretAccessKey: 'secret',
+      retry: { attempts: 4 },
+    });
+
+    expect(first.data).toBe(second.data);
+  });
+
+  it('does not share a client across different retry policies', () => {
+    const relaxed = createTigrisHttpClient({
+      baseUrl: base,
+      accessKeyId: 'AKIA',
+      secretAccessKey: 'secret',
+      retry: { attempts: 2 },
+    });
+    const aggressive = createTigrisHttpClient({
+      baseUrl: base,
+      accessKeyId: 'AKIA',
+      secretAccessKey: 'secret',
+      retry: { attempts: 9 },
+    });
+
+    expect(relaxed.data).not.toBe(aggressive.data);
+  });
+
+  it('skips the cache when shouldRetry makes the config unkeyable', () => {
+    const options = {
+      baseUrl: base,
+      accessKeyId: 'AKIA',
+      secretAccessKey: 'secret',
+      retry: { shouldRetry: () => true },
+    };
+
+    expect(createTigrisHttpClient(options).data).not.toBe(
+      createTigrisHttpClient(options).data
+    );
+  });
+});

--- a/shared/http-client.test.ts
+++ b/shared/http-client.test.ts
@@ -161,8 +161,12 @@ describe('retry', () => {
     });
     await client.request({ method: 'GET', path: '/bucket' });
 
-    expect(seen).toHaveLength(1);
-    expect(`${seen[0].origin}${seen[0].path}`).toBe(fetchMock.mock.calls[0][0]);
+    // Once per failed attempt — including the last, where the result decides
+    // whether this reports as `retries_exhausted`.
+    expect(seen).toHaveLength(2);
+    for (const { origin, path } of seen) {
+      expect(`${origin}${path}`).toBe(fetchMock.mock.calls[0][0]);
+    }
   });
 
   it('re-signs every attempt so x-amz-date stays inside its window', async () => {
@@ -277,6 +281,30 @@ describe('transport failures', () => {
     );
   });
 
+  it('cuts the backoff short when the caller aborts mid-wait', async () => {
+    // A Retry-After can hold the caller for the whole of maxDelayMs; an abort
+    // must not have to wait that out and then burn another signing pass.
+    fetchMock.mockImplementation(() =>
+      json(429, { Message: 'slow down' }, { headers: { 'retry-after': '30' } })
+    );
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 20);
+
+    const client = makeClient({
+      retry: { attempts: 3, baseDelayMs: 5000, maxDelayMs: 30_000 },
+    });
+
+    const started = Date.now();
+    await expect(
+      client.request({ method: 'GET', path: '/x', signal: controller.signal })
+    ).rejects.toThrow();
+    const elapsed = Date.now() - started;
+
+    expect(elapsed).toBeLessThan(1000);
+    // Only the first attempt ran; the retry never fired.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('forwards an AbortSignal to fetch', async () => {
     fetchMock.mockImplementation(() => json(200, { ok: true }));
     const controller = new AbortController();
@@ -371,6 +399,27 @@ describe('body parsing', () => {
 
     expect(response.error).toBeUndefined();
     expect(response.data).toEqual({});
+  });
+
+  it('propagates a mid-stream body failure instead of returning empty data', async () => {
+    // The 2xx body *is* the result, so a read that dies partway through is the
+    // real error. Swallowing it would be indistinguishable from an empty body
+    // and would hand the caller a `{}` that normalizes into bogus defaults.
+    fetchMock.mockImplementation(
+      () =>
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.error(new Error('connection reset mid-body'));
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+    );
+
+    await expect(
+      makeClient().request({ method: 'GET', path: '/x' })
+    ).rejects.toThrow();
   });
 
   it('returns non-JSON bodies as text', async () => {
@@ -480,6 +529,42 @@ describe('hooks', () => {
       attempt: 3,
       attempts: 3,
       status: 500,
+    });
+  });
+
+  it('does not claim retries_exhausted when a later attempt is non-retryable', async () => {
+    // 503 (retried) then 403 (not retryable) with budget to spare: the reason
+    // we stopped is the status, not an exhausted budget. Reporting otherwise
+    // points telemetry at capacity when the real cause is auth.
+    fetchMock
+      .mockImplementationOnce(() => json(503, { Message: 'unavailable' }))
+      .mockImplementationOnce(() => json(403, { Message: 'denied' }));
+    const onError = vi.fn();
+    setTigrisHttpHooks({ onError });
+
+    const client = makeClient({ retry: { attempts: 3, baseDelayMs: 0 } });
+    await client.request({ method: 'GET', path: '/x' });
+
+    expect(onError.mock.calls[0][0]).toMatchObject({
+      source: 'http_error',
+      status: 403,
+      attempt: 2,
+      attempts: 3,
+    });
+  });
+
+  it('reports retries_exhausted only when the budget actually ran out', async () => {
+    fetchMock.mockImplementation(() => json(503, { Message: 'unavailable' }));
+    const onError = vi.fn();
+    setTigrisHttpHooks({ onError });
+
+    const client = makeClient({ retry: { attempts: 2, baseDelayMs: 0 } });
+    await client.request({ method: 'GET', path: '/x' });
+
+    expect(onError.mock.calls[0][0]).toMatchObject({
+      source: 'retries_exhausted',
+      attempt: 2,
+      attempts: 2,
     });
   });
 

--- a/shared/http-client.ts
+++ b/shared/http-client.ts
@@ -9,10 +9,10 @@ import {
 } from './hooks';
 import {
   computeRetryDelay,
+  isRetryableFailure,
   type ResolvedRetry,
   type RetryConfig,
   resolveRetry,
-  shouldRetryFailure,
   sleep,
 } from './retry';
 import type { TigrisResponse } from './types';
@@ -376,15 +376,19 @@ export function createTigrisHttpClient(
             error,
           };
 
-          if (shouldRetryFailure(retry, context)) {
+          // Evaluated once: a caller's `shouldRetry` may have side effects,
+          // and it also decides the reported source below.
+          const retryable = isRetryableFailure(retry, context);
+
+          if (retryable && attempt < retry.attempts) {
             const delayMs = computeRetryDelay(retry, attempt);
             emitRetry(attempt, delayMs, error.message, error);
-            await sleep(delayMs);
+            await sleep(delayMs, req.signal);
             continue;
           }
 
           emitError(
-            attempt > 1 ? 'retries_exhausted' : 'network_error',
+            retryable ? 'retries_exhausted' : 'network_error',
             attempt,
             error.message,
             error
@@ -411,19 +415,21 @@ export function createTigrisHttpClient(
             status: response.status,
           };
 
-          if (shouldRetryFailure(retry, context)) {
+          const retryable = isRetryableFailure(retry, context);
+
+          if (retryable && attempt < retry.attempts) {
             const delayMs = computeRetryDelay(
               retry,
               attempt,
               response.headers.get('retry-after')
             );
             emitRetry(attempt, delayMs, message, error, response.status);
-            await sleep(delayMs);
+            await sleep(delayMs, req.signal);
             continue;
           }
 
           emitError(
-            attempt > 1 ? 'retries_exhausted' : 'http_error',
+            retryable ? 'retries_exhausted' : 'http_error',
             attempt,
             message,
             error,
@@ -471,7 +477,13 @@ export function createTigrisHttpClient(
           // Read as text first: endpoints like `POST ?restore` answer 200 with
           // an empty body while still advertising JSON, and `response.json()`
           // throws on ''. Parse only when there is something to parse.
-          const text = await safeText(response);
+          //
+          // Deliberately not `safeText` here. On a 2xx the body *is* the
+          // result, so a mid-stream read failure is the real error and must
+          // propagate — swallowing it to '' would be indistinguishable from a
+          // legitimately empty body and would hand the caller a bogus `{}`
+          // that later normalizes into plausible-looking defaults.
+          const text = await response.text();
           data = (text ? JSON.parse(text) : {}) as TResponse;
         } else {
           data = (await response.text()) as TResponse;

--- a/shared/http-client.ts
+++ b/shared/http-client.ts
@@ -1,7 +1,22 @@
 import { Sha256 } from '@aws-crypto/sha256-js';
 import { SignatureV4 } from '@smithy/signature-v4';
 import { TigrisHeaders } from './headers';
+import {
+  emitHook,
+  getTigrisHttpHooks,
+  type HttpErrorContext,
+  type HttpErrorSource,
+} from './hooks';
+import {
+  computeRetryDelay,
+  type ResolvedRetry,
+  type RetryConfig,
+  resolveRetry,
+  shouldRetryFailure,
+  sleep,
+} from './retry';
 import type { TigrisResponse } from './types';
+import { toError } from './utils';
 
 export interface HttpClientRequest<T = unknown> {
   method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD';
@@ -11,6 +26,13 @@ export interface HttpClientRequest<T = unknown> {
   query?: Record<string, string | number | boolean>;
   /** Return the raw response body as a ReadableStream instead of parsing it. */
   stream?: boolean;
+  /**
+   * Retry policy for this request, overriding the client's. Pass `false` to
+   * opt a single call out of a client that has retry enabled.
+   */
+  retry?: RetryConfig;
+  /** Forwarded to `fetch`; aborts the in-flight attempt. */
+  signal?: AbortSignal;
 }
 
 export type HttpClientResponse<T = unknown> =
@@ -41,6 +63,11 @@ export interface CreateHttpClientOptions {
   organizationId?: string;
   accessKeyId?: string;
   secretAccessKey?: string;
+  /**
+   * Default retry policy for every request from this client. Omitted or
+   * `false` means a single attempt — retry never engages unless asked for.
+   */
+  retry?: RetryConfig;
 }
 
 const cachedHttpClients = new Map<string, TigrisHttpClient>();
@@ -94,6 +121,74 @@ async function generateSignatureHeaders(
   return signedRequest.headers as Record<string, string>;
 }
 
+/**
+ * Stable cache-key fragment for a retry config, or `undefined` when the
+ * config cannot be keyed.
+ *
+ * A `shouldRetry` callback is an opaque function, so two clients with
+ * different predicates would collide on the same key and the first one built
+ * would be served to both. `tigris-client.ts` skips its cache for
+ * `credentialProvider` for the same reason.
+ */
+function retryCacheKey(config: RetryConfig | undefined): string | undefined {
+  if (config === undefined || config === false) {
+    return 'noretry';
+  }
+
+  if (config !== true && config.shouldRetry) {
+    return undefined;
+  }
+
+  const options = config === true ? {} : config;
+  // The method here only normalizes the numeric fields; the resolved
+  // `retryNetworkErrors` is deliberately not used below.
+  const retry = resolveRetry(config, 'GET');
+  return [
+    'retry',
+    retry.attempts,
+    retry.baseDelayMs,
+    retry.maxDelayMs,
+    // Tri-state, not the resolved boolean: an unset `retryNetworkErrors` is
+    // derived from each request's method, so it varies within one client and
+    // cannot be baked into a client-level key.
+    options.retryNetworkErrors === undefined
+      ? 'auto'
+      : options.retryNetworkErrors
+        ? 1
+        : 0,
+    retry.retryableStatuses.join('.'),
+  ].join(':');
+}
+
+/** Read a body without letting a mid-stream failure mask the real error. */
+async function safeText(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Mirror the pre-retry error-message extraction: a JSON body's `Message`
+ * field, else the status text.
+ */
+function extractErrorMessage(text: string, statusText: string): string {
+  if (text) {
+    try {
+      const parsed = JSON.parse(text) as { Message?: string };
+      // `||`, not `??`: an empty `Message` or an empty `statusText` should
+      // fall through rather than produce `new Error('')`. `fetch` leaves
+      // `statusText` empty for HTTP/2 responses, which have no reason phrase.
+      return parsed?.Message || statusText || 'Unknown error';
+    } catch {
+      // Not JSON — fall through to the status text, as before.
+    }
+  }
+
+  return statusText || 'Unknown error';
+}
+
 export function createTigrisHttpClient(
   options: CreateHttpClientOptions
 ): TigrisResponse<TigrisHttpClient, Error> {
@@ -103,9 +198,12 @@ export function createTigrisHttpClient(
     organizationId,
     accessKeyId,
     secretAccessKey,
+    retry: clientRetry,
   } = options;
 
-  let key = `${baseUrl}`;
+  const retryKey = retryCacheKey(clientRetry);
+
+  let key: string | undefined = `${baseUrl}`;
 
   if (organizationId) {
     key = `${key}-${organizationId}`;
@@ -119,9 +217,17 @@ export function createTigrisHttpClient(
     key = `${key}-${accessKeyId}`;
   }
 
-  const cachedClient = cachedHttpClients.get(key);
-  if (cachedClient !== undefined) {
-    return { data: cachedClient };
+  if (retryKey === undefined) {
+    key = undefined;
+  } else {
+    key = `${key}-${retryKey}`;
+  }
+
+  if (key !== undefined) {
+    const cachedClient = cachedHttpClients.get(key);
+    if (cachedClient !== undefined) {
+      return { data: cachedClient };
+    }
   }
 
   const client: TigrisHttpClient = {
@@ -136,12 +242,9 @@ export function createTigrisHttpClient(
         });
       }
 
-      let headers: Record<string, string> = {
-        'Content-Type': 'application/json',
-        ...req.headers,
-      };
-
-      // Prepare body for signing
+      // Prepare body for signing. Deterministic, so it is built once and
+      // reused across attempts — a retry must re-send the same bytes (and, for
+      // `createAccessKey`, the same `req_uuid`) for server-side dedup to work.
       let bodyString: string | undefined;
       if (req.body && req.method !== 'GET' && req.method !== 'HEAD') {
         if (req.body instanceof URLSearchParams) {
@@ -151,91 +254,242 @@ export function createTigrisHttpClient(
         }
       }
 
-      // Use credentials-based auth with signature if available
-      if (accessKeyId && secretAccessKey && !sessionToken) {
-        const signedHeaders = await generateSignatureHeaders(
-          req.method,
-          url,
-          headers,
-          bodyString,
-          accessKeyId,
-          secretAccessKey
-        );
-        headers = signedHeaders;
-      } else {
-        // Use session token or pre-generated authorization
-        if (sessionToken) {
-          headers[TigrisHeaders.SESSION_TOKEN] = sessionToken;
-        }
+      const retry: ResolvedRetry = resolveRetry(
+        req.retry ?? clientRetry,
+        req.method
+      );
+      const target = `${url.pathname}${url.search}`;
+      const requestOrigin = url.origin;
 
-        if (organizationId) {
-          headers[TigrisHeaders.NAMESPACE] = organizationId;
-        }
-      }
-
-      const fetchOptions: RequestInit = {
-        method: req.method,
-        headers,
+      const emitError = (
+        source: HttpErrorSource,
+        attempt: number,
+        message: string,
+        error: Error,
+        status?: number
+      ): void => {
+        const context: HttpErrorContext = {
+          source,
+          method: req.method,
+          origin: requestOrigin,
+          path: target,
+          attempt,
+          attempts: retry.attempts,
+          message,
+          error,
+          ...(organizationId !== undefined && { organizationId }),
+          ...(status !== undefined && { status }),
+        };
+        emitHook(getTigrisHttpHooks()?.onError, context);
       };
 
-      if (bodyString) {
-        fetchOptions.body = bodyString;
-      }
+      const emitRetry = (
+        attempt: number,
+        delayMs: number,
+        message: string,
+        error: Error,
+        status?: number
+      ): void => {
+        emitHook(getTigrisHttpHooks()?.onRetry, {
+          source:
+            status === undefined
+              ? ('network_error' as const)
+              : ('http_error' as const),
+          method: req.method,
+          origin: requestOrigin,
+          path: target,
+          attempt,
+          attempts: retry.attempts,
+          message,
+          error,
+          delayMs,
+          ...(organizationId !== undefined && { organizationId }),
+          ...(status !== undefined && { status }),
+        });
+      };
 
-      const response = await fetch(url.toString(), fetchOptions);
+      for (let attempt = 1; ; attempt++) {
+        let headers: Record<string, string> = {
+          'Content-Type': 'application/json',
+          ...req.headers,
+        };
 
-      if (!response.ok) {
+        // Signed per attempt, not once up front: `x-amz-date` stays inside its
+        // validity window on a retried request, and a future credential
+        // provider would get a chance to refresh between attempts.
+        if (accessKeyId && secretAccessKey && !sessionToken) {
+          headers = await generateSignatureHeaders(
+            req.method,
+            url,
+            headers,
+            bodyString,
+            accessKeyId,
+            secretAccessKey
+          );
+        } else {
+          // Use session token or pre-generated authorization
+          if (sessionToken) {
+            headers[TigrisHeaders.SESSION_TOKEN] = sessionToken;
+          }
+
+          if (organizationId) {
+            headers[TigrisHeaders.NAMESPACE] = organizationId;
+          }
+        }
+
+        const fetchOptions: RequestInit = {
+          method: req.method,
+          headers,
+        };
+
+        if (bodyString) {
+          fetchOptions.body = bodyString;
+        }
+
+        if (req.signal) {
+          fetchOptions.signal = req.signal;
+        }
+
+        let response: Response;
         try {
-          const error = await response.json();
-          return {
-            status: response.status,
-            statusText: response.statusText,
-            headers: response.headers,
-            error: new Error(
-              error.Message ?? response.statusText ?? 'Unknown error'
-            ),
+          response = await fetch(url.toString(), fetchOptions);
+        } catch (caught) {
+          const error = toError(caught);
+
+          // An aborted request is the caller's own doing — never retry it.
+          // `fetch` rejects with a `DOMException`, which is not guaranteed to
+          // be an `Error` subclass in every runtime, so check the signal and
+          // the raw value rather than trusting the converted error's name.
+          if (
+            req.signal?.aborted === true ||
+            (caught as { name?: string })?.name === 'AbortError'
+          ) {
+            throw caught;
+          }
+
+          const context = {
+            method: req.method,
+            origin: requestOrigin,
+            path: target,
+            attempt,
+            attempts: retry.attempts,
+            error,
           };
-        } catch {
+
+          if (shouldRetryFailure(retry, context)) {
+            const delayMs = computeRetryDelay(retry, attempt);
+            emitRetry(attempt, delayMs, error.message, error);
+            await sleep(delayMs);
+            continue;
+          }
+
+          emitError(
+            attempt > 1 ? 'retries_exhausted' : 'network_error',
+            attempt,
+            error.message,
+            error
+          );
+
+          // Transport failures have always propagated to the caller rather
+          // than surfacing as `{ error }`; retry does not change that
+          // contract. Rethrow the original value, not the converted one, so a
+          // caller matching on a specific error type still sees it.
+          throw caught;
+        }
+
+        if (!response.ok) {
+          const text = await safeText(response);
+          const message = extractErrorMessage(text, response.statusText);
+          const error = new Error(message);
+
+          const context = {
+            method: req.method,
+            origin: requestOrigin,
+            path: target,
+            attempt,
+            attempts: retry.attempts,
+            status: response.status,
+          };
+
+          if (shouldRetryFailure(retry, context)) {
+            const delayMs = computeRetryDelay(
+              retry,
+              attempt,
+              response.headers.get('retry-after')
+            );
+            emitRetry(attempt, delayMs, message, error, response.status);
+            await sleep(delayMs);
+            continue;
+          }
+
+          emitError(
+            attempt > 1 ? 'retries_exhausted' : 'http_error',
+            attempt,
+            message,
+            error,
+            response.status
+          );
+
           return {
             status: response.status,
             statusText: response.statusText,
             headers: response.headers,
-            error: new Error(response.statusText),
+            error,
           };
         }
-      }
 
-      let data: TResponse;
+        if (req.stream) {
+          if (!response.body) {
+            const error = new Error('No body returned from stream request');
+            emitError(
+              'http_error',
+              attempt,
+              error.message,
+              error,
+              response.status
+            );
+            return {
+              status: response.status,
+              statusText: response.statusText,
+              headers: response.headers,
+              error,
+            };
+          }
 
-      if (req.stream) {
-        if (!response.body) {
           return {
             status: response.status,
             statusText: response.statusText,
             headers: response.headers,
-            error: new Error('No body returned from stream request'),
+            data: response.body as TResponse,
           };
         }
-        data = response.body as TResponse;
-      } else {
+
+        let data: TResponse;
         const contentType = response.headers.get('content-type');
+
         if (contentType?.includes('application/json')) {
-          data = (await response.json()) as TResponse;
+          // Read as text first: endpoints like `POST ?restore` answer 200 with
+          // an empty body while still advertising JSON, and `response.json()`
+          // throws on ''. Parse only when there is something to parse.
+          const text = await safeText(response);
+          data = (text ? JSON.parse(text) : {}) as TResponse;
         } else {
           data = (await response.text()) as TResponse;
         }
-      }
 
-      return {
-        status: response.status,
-        statusText: response.statusText,
-        headers: response.headers,
-        data,
-      };
+        return {
+          status: response.status,
+          statusText: response.statusText,
+          headers: response.headers,
+          data,
+        };
+      }
     },
   };
 
-  cachedHttpClients.set(key, client);
+  if (key !== undefined) {
+    cachedHttpClients.set(key, client);
+  }
 
   return { data: client };
 }

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -1,11 +1,24 @@
 export { getEnvVar, isNode, missingConfigError } from './config';
 export { TigrisHeaders } from './headers';
 export {
+  type HttpErrorContext,
+  type HttpErrorSource,
+  type RetryHookContext,
+  setTigrisHttpHooks,
+  type TigrisHttpHooks,
+} from './hooks';
+export {
   type CreateHttpClientOptions,
   createTigrisHttpClient,
   type HttpClientRequest,
   type HttpClientResponse,
   type TigrisHttpClient,
 } from './http-client';
+export {
+  DEFAULT_RETRYABLE_STATUSES,
+  type RetryConfig,
+  type RetryContext,
+  type RetryOptions,
+} from './retry';
 export type { TigrisResponse } from './types';
 export { executeWithConcurrency, handleError, toError } from './utils';

--- a/shared/package.json
+++ b/shared/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "description": "Internal shared source for @tigrisdata/* packages. Consumed via the @shared/* TS path alias and tsup esbuild alias; never built or published.",
   "type": "module",
+  "scripts": {
+    "test": "vitest run --config vitest.config.ts"
+  },
   "dependencies": {
     "@aws-crypto/sha256-js": "^5.2.0",
     "@smithy/signature-v4": "^5.3.14",

--- a/shared/retry.test.ts
+++ b/shared/retry.test.ts
@@ -2,13 +2,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   computeRetryDelay,
   DEFAULT_RETRYABLE_STATUSES,
+  isRetryableFailure,
   parseRetryAfter,
   resolveRetry,
-  shouldRetryFailure,
 } from './retry';
 
 const context = (
-  overrides: Partial<Parameters<typeof shouldRetryFailure>[1]>
+  overrides: Partial<Parameters<typeof isRetryableFailure>[1]>
 ) => ({
   method: 'POST',
   origin: 'https://t3.storage.dev',
@@ -91,20 +91,20 @@ describe('resolveRetry', () => {
   });
 });
 
-describe('shouldRetryFailure', () => {
+describe('isRetryableFailure', () => {
   it('retries the default transient statuses', () => {
     const retry = resolveRetry(true, 'GET');
 
     for (const status of DEFAULT_RETRYABLE_STATUSES) {
-      expect(shouldRetryFailure(retry, context({ status }))).toBe(true);
+      expect(isRetryableFailure(retry, context({ status }))).toBe(true);
     }
   });
 
   it('never retries 400 or 403', () => {
     const retry = resolveRetry(true, 'GET');
 
-    expect(shouldRetryFailure(retry, context({ status: 400 }))).toBe(false);
-    expect(shouldRetryFailure(retry, context({ status: 403 }))).toBe(false);
+    expect(isRetryableFailure(retry, context({ status: 400 }))).toBe(false);
+    expect(isRetryableFailure(retry, context({ status: 403 }))).toBe(false);
   });
 
   it('retries statuses identically for every method', () => {
@@ -114,37 +114,39 @@ describe('shouldRetryFailure', () => {
     for (const method of ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE']) {
       const retry = resolveRetry(true, method);
 
-      expect(shouldRetryFailure(retry, context({ method, status: 503 }))).toBe(
+      expect(isRetryableFailure(retry, context({ method, status: 503 }))).toBe(
         true
       );
-      expect(shouldRetryFailure(retry, context({ method, status: 429 }))).toBe(
+      expect(isRetryableFailure(retry, context({ method, status: 429 }))).toBe(
         true
       );
-      expect(shouldRetryFailure(retry, context({ method, status: 403 }))).toBe(
+      expect(isRetryableFailure(retry, context({ method, status: 403 }))).toBe(
         false
       );
     }
   });
 
-  it('stops at the attempt ceiling', () => {
+  it('ignores the attempt ceiling — that is the caller"s check', () => {
+    // Separating the two lets the caller tell "ran out of attempts" from
+    // "was never retryable", which is what the reported source depends on.
     const retry = resolveRetry({ attempts: 2 }, 'GET');
 
     expect(
-      shouldRetryFailure(retry, context({ status: 500, attempt: 1 }))
+      isRetryableFailure(retry, context({ status: 500, attempt: 1 }))
     ).toBe(true);
     expect(
-      shouldRetryFailure(retry, context({ status: 500, attempt: 2 }))
-    ).toBe(false);
+      isRetryableFailure(retry, context({ status: 500, attempt: 9 }))
+    ).toBe(true);
   });
 
   it('retries transport errors only when enabled', () => {
     const error = new Error('connection reset');
 
     expect(
-      shouldRetryFailure(resolveRetry(true, 'GET'), context({ error }))
+      isRetryableFailure(resolveRetry(true, 'GET'), context({ error }))
     ).toBe(true);
     expect(
-      shouldRetryFailure(
+      isRetryableFailure(
         resolveRetry({ retryNetworkErrors: false }, 'GET'),
         context({ error })
       )
@@ -157,14 +159,14 @@ describe('shouldRetryFailure', () => {
       'GET'
     );
 
-    expect(shouldRetryFailure(retry, context({ status: 403 }))).toBe(true);
-    expect(shouldRetryFailure(retry, context({ status: 500 }))).toBe(false);
+    expect(isRetryableFailure(retry, context({ status: 403 }))).toBe(true);
+    expect(isRetryableFailure(retry, context({ status: 500 }))).toBe(false);
   });
 
-  it('applies the attempt ceiling even with a custom shouldRetry', () => {
+  it('defers to a custom shouldRetry regardless of attempt', () => {
     const retry = resolveRetry({ attempts: 2, shouldRetry: () => true }, 'GET');
 
-    expect(shouldRetryFailure(retry, context({ attempt: 2 }))).toBe(false);
+    expect(isRetryableFailure(retry, context({ attempt: 2 }))).toBe(true);
   });
 });
 

--- a/shared/retry.test.ts
+++ b/shared/retry.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  computeRetryDelay,
+  DEFAULT_RETRYABLE_STATUSES,
+  parseRetryAfter,
+  resolveRetry,
+  shouldRetryFailure,
+} from './retry';
+
+const context = (
+  overrides: Partial<Parameters<typeof shouldRetryFailure>[1]>
+) => ({
+  method: 'POST',
+  origin: 'https://t3.storage.dev',
+  path: '/bucket',
+  attempt: 1,
+  attempts: 3,
+  ...overrides,
+});
+
+describe('resolveRetry', () => {
+  it('resolves an omitted config to a single attempt', () => {
+    const retry = resolveRetry(undefined, 'GET');
+
+    expect(retry.attempts).toBe(1);
+    expect(retry.retryNetworkErrors).toBe(false);
+    expect(retry.retryableStatuses).toEqual([]);
+  });
+
+  it('resolves false to a single attempt', () => {
+    expect(resolveRetry(false, 'GET').attempts).toBe(1);
+  });
+
+  it('resolves true to the defaults', () => {
+    const retry = resolveRetry(true, 'GET');
+
+    expect(retry.attempts).toBe(3);
+    expect(retry.baseDelayMs).toBe(100);
+    expect(retry.maxDelayMs).toBe(2000);
+    expect(retry.retryableStatuses).toEqual(DEFAULT_RETRYABLE_STATUSES);
+  });
+
+  it('derives retryNetworkErrors from the method when unset', () => {
+    // Safe to re-send: the request carries no side effect.
+    expect(resolveRetry(true, 'GET').retryNetworkErrors).toBe(true);
+    expect(resolveRetry(true, 'HEAD').retryNetworkErrors).toBe(true);
+
+    // A transport failure leaves these with an unknown outcome, so the write
+    // may already have landed.
+    for (const method of ['POST', 'PUT', 'PATCH', 'DELETE']) {
+      expect(resolveRetry(true, method).retryNetworkErrors).toBe(false);
+    }
+  });
+
+  it('lets an explicit retryNetworkErrors override the method default', () => {
+    // The escape hatch for a write the caller knows is safe to repeat —
+    // `createAccessKey` dedupes on the `req_uuid` it sends.
+    expect(
+      resolveRetry({ retryNetworkErrors: true }, 'POST').retryNetworkErrors
+    ).toBe(true);
+
+    expect(
+      resolveRetry({ retryNetworkErrors: false }, 'GET').retryNetworkErrors
+    ).toBe(false);
+  });
+
+  it('keeps caller overrides', () => {
+    const retry = resolveRetry(
+      {
+        attempts: 5,
+        baseDelayMs: 10,
+        maxDelayMs: 50,
+        retryableStatuses: [503],
+        retryNetworkErrors: false,
+      },
+      'GET'
+    );
+
+    expect(retry).toMatchObject({
+      attempts: 5,
+      baseDelayMs: 10,
+      maxDelayMs: 50,
+      retryableStatuses: [503],
+      retryNetworkErrors: false,
+    });
+  });
+
+  it('floors attempts at one so a bad value cannot skip the request', () => {
+    expect(resolveRetry({ attempts: 0 }, 'GET').attempts).toBe(1);
+    expect(resolveRetry({ attempts: -3 }, 'GET').attempts).toBe(1);
+  });
+});
+
+describe('shouldRetryFailure', () => {
+  it('retries the default transient statuses', () => {
+    const retry = resolveRetry(true, 'GET');
+
+    for (const status of DEFAULT_RETRYABLE_STATUSES) {
+      expect(shouldRetryFailure(retry, context({ status }))).toBe(true);
+    }
+  });
+
+  it('never retries 400 or 403', () => {
+    const retry = resolveRetry(true, 'GET');
+
+    expect(shouldRetryFailure(retry, context({ status: 400 }))).toBe(false);
+    expect(shouldRetryFailure(retry, context({ status: 403 }))).toBe(false);
+  });
+
+  it('retries statuses identically for every method', () => {
+    // A 503 means the server is telling you it did not process the request,
+    // so re-sending is safe whatever the operation. Only transport failures,
+    // where the outcome is unknown, are method-sensitive.
+    for (const method of ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE']) {
+      const retry = resolveRetry(true, method);
+
+      expect(shouldRetryFailure(retry, context({ method, status: 503 }))).toBe(
+        true
+      );
+      expect(shouldRetryFailure(retry, context({ method, status: 429 }))).toBe(
+        true
+      );
+      expect(shouldRetryFailure(retry, context({ method, status: 403 }))).toBe(
+        false
+      );
+    }
+  });
+
+  it('stops at the attempt ceiling', () => {
+    const retry = resolveRetry({ attempts: 2 }, 'GET');
+
+    expect(
+      shouldRetryFailure(retry, context({ status: 500, attempt: 1 }))
+    ).toBe(true);
+    expect(
+      shouldRetryFailure(retry, context({ status: 500, attempt: 2 }))
+    ).toBe(false);
+  });
+
+  it('retries transport errors only when enabled', () => {
+    const error = new Error('connection reset');
+
+    expect(
+      shouldRetryFailure(resolveRetry(true, 'GET'), context({ error }))
+    ).toBe(true);
+    expect(
+      shouldRetryFailure(
+        resolveRetry({ retryNetworkErrors: false }, 'GET'),
+        context({ error })
+      )
+    ).toBe(false);
+  });
+
+  it('lets shouldRetry replace the status and network defaults', () => {
+    const retry = resolveRetry(
+      { shouldRetry: (ctx) => ctx.status === 403 },
+      'GET'
+    );
+
+    expect(shouldRetryFailure(retry, context({ status: 403 }))).toBe(true);
+    expect(shouldRetryFailure(retry, context({ status: 500 }))).toBe(false);
+  });
+
+  it('applies the attempt ceiling even with a custom shouldRetry', () => {
+    const retry = resolveRetry({ attempts: 2, shouldRetry: () => true }, 'GET');
+
+    expect(shouldRetryFailure(retry, context({ attempt: 2 }))).toBe(false);
+  });
+});
+
+describe('parseRetryAfter', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reads delay-seconds', () => {
+    expect(parseRetryAfter('2')).toBe(2000);
+    expect(parseRetryAfter(' 0 ')).toBe(0);
+  });
+
+  it('reads an HTTP-date relative to now', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
+    expect(parseRetryAfter('Thu, 01 Jan 2026 00:00:05 GMT')).toBe(5000);
+  });
+
+  it('clamps a past date to zero rather than going negative', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:10Z'));
+
+    expect(parseRetryAfter('Thu, 01 Jan 2026 00:00:00 GMT')).toBe(0);
+  });
+
+  it('returns undefined for missing or unparseable values', () => {
+    expect(parseRetryAfter(null)).toBeUndefined();
+    expect(parseRetryAfter(undefined)).toBeUndefined();
+    expect(parseRetryAfter('')).toBeUndefined();
+    expect(parseRetryAfter('soon')).toBeUndefined();
+  });
+});
+
+describe('computeRetryDelay', () => {
+  it('grows exponentially and applies full jitter', () => {
+    const retry = resolveRetry({ baseDelayMs: 100, maxDelayMs: 10_000 }, 'GET');
+
+    expect(computeRetryDelay(retry, 1, null, () => 1)).toBe(100);
+    expect(computeRetryDelay(retry, 2, null, () => 1)).toBe(200);
+    expect(computeRetryDelay(retry, 3, null, () => 1)).toBe(400);
+    // Full jitter samples the whole [0, exponential] window.
+    expect(computeRetryDelay(retry, 3, null, () => 0)).toBe(0);
+    expect(computeRetryDelay(retry, 3, null, () => 0.5)).toBe(200);
+  });
+
+  it('caps the exponential at maxDelayMs', () => {
+    const retry = resolveRetry({ baseDelayMs: 100, maxDelayMs: 250 }, 'GET');
+
+    expect(computeRetryDelay(retry, 10, null, () => 1)).toBe(250);
+  });
+
+  it('prefers Retry-After over the computed backoff', () => {
+    const retry = resolveRetry({ baseDelayMs: 100, maxDelayMs: 10_000 }, 'GET');
+
+    expect(computeRetryDelay(retry, 1, '3', () => 1)).toBe(3000);
+  });
+
+  it('clamps Retry-After to maxDelayMs so a large value cannot stall the caller', () => {
+    const retry = resolveRetry({ baseDelayMs: 100, maxDelayMs: 2000 }, 'GET');
+
+    expect(computeRetryDelay(retry, 1, '600', () => 1)).toBe(2000);
+  });
+});

--- a/shared/retry.ts
+++ b/shared/retry.ts
@@ -55,6 +55,10 @@ export interface RetryOptions {
    * Full override for the retry decision. When supplied, it replaces both
    * `retryableStatuses` and `retryNetworkErrors` — the attempt ceiling still
    * applies.
+   *
+   * Called once per failed attempt, including the final one, where its result
+   * decides whether the failure is reported as `retries_exhausted` rather than
+   * a plain error. Keep it pure: it is a classification, not a hook.
    */
   shouldRetry?: (context: RetryContext) => boolean;
 }
@@ -144,15 +148,20 @@ export function resolveRetry(
   };
 }
 
-/** Whether the failure described by `context` earns another attempt. */
-export function shouldRetryFailure(
+/**
+ * Whether the failure described by `context` is retryable *by policy*,
+ * ignoring how many attempts are left.
+ *
+ * Kept separate from the attempt ceiling so a caller can tell the two reasons
+ * for giving up apart: a retryable failure that ran out of attempts is
+ * `retries_exhausted`, while a failure that was never retryable is not — even
+ * when it happens on a later attempt. Conflating them reports an exhausted
+ * budget for, say, a `503` followed by a `403`.
+ */
+export function isRetryableFailure(
   retry: ResolvedRetry,
   context: RetryContext
 ): boolean {
-  if (context.attempt >= retry.attempts) {
-    return false;
-  }
-
   if (retry.shouldRetry) {
     return retry.shouldRetry(context);
   }
@@ -217,9 +226,42 @@ export function computeRetryDelay(
   return Math.round(random() * exponential);
 }
 
-export function sleep(ms: number): Promise<void> {
+/** The value a runtime would reject an aborted operation with. */
+function abortReason(signal: AbortSignal): unknown {
+  return (
+    signal.reason ?? new DOMException('The operation was aborted', 'AbortError')
+  );
+}
+
+/**
+ * Wait `ms`, rejecting early if `signal` aborts.
+ *
+ * Backoff has to observe cancellation: a `Retry-After` can hold the caller for
+ * the whole of `maxDelayMs`, and without this an abort would wait that out and
+ * then burn a signing pass and a `fetch` that is going to reject anyway.
+ */
+export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) {
+    return Promise.reject(abortReason(signal));
+  }
+
   if (ms <= 0) {
     return Promise.resolve();
   }
-  return new Promise((resolve) => setTimeout(resolve, ms));
+
+  return new Promise((resolve, reject) => {
+    let timer: ReturnType<typeof setTimeout>;
+
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(abortReason(signal as AbortSignal));
+    };
+
+    timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
 }

--- a/shared/retry.ts
+++ b/shared/retry.ts
@@ -1,0 +1,225 @@
+/**
+ * Statuses worth another attempt: request timeout, throttling, and transient
+ * server-side failures.
+ *
+ * Deliberately excludes 400 and 403. Both are deterministic for this client —
+ * a retry re-sends a byte-identical request and can only fail again. 403 in
+ * particular is how `SignatureDoesNotMatch` surfaces (see the SigV4 notes in
+ * AGENTS.md), which is the one error we most want to report immediately
+ * instead of burying under three attempts' worth of latency.
+ */
+export const DEFAULT_RETRYABLE_STATUSES = [408, 429, 500, 502, 503, 504];
+
+export interface RetryContext {
+  method: string;
+  /**
+   * Scheme, host, and port the request went to. Split from `path` so a
+   * consumer can reconstruct the absolute URL as `${origin}${path}` while
+   * keeping the default identifier host-independent.
+   */
+  origin: string;
+  /** Request path including query string. */
+  path: string;
+  /** 1-based index of the attempt that just failed. */
+  attempt: number;
+  /** Total attempts allowed. */
+  attempts: number;
+  /** Response status, when the server answered at all. */
+  status?: number;
+  /** Transport error, when the request never produced a response. */
+  error?: Error;
+}
+
+export interface RetryOptions {
+  /** Total attempts, including the first. Default 3. */
+  attempts?: number;
+  /** First-retry backoff in ms; doubles per attempt. Default 100. */
+  baseDelayMs?: number;
+  /** Ceiling for any single backoff, and for a `Retry-After`. Default 2000. */
+  maxDelayMs?: number;
+  /** Statuses to retry. Default {@link DEFAULT_RETRYABLE_STATUSES}. */
+  retryableStatuses?: number[];
+  /**
+   * Retry transport failures (DNS, connection reset, TLS) where the request
+   * never produced a response.
+   *
+   * Defaults to whether the request method is safe to re-send — `GET` and
+   * `HEAD` retry, everything else does not. A transport failure leaves the
+   * outcome unknown, so a write may already have landed on the server even
+   * though the client saw a failure. Set explicitly to override in either
+   * direction; `true` is the escape hatch for an operation the caller knows is
+   * safe to repeat.
+   */
+  retryNetworkErrors?: boolean;
+  /**
+   * Full override for the retry decision. When supplied, it replaces both
+   * `retryableStatuses` and `retryNetworkErrors` — the attempt ceiling still
+   * applies.
+   */
+  shouldRetry?: (context: RetryContext) => boolean;
+}
+
+/** `true` selects the defaults; `false`/omitted disables retry entirely. */
+export type RetryConfig = boolean | RetryOptions;
+
+export interface ResolvedRetry {
+  attempts: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+  retryableStatuses: number[];
+  retryNetworkErrors: boolean;
+  shouldRetry?: (context: RetryContext) => boolean;
+}
+
+const RETRY_DEFAULTS = {
+  attempts: 3,
+  baseDelayMs: 100,
+  maxDelayMs: 2000,
+} as const;
+
+/**
+ * Whether a transport failure on `method` is safe to re-send by default.
+ *
+ * Keyed on the HTTP method because that is the only thing this layer knows
+ * about the operation. It is a deliberately blunt first cut, and it is
+ * conservative in the wrong direction for several real operations — in
+ * `packages/iam` these are safe to retry but will not be, because they are not
+ * `GET`:
+ *
+ * - `access-key/get.ts`, `access-key/list.ts`, `policy/get.ts`,
+ *   `policy/list.ts` — reads issued as `POST ?Action=...`
+ * - `access-key/create.ts` — dedupes on the `req_uuid` it sends, making it the
+ *   one idempotent write in the package
+ *
+ * Callers can opt those back in with an explicit `retryNetworkErrors: true`.
+ * The intended next iteration is a per-operation `idempotent` flag on
+ * `HttpClientRequest`, required so a new operation cannot be added without
+ * classifying itself, which would let this rule retire.
+ */
+function methodIsSafeToReplay(method: string): boolean {
+  return method === 'GET' || method === 'HEAD';
+}
+
+/** A resolved config that performs exactly one attempt. */
+const NO_RETRY: ResolvedRetry = {
+  attempts: 1,
+  baseDelayMs: 0,
+  maxDelayMs: 0,
+  retryableStatuses: [],
+  retryNetworkErrors: false,
+};
+
+/**
+ * Resolve a `retry` config into concrete numbers for a request.
+ *
+ * Retry is opt-in: an omitted or `false` config yields a single attempt, which
+ * is what this client has always done. Nothing retries unless a consumer asks
+ * for it.
+ *
+ * `method` only affects `retryNetworkErrors`. Status-code retries are
+ * method-independent: a `503` means the server is telling you it did not
+ * process the request, so re-sending is safe whatever the operation.
+ */
+export function resolveRetry(
+  config: RetryConfig | undefined,
+  method: string
+): ResolvedRetry {
+  if (config === undefined || config === false) {
+    return NO_RETRY;
+  }
+
+  const options = config === true ? {} : config;
+
+  return {
+    attempts: Math.max(
+      1,
+      Math.floor(options.attempts ?? RETRY_DEFAULTS.attempts)
+    ),
+    baseDelayMs: Math.max(0, options.baseDelayMs ?? RETRY_DEFAULTS.baseDelayMs),
+    maxDelayMs: Math.max(0, options.maxDelayMs ?? RETRY_DEFAULTS.maxDelayMs),
+    retryableStatuses: options.retryableStatuses ?? DEFAULT_RETRYABLE_STATUSES,
+    retryNetworkErrors:
+      options.retryNetworkErrors ?? methodIsSafeToReplay(method),
+    shouldRetry: options.shouldRetry,
+  };
+}
+
+/** Whether the failure described by `context` earns another attempt. */
+export function shouldRetryFailure(
+  retry: ResolvedRetry,
+  context: RetryContext
+): boolean {
+  if (context.attempt >= retry.attempts) {
+    return false;
+  }
+
+  if (retry.shouldRetry) {
+    return retry.shouldRetry(context);
+  }
+
+  if (context.status !== undefined) {
+    return retry.retryableStatuses.includes(context.status);
+  }
+
+  return retry.retryNetworkErrors;
+}
+
+/**
+ * Parse a `Retry-After` value into milliseconds. The header comes in two
+ * shapes per RFC 9110 — delay-seconds, or an HTTP-date.
+ */
+export function parseRetryAfter(
+  value: string | null | undefined
+): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  const seconds = Number(trimmed);
+  if (trimmed !== '' && Number.isFinite(seconds)) {
+    return Math.max(0, seconds * 1000);
+  }
+
+  const date = Date.parse(trimmed);
+  if (Number.isNaN(date)) {
+    return undefined;
+  }
+
+  return Math.max(0, date - Date.now());
+}
+
+/**
+ * Full-jitter exponential backoff, mirroring the AWS SDK's `standard` retry
+ * mode so the two client paths in this SDK behave alike.
+ *
+ * A `Retry-After` wins when the server sends one — that is the server telling
+ * us exactly how long to wait. It is still clamped to `maxDelayMs` so a large
+ * or hostile value cannot stall the caller; raise `maxDelayMs` to honor long
+ * throttling windows in full.
+ */
+export function computeRetryDelay(
+  retry: ResolvedRetry,
+  attempt: number,
+  retryAfter?: string | null,
+  random: () => number = Math.random
+): number {
+  const serverDelay = parseRetryAfter(retryAfter);
+  if (serverDelay !== undefined) {
+    return Math.min(serverDelay, retry.maxDelayMs);
+  }
+
+  const exponential = Math.min(
+    retry.baseDelayMs * 2 ** (attempt - 1),
+    retry.maxDelayMs
+  );
+
+  return Math.round(random() * exponential);
+}
+
+export function sleep(ms: number): Promise<void> {
+  if (ms <= 0) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,3 +1,5 @@
+import type { RetryConfig } from './retry';
+
 export type TigrisResponse<T, E = Error> =
   | {
       data: T;
@@ -27,4 +29,20 @@ export type TigrisAuthConfig = {
   }>;
 };
 
-export type TigrisConfig = TigrisEndpointsConfig & TigrisAuthConfig;
+export type TigrisRetryConfig = {
+  /**
+   * Retry policy for requests made through the Tigris HTTP client — the
+   * bucket, fork, and IAM operations. Opt-in: omitted or `false` performs a
+   * single attempt. `true` selects the defaults (3 attempts, exponential
+   * backoff with full jitter, retrying 408/429/5xx).
+   *
+   * Object data-plane calls (`put`, `get`, `list`, multipart) go through the
+   * AWS SDK's S3 client and keep its own retry policy; this option does not
+   * apply to them.
+   */
+  retry?: RetryConfig;
+};
+
+export type TigrisConfig = TigrisEndpointsConfig &
+  TigrisAuthConfig &
+  TigrisRetryConfig;

--- a/shared/vitest.config.ts
+++ b/shared/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import { baseConfig } from '../vitest.config.base';
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      environment: 'node',
+      include: ['**/*.{test,spec}.ts'],
+      exclude: ['node_modules', 'dist'],
+    },
+  })
+);


### PR DESCRIPTION
## Summary

`createTigrisHttpClient` performed exactly one attempt and had no way to report
failures, so consumers hand-rolled both. This adds opt-in retry and an
injectable error hook.

**Retry is opt-in** — an omitted or `false` config keeps today's
single-attempt behavior, so nothing changes for existing callers unless they
ask for it.

```ts
await updateBucket('my-bucket', {
  access: 'public',
  config: { retry: { attempts: 5 } },
});
```

```ts
import { setTigrisHttpHooks } from '@tigrisdata/storage';

setTigrisHttpHooks({
  onError: ({ source, method, origin, path, status, message }) => {
    Sentry.captureException(new Error(`Tigris ${status} ${origin}${path}`), {
      tags: { api_error_source: source, api_method: method },
      contexts: { error_detail: { message } },
    });
  },
});
```

## Design notes

The reference was the console's `FetchApi.tsx`. Three things there were
deliberately **not** copied:

- **No backoff.** Fine for a browser driven by a human; a tight 3× retry from
  a server-side loop is a self-inflicted thundering herd. This uses
  exponential backoff with full jitter and honors `Retry-After`.
- **Retrying 400 and 403.** Both are deterministic for this client — a retry
  re-sends a byte-identical request. 403 in particular is how
  `SignatureDoesNotMatch` surfaces (see the SigV4 notes in `AGENTS.md`), the
  one error we most want to surface immediately rather than bury under three
  attempts. `429` was missing there entirely and is included here.
- **Full response bodies into Sentry.** IAM error bodies can carry credential
  material. The hook context reports status and a parsed message; what a
  consumer forwards is their choice.

**Transport failures are treated separately from status codes.** A `503`
means the server is telling you it didn't process the request, so re-sending
is safe for any method. A transport failure leaves the outcome *unknown* — the
write may already have landed — so those are retried only when the method is
safe to re-send (`GET`, `HEAD`). `retryNetworkErrors: true` opts a known-safe
operation back in. This puts the safety decision where the knowledge is:
tigris-os-console otherwise had to invent its own `SdkCallKind` / `RETRY_POLICY`
map and re-decide at every call site.

**The hook registry lives on a versioned `globalThis` symbol, not module
state.** `shared/` is bundled into each package rather than published once, so
a module-level variable gives `@tigrisdata/storage` and `@tigrisdata/iam`
separate registries — a hook registered through one would silently drop the
other's telemetry, and the CJS/ESM builds split the same way. Verified against
the built output before and after.

**Contexts report `origin` and `path` separately** so a consumer can use the
host-independent `path` as an identifier or recompose `${origin}${path}` to
match what another HTTP client reports for the same endpoint. `shouldRetry`
receives the same pair.

## Also fixed

Two latent bugs in the same code path:

- A 2xx carrying a JSON content-type with an empty body — as `POST ?restore`
  returns — threw a parse error out of `request()` instead of resolving. Left
  alone, wrapping this in a retry loop would have silently turned it into a
  retry trigger.
- An error body with no `Message` and no reason phrase produced
  `new Error('')`. `fetch` leaves `statusText` empty for HTTP/2, which has no
  reason phrase.

`shared/` also gets a `test` script: its 16 existing tests never ran in CI,
because `pnpm -r --if-present run test` skipped the package.

## Scope

Covers requests through `createTigrisHttpClient` — bucket, fork, and IAM
operations. Object data-plane calls (`put`, `get`, `list`, multipart) go
through the AWS SDK's S3 client, which keeps its own retry policy and is not
covered by the hooks. Wiring that path was scoped out of this PR and is a
sensible follow-up.

## Test plan

- `shared/`: 92 tests, all new — retry resolution, backoff/jitter,
  `Retry-After` parsing, method-derived transport retries, the hook registry's
  cross-bundle behavior, and end-to-end client behavior against a mocked
  `fetch`.
- `packages/storage`: 207 passed / 9 skipped, including live-gateway
  integration tests.
- `tsc --noEmit` clean for `storage` and `iam`; `pnpm build` and
  `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Core `request()` path is reworked; opt-in retry can amplify load or duplicate writes if `retryNetworkErrors` is misused on non-idempotent POSTs, though defaults are conservative and transport retries stay off for mutating methods.
> 
> **Overview**
> Adds **opt-in retry** and **`setTigrisHttpHooks`** for the shared Tigris HTTP client used by bucket/fork/IAM APIs. Default behavior stays **one attempt** unless `config.retry` or per-request `retry` is set; storage and IAM clients now forward `options?.retry ?? config.retry`.
> 
> When enabled, retries use **3 attempts by default**, exponential backoff with full jitter, **`Retry-After`**, and statuses **408/429/5xx** (not **400/403**). Transport failures retry only for **GET/HEAD** unless `retryNetworkErrors: true`; writes still retry on retryable status codes. Retries **re-sign** each attempt and **reuse the same body**; **`AbortSignal`** cancels waits and attempts.
> 
> Hooks live on a **versioned `globalThis` registry** so one registration covers bundled `@tigrisdata/storage` and `@tigrisdata/iam`; `onError` / `onRetry` are fire-and-forget and cannot fail requests. **S3 data-plane calls are out of scope.**
> 
> Also fixes **empty JSON 2xx** bodies (e.g. restore) resolving as `{}`, and **empty error messages** (HTTP/2) falling back to `Unknown error`. Adds **`shared/` vitest** and broad unit tests for retry, hooks, and client behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5312b16eba086be8674bc21ee411b3ec93346e8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->