### PR TITLE
docs: narrow the snapshot-bucket caveat on soft delete

### DIFF
--- a/.changeset/soft-delete-snapshot-caveat.md
+++ b/.changeset/soft-delete-snapshot-caveat.md
@@ -1,0 +1,8 @@
+---
+'@tigrisdata/storage': patch
+'@tigrisdata/cli': patch
+---
+
+Correct the snapshot-bucket caveat on soft delete.
+
+The docs said not to rely on soft delete at all on a snapshot bucket. What actually happens is narrower: a **plain** delete there records a delete marker rather than soft-deleting, so nothing lands in the soft-delete view — but deleting one specific version does soft-delete that version, and it shows up in `list({ deleted: true })` like any other.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,10 +235,13 @@ Other behaviour worth knowing before you debug it as a bug:
   reports it yet. Assert against whichever view the test is about.
 - `retentionDays` must be between 7 and 90; the gateway rejects anything
   outside that range.
-- Soft delete produced no recoverable copies at all on snapshot buckets
-  in testing. Those retain deleted objects as versions and delete
-  markers, recoverable through `listVersions()` and
-  `remove(path, { versionId })` instead.
+- On a snapshot bucket, a **plain** delete records a delete marker
+  rather than soft-deleting, so nothing lands in the soft-delete view
+  and `list({ deleted: true })` stays empty for it — recover those
+  through `listVersions()` on a specific `versionId`. Deleting one
+  specific version *does* soft-delete that version. A test that deletes
+  without a `versionId` on a snapshot bucket and then waits for the
+  soft-delete view will wait forever.
 - To destroy a soft-deleted version use `purgeDeletedObject`, not
   `remove(path, { versionId })` — a versioned delete aimed at a
   soft-deleted version is rejected with `400 InvalidArgument` unless it

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1035,7 +1035,7 @@ tigris objects list <bucket> [flags]
 | `--limit` | Maximum number of items to return per page |
 | `-pt, --page-token` | Pagination token from a previous request to fetch the next page |
 | `--source` | List objects from a specific storage source on buckets with shadow migration enabled |
