### PR TITLE
feat: soft-delete object recovery in the SDK and CLI

### DIFF
--- a/.changeset/cli-required-arg-exit-code.md
+++ b/.changeset/cli-required-arg-exit-code.md
@@ -1,0 +1,9 @@
+---
+'@tigrisdata/cli': patch
+---
+
+Fix commands exiting 0 when a required argument was missing.
+
+A command declaring an argument as required printed the reason (e.g. `--access is required`) and then exited 0, so a rejected invocation was indistinguishable from a successful one and scripts carried on as if the command had worked. It now exits 1. Affects `tigris objects set --access` and `tigris iam users update-role --role`.
+
+The error also now prints the argument's description, since a required flag was previously indistinguishable from an optional one. Required flags are marked as such in the generated command reference for the same reason.

--- a/.changeset/cli-soft-delete-objects.md
+++ b/.changeset/cli-soft-delete-objects.md
@@ -1,0 +1,13 @@
+---
+'@tigrisdata/cli': minor
+'@tigrisdata/storage': patch
+---
+
+Surface soft-delete object recovery in the CLI.
+
+- `tigris objects list <bucket> --deleted` lists soft-deleted objects.
+- `tigris objects list-versions <bucket> --deleted` lists their recoverable versions.
+- `tigris objects restore-deleted <bucket> <key> --version-id <id>` brings one back.
+- `tigris objects purge <bucket> <key> --version-id <id>` destroys one for good.
+
+Also documents that soft delete should not be relied on for snapshot buckets — those keep deleted objects as versions, recoverable with `tigris objects list-versions`.

--- a/.changeset/soft-delete-list-restore-purge.md
+++ b/.changeset/soft-delete-list-restore-purge.md
@@ -1,0 +1,9 @@
+---
+'@tigrisdata/storage': minor
+---
+
+Add soft-delete object recovery: list deleted objects, restore one, or purge it for good.
+
+- `list({ deleted: true })` and `listVersions({ deleted: true })` read the bucket's soft-delete view instead of its live objects.
+- `restoreDeletedObject(path, versionId)` brings a deleted object back.
+- `purgeDeletedObject(path, versionId)` permanently destroys a deleted version before its retention period expires.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,3 +200,46 @@ access-key auth:
   `=`, `&`) — catches the `uriEscapePath` regression. Unit tests on
   `encodeObjectKey` alone aren't enough; the bug only shows up when
   the signer's canonicalization pass runs end-to-end.
+
+### Object soft delete does not take effect immediately
+
+Scope: object-level soft delete — `updateBucket(name, { softDelete })`,
+`list({ deleted: true })`, `listVersions({ deleted: true })`,
+`restoreDeletedObject`, and `purgeDeletedObject`.
+
+Enabling soft delete on a bucket does not reach the data plane straight
+away. A delete issued inside that window is an ordinary **hard** delete:
+nothing lands in the soft-delete view, and no amount of polling makes it
+appear, because there is nothing to find. Measured on a fresh bucket, a
+delete at +389ms after `updateBucket` was unrecoverable, while every
+delete from +4.8s onward was recoverable.
+
+**Rule for tests**: never `put` → `remove` → assert immediately after
+enabling soft delete. Retry the whole put/delete cycle until a
+recoverable copy actually appears — see `softDeleteObject()` in
+`packages/storage/src/test/soft-delete.integration.test.ts`.
+
+Symptoms that point at this:
+
+- `list({ deleted: true })` and `listVersions({ deleted: true })` both
+  return empty for a key you just deleted, and stay empty however long
+  you wait.
+- The same test passes when run on its own (more elapsed time before the
+  first delete) but fails in a suite, or vice versa.
+
+Other behaviour worth knowing before you debug it as a bug:
+
+- The listing view and the versions view are **separate indexes that
+  settle independently**. Waiting for a key to appear in
+  `listVersions({ deleted: true })` does not mean `list({ deleted: true })`
+  reports it yet. Assert against whichever view the test is about.
+- `retentionDays` must be between 7 and 90; the gateway rejects anything
+  outside that range.
+- Soft delete produced no recoverable copies at all on snapshot buckets
+  in testing. Those retain deleted objects as versions and delete
+  markers, recoverable through `listVersions()` and
+  `remove(path, { versionId })` instead.
+- To destroy a soft-deleted version use `purgeDeletedObject`, not
+  `remove(path, { versionId })` — a versioned delete aimed at a
+  soft-deleted version is rejected with `400 InvalidArgument` unless it
+  targets the soft-delete view.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1007,7 +1007,7 @@ Low-level object operations for listing, downloading, uploading, and deleting in
 | Command | Description |
 |---------|-------------|
 | `tigris objects list` (l) | List objects in a bucket, optionally filtered by a key prefix |
-| `tigris objects list-versions` (lv) | List object versions and delete markers in a bucket (requires bucket versioning). Returns both arrays separately to match the S3 ListObjectVersions response |
+| `tigris objects list-versions` (lv) | List object versions and delete markers in a bucket (requires bucket versioning), or with --deleted the recoverable versions of soft-deleted objects. Returns both arrays separately to match the S3 ListObjectVersions response |
 | `tigris objects get` (g) | Download an object by key. Prints to stdout by default, or saves to a file with --output |
 | `tigris objects put` (p) | Upload a local file — or data piped via stdin — as an object. Content-type is auto-detected from the file extension unless overridden |
 | `tigris objects delete` (d) | Delete one or more objects by key from the given bucket. On a versioned bucket, the default creates a delete marker; use --version-id or --all-versions to hard-delete versions |
@@ -1016,6 +1016,8 @@ Low-level object operations for listing, downloading, uploading, and deleting in
 | `tigris objects info` (i) | Show metadata for an object (content type, size, modified date) |
 | `tigris objects restore` (rs) | Restore an archived object (e.g. one in the GLACIER tier) into an actively-readable copy for a number of days |
 | `tigris objects restore-info` (ri) | Show the restore state of an archived object (archived, in-progress, or restored) |
+| `tigris objects restore-deleted` (rd) | Restore a soft-deleted object within its retention window. List recoverable objects with "tigris objects list --deleted", then pick a version with "tigris objects list-versions --deleted" |
+| `tigris objects purge` (pg) | Permanently destroy a soft-deleted object version before its retention period expires. This cannot be undone — the version can no longer be restored with "tigris objects restore-deleted" |
 
 #### `tigris objects list` (l)
 
@@ -1033,6 +1035,7 @@ tigris objects list <bucket> [flags]
 | `--limit` | Maximum number of items to return per page |
 | `-pt, --page-token` | Pagination token from a previous request to fetch the next page |
 | `--source` | List objects from a specific storage source on buckets with shadow migration enabled |
+| `--deleted` | List soft-deleted objects instead of live ones. Requires soft delete on the bucket. Not the recovery path for snapshot buckets — use "tigris objects list-versions" for those |
 
 **Examples:**
 ```bash
@@ -1041,11 +1044,12 @@ tigris objects list t3://my-bucket
 tigris objects list t3://my-bucket/images/
 tigris objects list my-bucket --prefix images/
 tigris objects list my-bucket --format json
+tigris objects list my-bucket --deleted
 ```
 
 #### `tigris objects list-versions` (lv)
 
-List object versions and delete markers in a bucket (requires bucket versioning). Returns both arrays separately to match the S3 ListObjectVersions response
+List object versions and delete markers in a bucket (requires bucket versioning), or with --deleted the recoverable versions of soft-deleted objects. Returns both arrays separately to match the S3 ListObjectVersions response
 
 ```
 tigris objects list-versions <bucket> [flags]
@@ -1059,6 +1063,7 @@ tigris objects list-versions <bucket> [flags]
 | `--limit` | Maximum number of items to return per page |
 | `--key-marker` | Pagination marker — the key to start listing from (from a prior nextKeyMarker) |
 | `--version-id-marker` | Pagination marker — the version id to start listing from (from a prior nextVersionIdMarker) |
+| `--deleted` | List the recoverable versions of soft-deleted objects. Use the version id with "tigris objects restore-deleted" or "tigris objects purge" |
 
 **Examples:**
 ```bash
@@ -1066,6 +1071,7 @@ tigris objects list-versions my-bucket
 tigris objects list-versions t3://my-bucket/logs/
 tigris objects list-versions my-bucket --prefix images/
 tigris objects list-versions my-bucket --format json
+tigris objects list-versions my-bucket --prefix report.pdf --deleted
 ```
 
 #### `tigris objects get` (g)
@@ -1123,7 +1129,7 @@ tigris objects delete <bucket> [key] [flags]
 
 | Flag | Description |
 |------|-------------|
-| `--version-id` | Hard-delete a specific object version (requires bucket versioning). Targets a single key |
+| `--version-id` | Hard-delete a specific object version (requires bucket versioning). Targets a single key. To destroy a soft-deleted version, use "tigris objects purge" |
 | `--all-versions` | Hard-delete every version and delete marker for the given key(s). Mutually exclusive with --version-id |
 | `--force` | Skip confirmation prompts (alias for --yes) |
 
@@ -1146,7 +1152,7 @@ tigris objects set <bucket> [key] [flags]
 
 | Flag | Description |
 |------|-------------|
-| `-a, --access` | Access level |
+| `-a, --access` | Access level **(required)** |
 | `-n, --new-key` | Rename the object to a new key |
 
 **Examples:**
@@ -1238,6 +1244,45 @@ tigris objects restore-info <bucket> [key] [flags]
 tigris objects restore-info my-bucket archived.bin
 tigris objects restore-info t3://my-bucket/archived.bin --format json
 tigris objects restore-info my-bucket archived.bin --snapshot-version 1765889000501544464
+```
+
+#### `tigris objects restore-deleted` (rd)
+
+Restore a soft-deleted object within its retention window. List recoverable objects with "tigris objects list --deleted", then pick a version with "tigris objects list-versions --deleted"
+
+```
+tigris objects restore-deleted <bucket> [key] [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--version-id` | The soft-deleted version to bring back, from "tigris objects list-versions --deleted" **(required)** |
+| `--format` | Output format (default: table) |
+
+**Examples:**
+```bash
+tigris objects restore-deleted my-bucket report.pdf --version-id 1787749774802410496
+tigris objects restore-deleted t3://my-bucket/report.pdf --version-id 1787749774802410496
+```
+
+#### `tigris objects purge` (pg)
+
+Permanently destroy a soft-deleted object version before its retention period expires. This cannot be undone — the version can no longer be restored with "tigris objects restore-deleted"
+
+```
+tigris objects purge <bucket> [key] [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--version-id` | The soft-deleted version to destroy, from "tigris objects list-versions --deleted" **(required)** |
+| `--force` | Skip confirmation prompts (alias for --yes) |
+| `--format` | Output format (default: table) |
+
+**Examples:**
+```bash
+tigris objects purge my-bucket report.pdf --version-id 1787749774802410496 --yes
+tigris objects purge t3://my-bucket/report.pdf --version-id 1787749774802410496 --yes
 ```
 
 ### `tigris access-keys` (keys)
@@ -1667,7 +1712,7 @@ tigris iam users update-role [resource] [flags]
 
 | Flag | Description |
 |------|-------------|
-| `-r, --role` | Role(s) to assign (comma-separated). Each role pairs with the corresponding user ID. If one role is given, it applies to all users |
+| `-r, --role` | Role(s) to assign (comma-separated). Each role pairs with the corresponding user ID. If one role is given, it applies to all users **(required)** |
 
 **Examples:**
 ```bash

--- a/packages/cli/scripts/update-docs.ts
+++ b/packages/cli/scripts/update-docs.ts
@@ -93,7 +93,12 @@ function renderLeafDetail(cmd: CommandSpec, parentPath: string[]): string[] {
         : `--${arg.name}`;
       const defaultStr =
         arg.default !== undefined ? ` (default: ${arg.default})` : '';
-      lines.push(`| \`${flagName}\` | ${arg.description ?? ''}${defaultStr} |`);
+      // A required flag is otherwise indistinguishable from an optional one
+      // here, since `required` only shapes the usage line for positionals.
+      const requiredStr = arg.required ? ' **(required)**' : '';
+      lines.push(
+        `| \`${flagName}\` | ${arg.description ?? ''}${defaultStr}${requiredStr} |`
+      );
     }
     lines.push('');
   }

--- a/packages/cli/src/cli-core.ts
+++ b/packages/cli/src/cli-core.ts
@@ -477,6 +477,13 @@ export function validateRequiredWhen(
 
     if (arg.required && !getOptionValue(options, arg.name, args)) {
       console.error(`--${arg.name} is required`);
+      // `required` is invisible in --help and the generated docs for
+      // non-positional arguments, so the description is the only place that
+      // says what a valid value is or where to get one. Echo it here rather
+      // than making the user go and run --help.
+      if (arg.description) {
+        console.error(`  ${arg.description}`);
+      }
       return false;
     }
   }
@@ -655,7 +662,10 @@ export function registerCommands(
               allArguments.length > 0 &&
               !validateRequiredWhen(allArguments, extracted)
             ) {
-              return;
+              // validateRequiredWhen has already printed the reason. Exit
+              // non-zero so scripts can tell a rejected invocation from a
+              // successful one — returning here reported success.
+              process.exit(1);
             }
 
             checkRemovedArguments(allArguments, extracted);
@@ -706,7 +716,9 @@ export function registerCommands(
           spec.arguments &&
           !validateRequiredWhen(spec.arguments, extracted)
         ) {
-          return;
+          // See the matching branch above: exit non-zero rather than
+          // returning, so a rejected invocation is visible to callers.
+          process.exit(1);
         }
 
         checkRemovedArguments(spec.arguments, extracted);

--- a/packages/cli/src/lib/objects/list-versions.ts
+++ b/packages/cli/src/lib/objects/list-versions.ts
@@ -28,6 +28,7 @@ export default async function listObjectVersions(
     'versionIdMarker',
   ]);
   const format = getFormat(options);