-| `--deleted` | List soft-deleted objects instead of live ones. Requires soft delete on the bucket. Not the recovery path for snapshot buckets — use "tigris objects list-versions" for those |
+| `--deleted` | List soft-deleted objects instead of live ones. Requires soft delete on the bucket. On a snapshot bucket a plain delete records a delete marker instead, so use "tigris objects list-versions" for those |
 
 **Examples:**
 ```bash

--- a/packages/cli/src/specs.yaml
+++ b/packages/cli/src/specs.yaml
@@ -1492,7 +1492,7 @@ commands:
             description: List objects from a specific storage source on buckets with shadow migration enabled
             options: [tigris, shadow]
           - name: deleted
-            description: List soft-deleted objects instead of live ones. Requires soft delete on the bucket. Not the recovery path for snapshot buckets — use "tigris objects list-versions" for those
+            description: List soft-deleted objects instead of live ones. Requires soft delete on the bucket. On a snapshot bucket a plain delete records a delete marker instead, so use "tigris objects list-versions" for those
             type: flag
       # list-versions
       - name: list-versions

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -505,11 +505,13 @@ you rely on this:
 - **Enabling soft delete takes a few seconds to take effect.** An object
   deleted immediately afterwards is deleted for good, and no amount of
   retrying the lookup brings it back.
-- **Do not rely on soft delete on a snapshot bucket.** On buckets created with
-  `enableSnapshot: true`, repeated deletes produced no recoverable copies in
-  our testing and the soft-delete view stayed empty. Snapshot buckets already
-  retain deleted objects as versions and delete markers, so recover those with
-  `listVersions()` and `remove(path, { versionId })` instead.
+- **On a snapshot bucket, a plain delete is not a soft delete.** Removing an
+  object without a `versionId` records a delete marker, exactly as versioning
+  normally does, and leaves earlier versions live — nothing lands in the
+  soft-delete view. Recover from that with `listVersions()` and
+  `get`/`remove` on a specific `versionId`. Deleting one specific version
+  *does* soft-delete that version, and it shows up in `list({ deleted: true })`
+  like any other.
 
 Recovering an object is a three-step flow: find the deleted keys, pick the
 version to act on, then restore or purge it.

--- a/packages/storage/src/lib/object/list.ts
+++ b/packages/storage/src/lib/object/list.ts
@@ -22,12 +22,12 @@ export type ListOptions = {
    * deleted objects, and live objects are left out entirely.
    *
    * Requires soft delete to be enabled on the bucket
-   * (`updateBucket(name, { softDelete })`). Do not rely on it for snapshot
-   * buckets: this view stayed empty on them in testing, and they retain
-   * deleted objects as versions and delete markers that `listVersions()`
-   * reports instead. To act on an entry here, look up its recoverable
-   * versions with `listVersions({ deleted: true })`, then pass a `versionId`
-   * to `restoreDeletedObject` or `purgeDeletedObject`.
+   * (`updateBucket(name, { softDelete })`). On a snapshot bucket, note that a
+   * plain delete records a delete marker rather than soft-deleting, so those
+   * objects appear in `listVersions()` and not here; deleting one specific
+   * version does soft-delete that version. To act on an entry here, look up
+   * its recoverable versions with `listVersions({ deleted: true })`, then pass
+   * a `versionId` to `restoreDeletedObject` or `purgeDeletedObject`.
    */
   deleted?: boolean;
   config?: TigrisStorageConfig;


### PR DESCRIPTION
Follow-up to #272. The soft-delete docs that shipped there overstated how snapshot buckets behave.

## What was wrong

The docs said, in four places, not to rely on soft delete **at all** on a snapshot bucket:

> **Do not rely on soft delete on a snapshot bucket.** On buckets created with `enableSnapshot: true`, repeated deletes produced no recoverable copies in our testing and the soft-delete view stayed empty.

The measurement behind that was real, but the conclusion generalised from it. The probe only ever issued **plain** deletes — `remove(key)` with no `versionId`. It never tried deleting a specific version on a snapshot bucket, so it could not have seen the case where soft delete does apply.

## What actually happens

Documented authoritatively in [tigris-os-docs#532](https://github.com/tigrisdata/tigris-os-docs/pull/532):

- A **plain** delete on a snapshot bucket records a delete marker, exactly as versioning normally does, and leaves earlier versions live. Nothing lands in the soft-delete view — which is precisely what the probe observed, and is expected behaviour rather than soft delete failing.
- Deleting **one specific version** *does* soft-delete that version, and it appears in `list({ deleted: true })` like any other.

So the observation was right and the explanation was wrong, in a way that would steer people away from a working feature.

## Changes

Corrected in all four places the claim appeared:

- `packages/storage/README.md` — the caveat under "Recovering deleted objects"
- `packages/storage/src/lib/object/list.ts` — the `ListOptions.deleted` JSDoc
- `packages/cli/src/specs.yaml` — the `objects list --deleted` flag description (CLI README regenerated)
- `AGENTS.md` — the "Known pitfalls" entry, which now names the concrete trap: a test that deletes without a `versionId` on a snapshot bucket and then waits on the soft-delete view will wait forever

CHANGELOGs are left alone — they record what shipped in 3.20.0.

## Downstream

`docs/sdks/tigris/api.mdx` in tigris-os-docs is generated from this package's `.d.ts`, so it currently carries the old JSDoc from 3.20.0. It will pick this up on the next release + `npm run build:sdk-api`.

## Testing

Docs and JSDoc only — no behaviour change. Biome clean, both packages typecheck and build, CLI 967 passed / 224 skipped, storage 215 passed / 9 skipped.

One caveat on that last number: an earlier run showed 2 storage failures, and I did not capture the test names before re-running. Three subsequent runs were clean. Those are live-gateway integration tests with known eventual-consistency flakiness, and nothing in this PR touches runtime code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and JSDoc only; no production code paths are modified.
> 
> **Overview**
> Replaces the overstated claim that soft delete should not be relied on **at all** on snapshot buckets with a precise split: **plain** deletes (`remove` without `versionId`) create delete markers and never show up in `list({ deleted: true })`; **version-specific** deletes still soft-delete and appear in the soft-delete view like any other bucket.
> 
> The same corrected guidance is applied in `packages/storage/README.md`, `ListOptions.deleted` JSDoc in `list.ts`, CLI `objects list --deleted` help (`specs.yaml` / README), `AGENTS.md` (including the trap of polling the soft-delete view after a plain delete on a snapshot bucket), and a patch changeset for `@tigrisdata/storage` and `@tigrisdata/cli`. No runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88c105f55a7e073593ace8934af79c9491fadfa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->