+  const deleted = !!getOption<boolean>(options, ['deleted']);
   const { limit } = getPaginationOptions(options);
 
   if (!bucketArg) {
@@ -43,6 +44,7 @@ export default async function listObjectVersions(
   const { data, error } = await listVersions({
     prefix,
     ...(delimiter ? { delimiter } : {}),
+    ...(deleted ? { deleted } : {}),
     ...(limit !== undefined ? { limit } : {}),
     ...(keyMarker ? { keyMarker } : {}),
     ...(versionIdMarker ? { versionIdMarker } : {}),

--- a/packages/cli/src/lib/objects/list.ts
+++ b/packages/cli/src/lib/objects/list.ts
@@ -26,6 +26,7 @@ export default async function listObjects(options: Record<string, unknown>) {
     'snapshot',
   ]);
   const source = getOption<'tigris' | 'shadow'>(options, ['source']);
+  const deleted = !!getOption<boolean>(options, ['deleted']);
   const { limit, pageToken } = getPaginationOptions(options);
 
   if (!bucketArg) {
@@ -42,6 +43,7 @@ export default async function listObjects(options: Record<string, unknown>) {
     prefix,
     ...(snapshotVersion ? { snapshotVersion } : {}),
     ...(source ? { source } : {}),
+    ...(deleted ? { deleted } : {}),
     ...(limit !== undefined ? { limit } : {}),
     ...(pageToken ? { paginationToken: pageToken } : {}),
     config: {

--- a/packages/cli/src/lib/objects/purge.ts
+++ b/packages/cli/src/lib/objects/purge.ts
@@ -1,0 +1,72 @@
+import { getStorageConfig } from '@auth/provider.js';
+import { purgeDeletedObject } from '@tigrisdata/storage';
+import { failWithError } from '@utils/exit.js';
+import { confirm, requireInteractive } from '@utils/interactive.js';
+import { msg, printStart, printSuccess } from '@utils/messages.js';
+import { getFormat, getOption } from '@utils/options.js';
+import { resolveObjectArgs } from '@utils/path.js';
+
+const context = msg('objects', 'purge');
+
+export default async function purge(options: Record<string, unknown>) {
+  printStart(context);
+
+  const format = getFormat(options);
+  const bucketArg = getOption<string>(options, ['bucket']);
+  const keyArg = getOption<string>(options, ['key']);
+  const versionId = getOption<string>(options, ['version-id', 'versionId']);
+  const force = getOption<boolean>(options, ['yes', 'y', 'force']);
+
+  if (!bucketArg) {
+    failWithError(context, 'Bucket name or path is required');
+  }
+
+  const { bucket, key } = resolveObjectArgs(bucketArg, keyArg);
+
+  if (!key) {
+    failWithError(context, 'Object key is required');
+  }
+
+  // The spec marks --version-id required, so the CLI rejects a missing one
+  // before reaching here. Kept as a guard for direct callers of this handler.
+  if (!versionId) {
+    failWithError(context, '--version-id is required');
+  }
+
+  if (!force) {
+    requireInteractive('Use --yes to skip confirmation');
+    const confirmed = await confirm(
+      `Permanently destroy version '${versionId}' of '${key}' in '${bucket}'? It can no longer be restored.`
+    );
+    if (!confirmed) {
+      console.log('Aborted');
+      return;
+    }
+  }
+
+  const config = await getStorageConfig();
+
+  const { error } = await purgeDeletedObject(key, versionId, {
+    config: {
+      ...config,
+      bucket,
+    },
+  });
+
+  if (error) {
+    failWithError(context, error);
+  }
+
+  if (format === 'json') {
+    console.log(
+      JSON.stringify({
+        action: 'purged',
+        bucket,
+        key,
+        versionId,
+      })
+    );
+  }
+
+  printSuccess(context, { key, bucket, versionId });
+}

--- a/packages/cli/src/lib/objects/restore-deleted.ts
+++ b/packages/cli/src/lib/objects/restore-deleted.ts
@@ -1,0 +1,60 @@
+import { getStorageConfig } from '@auth/provider.js';
+import { restoreDeletedObject } from '@tigrisdata/storage';
+import { failWithError, printNextActions } from '@utils/exit.js';
+import { msg, printStart, printSuccess } from '@utils/messages.js';
+import { getFormat, getOption } from '@utils/options.js';
+import { resolveObjectArgs } from '@utils/path.js';
+
+const context = msg('objects', 'restore-deleted');
+
+export default async function restoreDeleted(options: Record<string, unknown>) {
+  printStart(context);
+
+  const format = getFormat(options);
+  const bucketArg = getOption<string>(options, ['bucket']);
+  const keyArg = getOption<string>(options, ['key']);
+  const versionId = getOption<string>(options, ['version-id', 'versionId']);
+
+  if (!bucketArg) {
+    failWithError(context, 'Bucket name or path is required');
+  }
+
+  const { bucket, key } = resolveObjectArgs(bucketArg, keyArg);
+
+  if (!key) {
+    failWithError(context, 'Object key is required');
+  }
+
+  // The spec marks --version-id required, so the CLI rejects a missing one
+  // before reaching here. Kept as a guard for direct callers of this handler.
+  if (!versionId) {
+    failWithError(context, '--version-id is required');
+  }
+
+  const config = await getStorageConfig();
+
+  const { error } = await restoreDeletedObject(key, versionId, {
+    config: {
+      ...config,
+      bucket,
+    },
+  });
+
+  if (error) {
+    failWithError(context, error);
+  }
+
+  if (format === 'json') {
+    console.log(
+      JSON.stringify({
+        action: 'restored',
+        bucket,
+        key,
+        versionId,
+      })
+    );
+  }
+
+  printSuccess(context, { key, bucket });
+  printNextActions(context, { bucket });
+}

--- a/packages/cli/src/specs.yaml
+++ b/packages/cli/src/specs.yaml
@@ -1458,6 +1458,7 @@ commands:
           - "tigris objects list t3://my-bucket/images/"
           - "tigris objects list my-bucket --prefix images/"
           - "tigris objects list my-bucket --format json"
+          - "tigris objects list my-bucket --deleted"
         messages:
           onStart: 'Listing objects...'
           onSuccess: 'Found {{count}} object(s)'
@@ -1490,15 +1491,19 @@ commands:
           - name: source
             description: List objects from a specific storage source on buckets with shadow migration enabled
             options: [tigris, shadow]
+          - name: deleted
+            description: List soft-deleted objects instead of live ones. Requires soft delete on the bucket. Not the recovery path for snapshot buckets — use "tigris objects list-versions" for those
+            type: flag
       # list-versions
       - name: list-versions
-        description: List object versions and delete markers in a bucket (requires bucket versioning). Returns both arrays separately to match the S3 ListObjectVersions response
+        description: List object versions and delete markers in a bucket (requires bucket versioning), or with --deleted the recoverable versions of soft-deleted objects. Returns both arrays separately to match the S3 ListObjectVersions response
         alias: lv
         examples:
           - "tigris objects list-versions my-bucket"
           - "tigris objects list-versions t3://my-bucket/logs/"
           - "tigris objects list-versions my-bucket --prefix images/"
           - "tigris objects list-versions my-bucket --format json"
+          - "tigris objects list-versions my-bucket --prefix report.pdf --deleted"
         messages:
           onStart: 'Listing object versions...'
           onSuccess: 'Found {{versions}} version(s) and {{deleteMarkers}} delete marker(s)'
@@ -1528,6 +1533,9 @@ commands:
             description: Pagination marker — the key to start listing from (from a prior nextKeyMarker)
           - name: version-id-marker
             description: Pagination marker — the version id to start listing from (from a prior nextVersionIdMarker)
+          - name: deleted
+            description: List the recoverable versions of soft-deleted objects. Use the version id with "tigris objects restore-deleted" or "tigris objects purge"
+            type: flag
       # get
       - name: get
         description: Download an object by key. Prints to stdout by default, or saves to a file with --output
@@ -1644,7 +1652,7 @@ commands:
             examples:
               - my-file.txt
           - name: version-id
-            description: Hard-delete a specific object version (requires bucket versioning). Targets a single key
+            description: Hard-delete a specific object version (requires bucket versioning). Targets a single key. To destroy a soft-deleted version, use "tigris objects purge"
           - name: all-versions
             description: Hard-delete every version and delete marker for the given key(s). Mutually exclusive with --version-id
             type: flag
@@ -1798,6 +1806,74 @@ commands:
           - name: snapshot-version
             description: Inspect the object as of a specific bucket snapshot. Accepts a snapshot version string or any UNIX nanosecond-precision timestamp (e.g. 1765889000501544464)
             alias: snapshot
+          - name: format
+            description: Output format
+            options: [json, table, xml]
+            default: table
+      # restore-deleted
+      - name: restore-deleted
+        description: Restore a soft-deleted object within its retention window. List recoverable objects with "tigris objects list --deleted", then pick a version with "tigris objects list-versions --deleted"
+        alias: rd
+        examples:
+          - "tigris objects restore-deleted my-bucket report.pdf --version-id 1787749774802410496"
+          - "tigris objects restore-deleted t3://my-bucket/report.pdf --version-id 1787749774802410496"
+        messages:
+          onStart: 'Restoring deleted object...'
+          onSuccess: "Object '{{key}}' restored successfully"
+          onFailure: 'Failed to restore deleted object'
+          nextActions:
+            - command: 'tigris ls {{bucket}}'
+              description: 'List objects in the bucket'
+        arguments:
+          - name: bucket
+            type: positional
+            required: true
+            description: Name of the bucket, or a full path (t3://bucket/key)
+            examples:
+              - my-bucket
+              - t3://my-bucket/report.pdf
+          - name: key
+            type: positional
+            description: Key of the object (omit if bucket contains the full path)
+            examples:
+              - report.pdf
+          - name: version-id
+            required: true
+            description: The soft-deleted version to bring back, from "tigris objects list-versions --deleted"
+          - name: format
+            description: Output format
+            options: [json, table, xml]
+            default: table
+      # purge
+      - name: purge
+        description: Permanently destroy a soft-deleted object version before its retention period expires. This cannot be undone — the version can no longer be restored with "tigris objects restore-deleted"
+        alias: pg
+        examples:
+          - "tigris objects purge my-bucket report.pdf --version-id 1787749774802410496 --yes"
+          - "tigris objects purge t3://my-bucket/report.pdf --version-id 1787749774802410496 --yes"
+        messages:
+          onStart: 'Purging deleted object...'
+          onSuccess: "Purged version '{{versionId}}' of '{{key}}'"
+          onFailure: 'Failed to purge deleted object'
+        arguments:
+          - name: bucket
+            type: positional
+            required: true
+            description: Name of the bucket, or a full path (t3://bucket/key)
+            examples:
+              - my-bucket
+              - t3://my-bucket/report.pdf
+          - name: key
+            type: positional
+            description: Key of the object (omit if bucket contains the full path)
+            examples:
+              - report.pdf
+          - name: version-id
+            required: true
+            description: The soft-deleted version to destroy, from "tigris objects list-versions --deleted"
+          - name: force
+            type: flag
+            description: Skip confirmation prompts (alias for --yes)
           - name: format
             description: Output format
             options: [json, table, xml]

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -314,6 +314,67 @@ describe('Destructive commands require --yes in non-TTY', () => {
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('Use --yes to skip confirmation');
   });
+
+  it('objects purge should require confirmation in non-TTY', () => {
+    const result = runCli('objects purge fake-bucket fake-key --version-id 1');
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('Use --yes to skip confirmation');
+  });
+});
+
+// A missing `required: true` argument used to print its reason and then exit
+// 0, so a rejected invocation was indistinguishable from a successful one.
+describe('Missing required arguments exit non-zero', () => {
+  it('objects set without --access exits 1', () => {
+    const result = runCli('objects set fake-bucket fake-key');
+    expect(result.stderr).toContain('--access is required');
+    expect(result.exitCode).toBe(1);
+  });
+
+  it('iam users update-role without --role exits 1', () => {
+    const result = runCli('iam users update-role fake-user');
+    expect(result.stderr).toContain('--role is required');
+    expect(result.exitCode).toBe(1);
+  });
+
+  // `required` is invisible in --help for a flag, so the description is the
+  // only thing telling the user what a valid value is.
+  it('reports the argument description alongside the error', () => {
+    const result = runCli('objects set fake-bucket fake-key');
+    expect(result.stderr).toContain('Access level');
+  });
+});
+
+// These fire before any credential or network use, so they run without
+// integration credentials.
+describe('Soft-delete argument validation', () => {
+  it('objects purge requires --version-id', () => {
+    const result = runCli('objects purge fake-bucket fake-key --yes');
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('--version-id is required');
+    // The error should point at where to get a version id.
+    expect(result.stderr).toContain('list-versions');
+  });
+
+  it('objects purge requires a key', () => {
+    const result = runCli('objects purge fake-bucket --version-id 1 --yes');
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('Object key is required');
+  });
+
+  it('objects restore-deleted requires --version-id', () => {
+    const result = runCli('objects restore-deleted fake-bucket fake-key');
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('--version-id is required');
+    // The error should point at where to get a version id.
+    expect(result.stderr).toContain('list-versions');
+  });
+
+  it('objects restore-deleted requires a key', () => {
+    const result = runCli('objects restore-deleted fake-bucket --version-id 1');
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('Object key is required');
+  });
 });
 
 describe.skipIf(skipTests)('CLI Integration Tests', () => {

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -437,6 +437,7 @@ list(options?: ListOptions): Promise<TigrisStorageResponse<ListResponse, Error>>
 | limit           | No           | The maximum number of objects to return. By default, returns up to 100 objects.  |
 | paginationToken | No           | The pagination token to continue listing objects from the previous request.      |
 | snapshotVersion | No           | Snapshot version of the bucket.                                                  |
+| deleted         | No           | List [soft-deleted objects](#recovering-deleted-objects) instead of live ones.   |
 | config          | No           | A configuration object to override the [default configuration](#authentication). |
 
 In case of successful `list`, the `data` property will be set to the list of objects and contains the following properties:
@@ -485,6 +486,127 @@ if (currentPage.data) {
 
 console.log(allFiles);
 ```
+
+## Recovering deleted objects
+
+When a bucket has soft delete enabled, deleting an object keeps a recoverable
+copy for the bucket's retention period instead of destroying it. Enable it with
+`updateBucket`:
+
+```ts
+await updateBucket('my-bucket', {
+  softDelete: { enabled: true, retentionDays: 30 },
+});
+```
+
+`retentionDays` must be between 7 and 90. Note that enabling soft delete takes
+a few seconds to take effect — an object deleted immediately afterwards may
+still be deleted for good.
+
+Recovering an object is a three-step flow: find the deleted keys, pick the
+version to act on, then restore or purge it.
+
+### 1. Find deleted objects
+
+Pass `deleted: true` to [`list`](#listing-objects). This is a separate view
+rather than an addition — the response contains only deleted objects, and live
+objects are left out. `prefix`, `delimiter`, `limit` and `paginationToken` all
+work as they normally do.
+
+```ts
+const result = await list({ deleted: true, prefix: 'Data/' });
+
+if (result.error) {
+  console.error('Error listing deleted objects:', result.error);
+} else {
+  console.log('Deleted objects:', result.data.items);
+}
+```
+
+### 2. Pick a version
+
+Pass `deleted: true` to `listVersions` to see the recoverable versions of a
+deleted object. Restoring and purging both act on a single version, so this is
+where you choose which one.
+
+```ts
+const { data } = await listVersions({
+  prefix: 'Data/small.txt',
+  deleted: true,
+});
+
+const versionId = data?.versions[0]?.versionId;
+```
+
+### 3. Restore or purge it
+
+#### `restoreDeletedObject`
+
+```ts
+restoreDeletedObject(path: string, versionId: string, options?: RestoreDeletedObjectOptions): Promise<TigrisStorageResponse<RestoreDeletedObjectResponse, Error>>;
+```
+
+Brings a deleted object back as a live object. This is unrelated to
+`restoreObject`, which thaws an archived (`GLACIER`) object.
+
+`restoreDeletedObject` accepts the following parameters:
+
+- `path`: (Required) A string specifying the path to the object
+- `versionId`: (Required) The soft-deleted version to bring back, from `listVersions({ deleted: true })`
+- `options`: (Optional) A JSON object with the following optional parameters:
+
+#### `options`
+
+| **Parameter** | **Required** | **Values**                                                                       |
+| ------------- | ------------ | -------------------------------------------------------------------------------- |
+| config        | No           | A configuration object to override the [default configuration](#authentication). |
+
+```ts
+const result = await restoreDeletedObject('Data/small.txt', versionId);
+
+if (result.error) {
+  console.error('Error restoring object:', result.error);
+} else {
+  console.log('Object restored:', result.data.path);
+}
+```
+
+#### `purgeDeletedObject`
+
+```ts
+purgeDeletedObject(path: string, versionId: string, options?: PurgeDeletedObjectOptions): Promise<TigrisStorageResponse<PurgeDeletedObjectResponse, Error>>;
+```
+
+Permanently destroys one deleted version before its retention period would
+have expired. This cannot be undone — the version can no longer be restored.
+
+`purgeDeletedObject` accepts the following parameters:
+
+- `path`: (Required) A string specifying the path to the object
+- `versionId`: (Required) The soft-deleted version to destroy, from `listVersions({ deleted: true })`
+- `options`: (Optional) A JSON object with the following optional parameters:
+
+#### `options`
+
+| **Parameter** | **Required** | **Values**                                                                       |
+| ------------- | ------------ | -------------------------------------------------------------------------------- |
+| config        | No           | A configuration object to override the [default configuration](#authentication). |
+
+```ts
+const result = await purgeDeletedObject('Data/small.txt', versionId);
+
+if (result.error) {
+  console.error('Error purging object:', result.error);
+} else {
+  console.log('Object purged for good:', result.data.path);
+}
+```
+
+Note this is not the same call as `remove(path, { versionId })`. A versioned
+delete aimed at a soft-deleted version is rejected with `400 InvalidArgument`
+unless it targets the soft-delete view, which is what this function does.
+`remove(path, { versionId })` is still the right call for hard-deleting a live
+object's versions on a versioned bucket.
 
 ## Creating a bucket
 

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -499,9 +499,17 @@ await updateBucket('my-bucket', {
 });
 ```
 
-`retentionDays` must be between 7 and 90. Note that enabling soft delete takes
-a few seconds to take effect — an object deleted immediately afterwards may
-still be deleted for good.
+`retentionDays` must be between 7 and 90. Two caveats are worth knowing before
+you rely on this:
+
+- **Enabling soft delete takes a few seconds to take effect.** An object
+  deleted immediately afterwards is deleted for good, and no amount of
+  retrying the lookup brings it back.
+- **Do not rely on soft delete on a snapshot bucket.** On buckets created with
+  `enableSnapshot: true`, repeated deletes produced no recoverable copies in
+  our testing and the soft-delete view stayed empty. Snapshot buckets already
+  retain deleted objects as versions and delete markers, so recover those with
+  `listVersions()` and `remove(path, { versionId })` instead.
 
 Recovering an object is a three-step flow: find the deleted keys, pick the
 version to act on, then restore or purge it.

--- a/packages/storage/src/lib/object/list-versions.ts
+++ b/packages/storage/src/lib/object/list-versions.ts
@@ -3,6 +3,7 @@ import { handleError } from '@shared/utils';
 import { getConfig, missingConfigError } from '../config';
 import { createTigrisClient } from '../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
+import { addSoftDeleteMiddleware } from './middleware';
 
 export type ListVersionsOptions = {
   delimiter?: string;
@@ -14,6 +15,13 @@ export type ListVersionsOptions = {
    * `keyMarker` is not also set, so passing it alone returns an error.
    */
   versionIdMarker?: string;
+  /**
+   * List the recoverable versions of the bucket's soft-deleted objects instead
+   * of its live ones. Use this to pick the `versionId` to hand to
+   * `restoreDeletedObject` or `purgeDeletedObject`; discover which keys are
+   * deleted in the first place with `list({ deleted: true })`.
+   */
+  deleted?: boolean;
   config?: TigrisStorageConfig;
 };
 
@@ -69,6 +77,10 @@ export async function listVersions(
     KeyMarker: options?.keyMarker,
     VersionIdMarker: options?.versionIdMarker,
   });
+
+  if (options?.deleted) {
+    addSoftDeleteMiddleware(command.middlewareStack);
+  }
 
   try {
     return tigrisClient

--- a/packages/storage/src/lib/object/list.ts
+++ b/packages/storage/src/lib/object/list.ts
@@ -4,7 +4,10 @@ import { TigrisHeaders } from '@shared/index';
 import { getConfig, missingConfigError } from '../config';
 import { createTigrisClient } from '../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
-import { addSnapshotVersionMiddleware } from './middleware';
+import {
+  addSnapshotVersionMiddleware,
+  addSoftDeleteMiddleware,
+} from './middleware';
 
 export type ListOptions = {
   delimiter?: string;
@@ -13,6 +16,17 @@ export type ListOptions = {
   paginationToken?: string;
   snapshotVersion?: string;
   source?: 'tigris' | 'shadow';
+  /**
+   * List the bucket's soft-deleted objects instead of its live ones. This is a
+   * separate view, not an addition: the response contains only recoverable
+   * deleted objects, and live objects are left out entirely.
+   *
+   * Requires soft delete to be enabled on the bucket
+   * (`updateBucket(name, { softDelete })`). To act on one of these entries,
+   * look up its recoverable versions with `listVersions({ deleted: true })`,
+   * then pass a `versionId` to `restoreDeletedObject` or `purgeDeletedObject`.
+   */
+  deleted?: boolean;
   config?: TigrisStorageConfig;
 };
 
@@ -55,6 +69,10 @@ export async function list(
 
   if (options?.snapshotVersion) {
     addSnapshotVersionMiddleware(list.middlewareStack, options.snapshotVersion);
+  }
+
+  if (options?.deleted) {
+    addSoftDeleteMiddleware(list.middlewareStack);
   }
 
   if (options?.source) {

--- a/packages/storage/src/lib/object/list.ts
+++ b/packages/storage/src/lib/object/list.ts
@@ -22,9 +22,12 @@ export type ListOptions = {
    * deleted objects, and live objects are left out entirely.
    *
    * Requires soft delete to be enabled on the bucket
-   * (`updateBucket(name, { softDelete })`). To act on one of these entries,
-   * look up its recoverable versions with `listVersions({ deleted: true })`,
-   * then pass a `versionId` to `restoreDeletedObject` or `purgeDeletedObject`.
+   * (`updateBucket(name, { softDelete })`). Do not rely on it for snapshot
+   * buckets: this view stayed empty on them in testing, and they retain
+   * deleted objects as versions and delete markers that `listVersions()`
+   * reports instead. To act on an entry here, look up its recoverable
+   * versions with `listVersions({ deleted: true })`, then pass a `versionId`
+   * to `restoreDeletedObject` or `purgeDeletedObject`.
    */
   deleted?: boolean;
   config?: TigrisStorageConfig;

--- a/packages/storage/src/lib/object/middleware.ts
+++ b/packages/storage/src/lib/object/middleware.ts
@@ -29,3 +29,58 @@ export function addSnapshotVersionMiddleware<
     }
   );
 }
+
+/**
+ * Point an S3 command at the bucket's soft-delete view instead of its live
+ * objects.
+ *
+ * On a bucket with soft delete enabled, a delete keeps a recoverable copy that
+ * the normal list/version calls no longer report. `X-Tigris-Soft-Delete` swaps
+ * the operation over to those copies: `ListObjectsV2` returns the deleted keys,
+ * `ListObjectVersions` returns their recoverable versions, and `DeleteObject`
+ * with a version purges one for good.
+ *
+ * The header is not optional on the purge path — a `DeleteObject` aimed at a
+ * soft-deleted version without it is rejected with `400 InvalidArgument`.
+ * Versioned deletes of a live object's own versions are unaffected.
+ */
+export function addSoftDeleteMiddleware<
+  Input extends object,
+  Output extends object,
+>(middlewareStack: MiddlewareStack<Input, Output>) {
+  middlewareStack.add(
+    (next) => async (args) => {
+      const req = args.request as HttpRequest;
+      req.headers[TigrisHeaders.SOFT_DELETE] = 'true';
+      return next(args);
+    },
+    {
+      name: 'X-Tigris-Soft-Delete-Middleware',
+      step: 'build',
+      override: true,
+    }
+  );
+}
+
+/**
+ * Turn a `RestoreObject` call into a soft-delete undelete of one specific
+ * version, rather than the archive thaw the command normally performs.
+ */
+export function addSoftDeleteRestoreMiddleware<
+  Input extends object,
+  Output extends object,
+>(middlewareStack: MiddlewareStack<Input, Output>, versionId: string) {
+  middlewareStack.add(
+    (next) => async (args) => {
+      const req = args.request as HttpRequest;
+      req.headers[TigrisHeaders.RESTORE_TYPE] = 'soft-delete';
+      req.headers[TigrisHeaders.RESTORE_VERSION] = versionId;
+      return next(args);
+    },
+    {
+      name: 'X-Tigris-Soft-Delete-Restore-Middleware',
+      step: 'build',
+      override: true,
+    }
+  );
+}

--- a/packages/storage/src/lib/object/remove.ts
+++ b/packages/storage/src/lib/object/remove.ts
@@ -3,6 +3,7 @@ import { handleError } from '@shared/utils';
 import { getConfig } from '../config';
 import { createTigrisClient } from '../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
+import { addSoftDeleteMiddleware } from './middleware';
 
 export type RemoveOptions = {
   config?: TigrisStorageConfig;
@@ -31,6 +32,72 @@ export async function remove(
       .then(() => {
         return { data: undefined };
       })
+      .catch(handleError);
+  } catch (error) {
+    return handleError(error as Error);
+  }
+}
+
+export type PurgeDeletedObjectOptions = {
+  config?: TigrisStorageConfig;
+};
+
+export type PurgeDeletedObjectResponse = {
+  path: string;
+  versionId: string;
+};
+
+/**
+ * Permanently destroy one soft-deleted version of an object, before its
+ * retention window would have expired. This cannot be undone — the version is
+ * no longer recoverable with `restoreDeletedObject`.
+ *
+ * `versionId` comes from `listVersions({ deleted: true, prefix })`; find the
+ * deleted keys themselves with `list({ deleted: true })`.
+ *
+ * Note this is not the same call as `remove(path, { versionId })`. A versioned
+ * delete aimed at a soft-deleted version is rejected with `400
+ * InvalidArgument` unless it targets the soft-delete view, which is what this
+ * does. `remove` is still the right call for hard-deleting a live object's
+ * versions on a versioned bucket.
+ */
+export async function purgeDeletedObject(
+  path: string,
+  versionId: string,
+  options?: PurgeDeletedObjectOptions
+): Promise<TigrisStorageResponse<PurgeDeletedObjectResponse, Error>> {
+  if (!path) {
+    return { error: new Error('Object path is required') };
+  }
+
+  if (!versionId) {
+    return { error: new Error('versionId is required') };
+  }
+
+  const config = getConfig();
+  const { data: tigrisClient, error } = createTigrisClient(options?.config);
+
+  if (error) {
+    return { error };
+  }
+
+  const purge = new DeleteObjectCommand({
+    Bucket: options?.config?.bucket ?? config.bucket,
+    Key: path,
+    VersionId: versionId,
+  });
+
+  addSoftDeleteMiddleware(purge.middlewareStack);
+
+  try {
+    return tigrisClient
+      .send(purge)
+      .then(() => ({
+        data: {
+          path,
+          versionId,
+        },
+      }))
       .catch(handleError);
   } catch (error) {
     return handleError(error as Error);

--- a/packages/storage/src/lib/object/restore.ts
+++ b/packages/storage/src/lib/object/restore.ts
@@ -4,7 +4,10 @@ import { handleError, TigrisHeaders } from '@shared/index';
 import { getConfig } from '../config';
 import { createTigrisClient } from '../tigris-client';
 import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
-import { addSnapshotVersionMiddleware } from './middleware';
+import {
+  addSnapshotVersionMiddleware,
+  addSoftDeleteRestoreMiddleware,
+} from './middleware';
 
 export type RestoreObjectOptions = {
   /**
@@ -65,6 +68,72 @@ export async function restoreObject(
           },
         };
       })
+      .catch(handleError);
+  } catch (error) {
+    return handleError(error as Error);
+  }
+}
+
+export type RestoreDeletedObjectOptions = {
+  config?: TigrisStorageConfig;
+};
+
+export type RestoreDeletedObjectResponse = {
+  path: string;
+  versionId: string;
+};
+
+/**
+ * Bring a soft-deleted object back as a live object.
+ *
+ * This is the undelete counterpart to `restoreBucket`, and is unrelated to
+ * `restoreObject` — that one thaws an archived (e.g. `GLACIER`) object, while
+ * this one recovers a deleted one within its retention window.
+ *
+ * Soft delete must be enabled on the bucket
+ * (`updateBucket(name, { softDelete })`). `versionId` comes from
+ * `listVersions({ deleted: true, prefix })`; find the deleted keys themselves
+ * with `list({ deleted: true })`.
+ */
+export async function restoreDeletedObject(
+  path: string,
+  versionId: string,
+  options?: RestoreDeletedObjectOptions
+): Promise<TigrisStorageResponse<RestoreDeletedObjectResponse, Error>> {
+  if (!path) {
+    return { error: new Error('Object path is required') };
+  }
+
+  if (!versionId) {
+    return { error: new Error('versionId is required') };
+  }
+
+  const config = getConfig();
+  const { data: tigrisClient, error } = createTigrisClient(options?.config);
+
+  if (error) {
+    return { error };
+  }
+
+  // Deliberately no `RestoreRequest`: the archive-thaw body would be
+  // meaningless here, and the gateway keys off the restore-type header
+  // instead.
+  const restore = new RestoreObjectCommand({
+    Bucket: options?.config?.bucket ?? config.bucket,
+    Key: path,
+  });
+
+  addSoftDeleteRestoreMiddleware(restore.middlewareStack, versionId);
+
+  try {
+    return tigrisClient
+      .send(restore)
+      .then(() => ({
+        data: {
+          path,
+          versionId,
+        },
+      }))
       .catch(handleError);
   } catch (error) {
     return handleError(error as Error);

--- a/packages/storage/src/server.ts
+++ b/packages/storage/src/server.ts
@@ -151,14 +151,23 @@ export {
   getPresignedUrl,
 } from './lib/object/presigned-url';
 export { type PutOptions, type PutResponse, put } from './lib/object/put';
-export { type RemoveOptions, remove } from './lib/object/remove';
+export {
+  type PurgeDeletedObjectOptions,
+  type PurgeDeletedObjectResponse,
+  purgeDeletedObject,
+  type RemoveOptions,
+  remove,
+} from './lib/object/remove';
 export {
   type GetRestoreInfoOptions,
   getRestoreInfo,
+  type RestoreDeletedObjectOptions,
+  type RestoreDeletedObjectResponse,
   type RestoreInfo,
   type RestoreObjectOptions,
   type RestoreObjectResponse,
   RestoreStatus,
+  restoreDeletedObject,
   restoreObject,
 } from './lib/object/restore';
 export {

--- a/packages/storage/src/test/soft-delete.integration.test.ts
+++ b/packages/storage/src/test/soft-delete.integration.test.ts
@@ -1,0 +1,338 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createBucket } from '../lib/bucket/create';
+import { removeBucket } from '../lib/bucket/remove';
+import { updateBucket } from '../lib/bucket/update';
+import { getConfig } from '../lib/config';
+import { list } from '../lib/object/list';
+import { listVersions } from '../lib/object/list-versions';
+import { put } from '../lib/object/put';
+import { purgeDeletedObject, remove } from '../lib/object/remove';
+import { restoreDeletedObject } from '../lib/object/restore';
+import { shouldSkipIntegrationTests } from './setup';
+
+const skipTests = shouldSkipIntegrationTests();
+
+const config = getConfig();
+
+// The gateway rejects a retention outside this range.
+const RETENTION_DAYS = 7;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * The soft-delete views are eventually consistent, so a delete does not show
+ * up in them straight away. Poll instead of sleeping a fixed amount.
+ */
+async function poll<T>(
+  check: () => Promise<T | undefined>,
+  attempts = 20,
+  delayMs = 750
+): Promise<T | undefined> {
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    const result = await check();
+    if (result !== undefined) {
+      return result;
+    }
+    await sleep(delayMs);
+  }
+  return undefined;
+}
+
+type BucketConfig = typeof config;
+
+/** The recoverable version of `key`, if the soft-delete view has one yet. */
+async function deletedVersionOf(
+  bucketConfig: BucketConfig,
+  key: string
+): Promise<string | undefined> {
+  const { data } = await listVersions({
+    prefix: key,
+    deleted: true,
+    config: bucketConfig,
+  });
+  return data?.versions.find((v) => v.name === key)?.versionId;
+}
+
+/**
+ * Write a key and delete it so that a recoverable copy exists, returning that
+ * copy's version.
+ *
+ * Enabling soft delete on a bucket takes a few seconds to reach the data
+ * plane, and a delete that lands inside that window is a plain hard delete
+ * that leaves nothing behind to find. No amount of polling recovers from
+ * that, so re-create and re-delete the key until a recoverable copy actually
+ * appears.
+ */
+async function softDeleteObject(
+  bucketConfig: BucketConfig,
+  key: string,
+  content = 'content'
+): Promise<string | undefined> {
+  for (let attempt = 0; attempt < 8; attempt++) {
+    await put(key, content, { config: bucketConfig });
+    await remove(key, { config: bucketConfig });
+
+    const versionId = await poll(
+      () => deletedVersionOf(bucketConfig, key),
+      6,
+      500
+    );
+    if (versionId) {
+      return versionId;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Wait for deleted keys to appear in `list({ deleted: true })`. This is a
+ * different index from the versions view and settles on its own schedule, so
+ * assertions about the listing have to wait on the listing.
+ */
+function waitForDeletedListing(
+  bucketConfig: BucketConfig,
+  prefix: string,
+  expectedCount: number
+): Promise<string[] | undefined> {
+  return poll(async () => {
+    const { data } = await list({
+      prefix,
+      deleted: true,
+      config: bucketConfig,
+    });
+    const names = data?.items.map((i) => i.name) ?? [];
+    return names.length >= expectedCount ? names : undefined;
+  });
+}
+
+/** Wait for a key to be present in, or absent from, the live listing. */
+function waitForLiveListing(
+  bucketConfig: BucketConfig,
+  key: string,
+  present: boolean
+): Promise<boolean | undefined> {
+  return poll(async () => {
+    const { data } = await list({ prefix: key, config: bucketConfig });
+    const found = (data?.items ?? []).some((i) => i.name === key);
+    return found === present ? true : undefined;
+  });
+}
+
+describe.skipIf(skipTests)('Object soft delete Integration Tests', () => {
+  const bucket = `test-soft-delete-${Date.now()}`.toLowerCase();
+  const bucketConfig = { ...config, bucket };
+
+  beforeAll(async () => {
+    const created = await createBucket(bucket, { config });
+    expect(
+      created.error,
+      `bucket create failed: ${created.error?.message}`
+    ).toBeUndefined();
+
+    const enabled = await updateBucket(bucket, {
+      softDelete: { enabled: true, retentionDays: RETENTION_DAYS },
+      config,
+    });
+    expect(
+      enabled.error,
+      `enabling soft delete failed: ${enabled.error?.message}`
+    ).toBeUndefined();
+
+    // Absorb the propagation window once here rather than in every test.
+    const canary = await softDeleteObject(bucketConfig, '.canary');
+    expect(canary, 'soft delete never took effect on the bucket').toBeTruthy();
+  });
+
+  afterAll(async () => {
+    await removeBucket(bucket, { force: true, config });
+  });
+
+  it('list({ deleted: true }) returns deleted objects and omits live ones', async () => {
+    const deletedKey = `deleted-${Date.now()}.txt`;
+    const liveKey = `live-${Date.now()}.txt`;
+
+    await put(liveKey, 'here', { config: bucketConfig });
+    const versionId = await softDeleteObject(bucketConfig, deletedKey, 'gone');
+    expect(versionId).toBeTruthy();
+    await waitForDeletedListing(bucketConfig, deletedKey, 1);
+
+    const deleted = await list({ deleted: true, config: bucketConfig });
+    expect(deleted.error).toBeUndefined();
+    const deletedNames = deleted.data?.items.map((i) => i.name) ?? [];
+    expect(deletedNames).toContain(deletedKey);
+    // The soft-delete view replaces the live listing rather than adding to it.
+    expect(deletedNames).not.toContain(liveKey);
+
+    await waitForLiveListing(bucketConfig, deletedKey, false);
+    const live = await list({ config: bucketConfig });
+    const liveNames = live.data?.items.map((i) => i.name) ?? [];
+    expect(liveNames).toContain(liveKey);
+    expect(liveNames).not.toContain(deletedKey);
+  });
+
+  it('list({ deleted: true }) honours prefix, delimiter and pagination', async () => {
+    const prefix = `page-${Date.now()}/`;
+    const keys = [`${prefix}a.txt`, `${prefix}b.txt`];
+    for (const key of keys) {
+      expect(await softDeleteObject(bucketConfig, key)).toBeTruthy();
+    }
+    await waitForDeletedListing(bucketConfig, prefix, keys.length);
+
+    const byPrefix = await list({
+      deleted: true,
+      prefix,
+      config: bucketConfig,
+    });
+    expect(byPrefix.data?.items.map((i) => i.name).sort()).toEqual(keys);
+
+    const byDelimiter = await list({
+      deleted: true,
+      delimiter: '/',
+      config: bucketConfig,
+    });
+    expect(byDelimiter.data?.commonPrefixes).toContain(prefix);
+
+    const firstPage = await list({
+      deleted: true,
+      prefix,
+      limit: 1,
+      config: bucketConfig,
+    });
+    expect(firstPage.data?.items).toHaveLength(1);
+    expect(firstPage.data?.hasMore).toBe(true);
+    expect(firstPage.data?.paginationToken).toBeTruthy();
+
+    const secondPage = await list({
+      deleted: true,
+      prefix,
+      limit: 1,
+      paginationToken: firstPage.data?.paginationToken,
+      config: bucketConfig,
+    });
+    expect(secondPage.data?.items).toHaveLength(1);
+    expect(secondPage.data?.items[0]?.name).not.toBe(
+      firstPage.data?.items[0]?.name
+    );
+  });
+
+  it('listVersions({ deleted: true }) exposes recoverable versions', async () => {
+    const key = `versions-${Date.now()}.txt`;
+    expect(await softDeleteObject(bucketConfig, key, 'v1')).toBeTruthy();
+
+    const deleted = await listVersions({
+      prefix: key,
+      deleted: true,
+      config: bucketConfig,
+    });
+    expect(deleted.error).toBeUndefined();
+    expect(deleted.data?.versions.length).toBeGreaterThanOrEqual(1);
+    expect(deleted.data?.versions[0]?.name).toBe(key);
+    expect(deleted.data?.versions[0]?.versionId).toBeTruthy();
+
+    // Without the flag the deleted object is not reported at all.
+    const live = await listVersions({ prefix: key, config: bucketConfig });
+    expect(live.data?.versions).toHaveLength(0);
+  });
+
+  it('restoreDeletedObject() brings a deleted object back', async () => {
+    const key = `restore-${Date.now()}.txt`;
+    const versionId = await softDeleteObject(bucketConfig, key, 'restore-me');
+    expect(versionId, 'no soft-deleted version found to restore').toBeTruthy();
+
+    const restored = await restoreDeletedObject(key, versionId as string, {
+      config: bucketConfig,
+    });
+    expect(restored.error).toBeUndefined();
+    expect(restored.data?.path).toBe(key);
+    expect(restored.data?.versionId).toBe(versionId);
+
+    await waitForLiveListing(bucketConfig, key, true);
+    const live = await list({ prefix: key, config: bucketConfig });
+    expect(live.data?.items.map((i) => i.name)).toContain(key);
+  });
+
+  it('purgeDeletedObject() destroys a deleted version for good', async () => {
+    const key = `purge-${Date.now()}.txt`;
+    const versionId = await softDeleteObject(bucketConfig, key, 'purge-me');
+    expect(versionId, 'no soft-deleted version found to purge').toBeTruthy();
+
+    const purged = await purgeDeletedObject(key, versionId as string, {
+      config: bucketConfig,
+    });
+    expect(purged.error).toBeUndefined();
+    expect(purged.data?.path).toBe(key);
+    expect(purged.data?.versionId).toBe(versionId);
+
+    // The version is gone from the soft-delete view, so it can no longer be
+    // restored.
+    const stillThere = await poll(async () => {
+      const found = await deletedVersionOf(bucketConfig, key);
+      return found === versionId ? undefined : false;
+    });
+    expect(stillThere).toBe(false);
+  });
+
+  // Object keys reach the gateway through the AWS SDK here, which signs and
+  // encodes them itself, but this repo has been bitten by key-encoding bugs
+  // that only surface end-to-end against a real signer. Cover both shapes.
+  it.each([
+    ['a nested key', (stamp: number) => `enc-${stamp}/nested/file.txt`],
+    [
+      'a key needing encoding',
+      (stamp: number) => `enc-${stamp}/a file &=+(1).txt`,
+    ],
+  ])('restores and purges %s', async (_label, makeKey) => {
+    const stamp = Date.now();
+
+    const restoreKey = makeKey(stamp);
+    const restoreVersion = await softDeleteObject(bucketConfig, restoreKey);
+    expect(restoreVersion).toBeTruthy();
+
+    const restored = await restoreDeletedObject(
+      restoreKey,
+      restoreVersion as string,
+      { config: bucketConfig }
+    );
+    expect(restored.error).toBeUndefined();
+    await waitForLiveListing(bucketConfig, restoreKey, true);
+    const live = await list({ prefix: restoreKey, config: bucketConfig });
+    expect(live.data?.items.map((i) => i.name)).toContain(restoreKey);
+
+    const purgeKey = `${makeKey(stamp)}.purge`;
+    const purgeVersion = await softDeleteObject(bucketConfig, purgeKey);
+    expect(purgeVersion).toBeTruthy();
+
+    const purged = await purgeDeletedObject(purgeKey, purgeVersion as string, {
+      config: bucketConfig,
+    });
+    expect(purged.error).toBeUndefined();
+
+    const stillThere = await poll(async () => {
+      const found = await deletedVersionOf(bucketConfig, purgeKey);
+      return found === purgeVersion ? undefined : false;
+    });
+    expect(stillThere).toBe(false);
+  });
+
+  it('restoreDeletedObject() and purgeDeletedObject() validate their input', async () => {
+    const missingPath = await restoreDeletedObject('', '1', {
+      config: bucketConfig,
+    });
+    expect(missingPath.error?.message).toBe('Object path is required');
+
+    const missingVersion = await restoreDeletedObject('some-key.txt', '', {
+      config: bucketConfig,
+    });
+    expect(missingVersion.error?.message).toBe('versionId is required');
+
+    const missingPurgePath = await purgeDeletedObject('', '1', {
+      config: bucketConfig,
+    });
+    expect(missingPurgePath.error?.message).toBe('Object path is required');
+
+    const missingPurgeVersion = await purgeDeletedObject('some-key.txt', '', {
+      config: bucketConfig,
+    });
+    expect(missingPurgeVersion.error?.message).toBe('versionId is required');
+  });
+});

--- a/shared/headers.ts
+++ b/shared/headers.ts
@@ -9,6 +9,16 @@ export enum TigrisHeaders {
   /** Prefix for user metadata headers; concatenate with a key, e.g. `${TigrisHeaders.META_PREFIX}author`. */
   META_PREFIX = 'x-amz-meta-',
 
+  /**
+   * Switches an object operation over to the bucket's soft-delete view — the
+   * recoverable copies kept after a delete, rather than the live objects.
+   */
+  SOFT_DELETE = 'X-Tigris-Soft-Delete',
+  /** Which kind of restore to perform, e.g. `soft-delete`. */
+  RESTORE_TYPE = 'X-Tigris-Restore-Type',
+  /** The soft-deleted version to bring back. */
+  RESTORE_VERSION = 'X-Tigris-Restore-Version',
+
   BUCKET_LIST_SOURCE = 'X-Tigris-List-Source', // tigris or shadow
   SCHEDULE_MIGRATION = 'X-Tigris-Schedule-Migration',
   SERVED_FROM = 'X-Tigris-Served-From',


### PR DESCRIPTION
Adds the three missing pieces of the storage API's object-level soft delete: listing deleted objects, restoring one, and purging one for good. SDK first, then the CLI on top.

## SDK (`@tigrisdata/storage`)

```ts
list({ deleted: true })            // the bucket's soft-delete view
listVersions({ deleted: true })    // pick a versionId
restoreDeletedObject(path, versionId)
purgeDeletedObject(path, versionId)
```

All four reuse the existing AWS SDK commands through a new `X-Tigris-Soft-Delete` middleware, mirroring the established `addSnapshotVersionMiddleware` pattern — so `prefix`, `delimiter`, `limit` and `paginationToken` keep working on the deleted view for free.

`restoreObject` was left alone: it thaws GLACIER objects, a genuinely different operation. `restoreDeletedObject` mirrors the existing `restoreBucket` naming instead.

## CLI (`@tigrisdata/cli`)

```
tigris objects list <bucket> --deleted
tigris objects list-versions <bucket> --deleted
tigris objects restore-deleted <bucket> <key> --version-id <id>
tigris objects purge <bucket> <key> --version-id <id>
```

Purge is its own command rather than a flag on `objects delete`, so it carries its own confirmation prompt ("It can no longer be restored"), joins the destructive-commands non-TTY guard, and leaves `objects delete --version-id` with a single meaning. `objects/delete.ts` is unchanged.

## Verified against the live gateway

The API shape was derived from probing `t3.storage.dev`, not from assumption. Three findings changed the design:

- **`deleted: true` replaces the listing rather than adding to it** — the response contains only deleted objects. Documented as such.
- **Purge genuinely needs the header.** `DeleteObject` with a `versionId` and no `x-tigris-soft-delete` returns `400 InvalidArgument` when it targets a soft-deleted version, so a dedicated call was required, not just nicer ergonomics.
- **Restore sends no `RestoreRequest` body** — the gateway keys off the restore-type header. Noted in a code comment so it isn't "fixed" later.

Two caveats are now documented because they can cost data:

- **Enabling soft delete takes a few seconds to reach the data plane.** An object deleted inside that window is gone for good. Measured: a delete at +389ms was hard-deleted; every one from +4.8s on was recoverable.
- **Do not rely on soft delete on snapshot buckets.** Repeated deletes produced no recoverable copies there in testing and the view stayed empty; snapshot buckets already retain deleted objects as versions, recoverable via `listVersions`.

## Incidental fix

A command with a missing required argument printed the reason and then **exited 0**, so a rejected invocation was indistinguishable from a successful one. Affected `tigris objects set --access` and `tigris iam users update-role --role`. It now exits 1 and prints the argument's description, and required flags are marked in the generated command reference (`required` was previously invisible in `--help` and the docs for non-positional arguments).

## Testing

- 8 new SDK integration tests against the real gateway, run with retries disabled across repeated runs. Covers nested keys and keys needing percent-encoding, per the repo's SigV4 encoding pitfall.
- 9 new CLI tests that run **without** credentials, so they execute in CI.
- Storage 215 passed / 9 skipped; CLI 967 passed / 224 skipped.
- Every CLI command was exercised end-to-end against `t3.storage.dev`: list → pick version → restore (object returns to the live listing) → purge (`VERSIONS AFTER=[]`).

Changesets included: `minor` for both packages' features, `patch` for the exit-code fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces permanent purge and restore paths against live object data; behavior is gateway-dependent and documented, but misuse or timing around soft-delete enablement can cause unrecoverable deletes.
> 
> **Overview**
> Adds **object-level soft-delete recovery** to `@tigrisdata/storage` and wires it through `@tigrisdata/cli`, using `X-Tigris-Soft-Delete` / restore-type middleware on existing S3 list/delete/restore commands (same pattern as snapshot headers).
> 
> **SDK:** `list` and `listVersions` accept `deleted: true` for the soft-delete view only (not mixed with live objects). New **`restoreDeletedObject`** and **`purgeDeletedObject`**; purge requires the soft-delete header or the gateway returns `400`. Docs and **AGENTS.md** call out propagation delay after enabling soft delete, separate listing vs versions indexes, snapshot-bucket limitations, and purge vs `remove(..., { versionId })`.
> 
> **CLI:** `--deleted` on `objects list` / `list-versions`; new **`objects restore-deleted`** and **`objects purge`** (purge has confirmation / non-TTY `--yes` like other destructive commands). Specs, README, and doc generation updated.
> 
> **CLI fix:** Missing **required flags** now **exit 1** (was 0), echo the flag description on error, and show **(required)** in generated reference docs — e.g. `objects set --access`, `iam users update-role --role`.
> 
> Integration and CLI validation tests added; changesets for minor SDK/CLI features and patch exit-code fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5d313e9c47cd13b33ce158e60ffbeb46bc386d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->