### PR TITLE
feat(iam): add ReadWrite role and centralize access key role types

### DIFF
--- a/.changeset/read-write-role.md
+++ b/.changeset/read-write-role.md
@@ -1,0 +1,23 @@
+---
+'@tigrisdata/iam': minor
+'@tigrisdata/agent-kit': minor
+'@tigrisdata/cli': minor
+---
+
+Add the `ReadWrite` access key role and centralize role types in `@tigrisdata/iam`.
+
+`ReadWrite` grants object read and write on a bucket, sitting between `ReadOnly`
+and `Editor`. It is accepted anywhere a bucket role is — `assignBucketRoles`,
+`createAccessKey`, `tigris access-keys assign --role ReadWrite`, and the
+`credentials.role` option on agent-kit's `createWorkspace` / `createForks`.
+
+The role union previously lived as four inline string-literal types in `iam` plus
+duplicated copies in `cli` and `agent-kit`, which had already drifted apart. It
+now lives once in `packages/iam/src/lib/access-key/types.ts` and is exported from
+the package root as `AccessKeyRole`, with `ACCESS_KEY_ROLES` for runtime
+validation and `BucketRoleAssignment` for `{ bucket, role }` pairs. The shared
+`AccessKey` and IAM list-response types moved to the same module.
+
+This also fixes a type fidelity bug: `createAccessKey`'s `bucketsRole` option and
+the raw IAM list response both excluded `NamespaceAdmin`, even though the API
+accepts and returns it in that field.

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.10/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/packages/agent-kit/src/forks.ts
+++ b/packages/agent-kit/src/forks.ts
@@ -1,5 +1,9 @@
 import type { TigrisResponse } from '@shared/types';
-import { createAccessKey, removeAccessKey } from '@tigrisdata/iam';
+import {
+  type BucketScopedRole,
+  createAccessKey,
+  removeAccessKey,
+} from '@tigrisdata/iam';
 import {
   createBucket,
   createBucketSnapshot,
@@ -14,7 +18,7 @@ export type CreateForksOptions = {
   prefix?: string;
   /** If provided, creates a scoped access key per fork with this role. */
   credentials?: {
-    role: 'Editor' | 'ReadOnly';
+    role: BucketScopedRole;
   };
   config?: TigrisAgentKitConfig;
 };

--- a/packages/agent-kit/src/workspace.ts
+++ b/packages/agent-kit/src/workspace.ts
@@ -1,5 +1,9 @@
 import type { TigrisResponse } from '@shared/types';
-import { createAccessKey, removeAccessKey } from '@tigrisdata/iam';
+import {
+  type BucketScopedRole,
+  createAccessKey,
+  removeAccessKey,
+} from '@tigrisdata/iam';
 import { createBucket, removeBucket, setBucketTtl } from '@tigrisdata/storage';
 import type { TigrisAgentKitConfig } from './config';
 
@@ -14,7 +18,7 @@ export type CreateWorkspaceOptions = {
   enableSnapshots?: boolean;
   /** If provided, creates a scoped access key with this role. */
   credentials?: {
-    role: 'Editor' | 'ReadOnly';
+    role: BucketScopedRole;
   };
   config?: TigrisAgentKitConfig;
 };

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1295,7 +1295,7 @@ Create, list, inspect, delete, and assign roles to access keys. Access keys are 
 | `tigris access-keys create` (c) | Create a new access key with the given name. Returns the key ID and secret (shown only once) |
 | `tigris access-keys delete` (d) | Permanently delete an access key by its ID. This revokes all access immediately |
 | `tigris access-keys get` (g) | Show details for an access key including its name, creation date, and assigned bucket roles |
-| `tigris access-keys assign` (a) | Assign per-bucket roles to an access key. Pair each --bucket with a --role (Editor or ReadOnly), or use --admin for org-wide access |
+| `tigris access-keys assign` (a) | Assign per-bucket roles to an access key. Pair each --bucket with a --role (Editor, ReadWrite, or ReadOnly), or use --admin for org-wide access |
 | `tigris access-keys rotate` (r) | Rotate an access key's secret. The current secret is immediately invalidated and a new one is returned (shown only once) |
 | `tigris access-keys attach-policy` (ap) | Attach an IAM policy to an access key. If no policy ARN is provided, shows interactive selection of available policies |
 | `tigris access-keys detach-policy` (dp) | Detach an IAM policy from an access key. If no policy ARN is provided, shows interactive selection of attached policies |
@@ -1365,7 +1365,7 @@ tigris access-keys get tid_AaBbCcDdEeFf
 
 #### `tigris access-keys assign` (a)
 
-Assign per-bucket roles to an access key. Pair each --bucket with a --role (Editor or ReadOnly), or use --admin for org-wide access
+Assign per-bucket roles to an access key. Pair each --bucket with a --role (Editor, ReadWrite, or ReadOnly), or use --admin for org-wide access
 
 ```
 tigris access-keys assign <id> [flags]

--- a/packages/cli/src/lib/access-keys/assign.ts
+++ b/packages/cli/src/lib/access-keys/assign.ts
@@ -1,5 +1,11 @@
 import { getIAMConfig } from '@auth/iam.js';
-import { assignBucketRoles, revokeAllBucketRoles } from '@tigrisdata/iam';
+import {
+  ACCESS_KEY_ROLES,
+  type AccessKeyRole,
+  assignBucketRoles,
+  type BucketRoleAssignment,
+  revokeAllBucketRoles,
+} from '@tigrisdata/iam';
 import {
   failWithError,
   getSuccessNextActions,
@@ -9,9 +15,6 @@ import { msg, printStart, printSuccess } from '@utils/messages.js';
 import { getFormat, getOption } from '@utils/options.js';
 
 const context = msg('access-keys', 'assign');
-
-type Role = 'Editor' | 'ReadOnly' | 'NamespaceAdmin';
-const validRoles: Role[] = ['Editor', 'ReadOnly', 'NamespaceAdmin'];
 
 function normalizeToArray<T>(value: T | T[] | undefined): T[] {
   if (!value) return [];
@@ -61,7 +64,7 @@ export default async function assign(options: Record<string, unknown>) {
     return;
   }
 
-  let assignments: { bucket: string; role: Role }[];
+  let assignments: BucketRoleAssignment[];
 
   if (admin) {
     // Admin access: grant NamespaceAdmin to all buckets
@@ -83,10 +86,10 @@ export default async function assign(options: Record<string, unknown>) {
 
     // Validate all roles
     for (const role of roles) {
-      if (!validRoles.includes(role as Role)) {
+      if (!ACCESS_KEY_ROLES.includes(role as AccessKeyRole)) {
         failWithError(
           context,
-          `Invalid role "${role}". Valid roles are: ${validRoles.join(', ')}`
+          `Invalid role "${role}". Valid roles are: ${ACCESS_KEY_ROLES.join(', ')}`
         );
       }
     }
@@ -96,13 +99,13 @@ export default async function assign(options: Record<string, unknown>) {
       // Single role applies to all buckets
       assignments = buckets.map((bucket) => ({
         bucket,
-        role: roles[0] as Role,
+        role: roles[0] as AccessKeyRole,
       }));
     } else if (roles.length === buckets.length) {
       // Pair buckets with roles
       assignments = buckets.map((bucket, i) => ({
         bucket,
-        role: roles[i] as Role,
+        role: roles[i] as AccessKeyRole,
       }));
     } else {
       failWithError(

--- a/packages/cli/src/lib/presign.ts
+++ b/packages/cli/src/lib/presign.ts
@@ -155,11 +155,13 @@ export function keyMatchesOperation(
     // Role must target this bucket or wildcard
     if (r.bucket !== targetBucket && r.bucket !== '*') return false;
 
-    // For put: need Editor
-    if (method === 'put') return r.role === 'Editor';
+    // For put: need write access
+    if (method === 'put') return r.role === 'Editor' || r.role === 'ReadWrite';
 
-    // For get: Editor or ReadOnly
-    return r.role === 'Editor' || r.role === 'ReadOnly';
+    // For get: any bucket-scoped role grants read
+    return (
+      r.role === 'Editor' || r.role === 'ReadWrite' || r.role === 'ReadOnly'
+    );
   });
 }
 
@@ -181,7 +183,10 @@ async function resolveAccessKeyAuto(
   );
 
   if (!match) {
-    const requiredRole = method === 'put' ? 'Editor' : 'Editor or ReadOnly';
+    const requiredRole =
+      method === 'put'
+        ? 'Editor or ReadWrite'
+        : 'Editor, ReadWrite, or ReadOnly';
     exitWithError(
       `No access key with ${requiredRole} access to bucket "${targetBucket}" found.\n` +
         `Create one: tigris access-keys create <name>\n` +

--- a/packages/cli/src/specs.yaml
+++ b/packages/cli/src/specs.yaml
@@ -1965,7 +1965,7 @@ commands:
             examples:
               - tid_AaBbCcDdEeFf
       - name: assign
-        description: Assign per-bucket roles to an access key. Pair each --bucket with a --role (Editor or ReadOnly), or use --admin for org-wide access
+        description: Assign per-bucket roles to an access key. Pair each --bucket with a --role (Editor, ReadWrite, or ReadOnly), or use --admin for org-wide access
         alias: a
         examples:
           - "tigris access-keys assign tid_AaBb --bucket my-bucket --role Editor"
@@ -1996,6 +1996,7 @@ commands:
             multiple: true
             options:
               - Editor
+              - ReadWrite
               - ReadOnly
           - name: admin
             description: Grant admin access to all buckets in the organization

--- a/packages/cli/test/lib/presign.test.ts
+++ b/packages/cli/test/lib/presign.test.ts
@@ -39,6 +39,21 @@ describe('keyMatchesOperation', () => {
       expect(keyMatchesOperation(key, 'my-bucket', 'get')).toBe(true);
     });
 
+    it('matches ReadWrite on target bucket', () => {
+      const key = makeKey([{ bucket: 'my-bucket', role: 'ReadWrite' }]);
+      expect(keyMatchesOperation(key, 'my-bucket', 'get')).toBe(true);
+    });
+
+    it('matches ReadWrite on wildcard bucket', () => {
+      const key = makeKey([{ bucket: '*', role: 'ReadWrite' }]);
+      expect(keyMatchesOperation(key, 'my-bucket', 'get')).toBe(true);
+    });
+
+    it('does not match ReadWrite on different bucket', () => {
+      const key = makeKey([{ bucket: 'other-bucket', role: 'ReadWrite' }]);
+      expect(keyMatchesOperation(key, 'my-bucket', 'get')).toBe(false);
+    });
+
     it('does not match Editor on different bucket', () => {
       const key = makeKey([{ bucket: 'other-bucket', role: 'Editor' }]);
       expect(keyMatchesOperation(key, 'my-bucket', 'get')).toBe(false);
@@ -63,6 +78,21 @@ describe('keyMatchesOperation', () => {
 
     it('does not match ReadOnly on wildcard bucket', () => {
       const key = makeKey([{ bucket: '*', role: 'ReadOnly' }]);
+      expect(keyMatchesOperation(key, 'my-bucket', 'put')).toBe(false);
+    });
+
+    it('matches ReadWrite on target bucket', () => {
+      const key = makeKey([{ bucket: 'my-bucket', role: 'ReadWrite' }]);
+      expect(keyMatchesOperation(key, 'my-bucket', 'put')).toBe(true);
+    });
+
+    it('matches ReadWrite on wildcard bucket', () => {
+      const key = makeKey([{ bucket: '*', role: 'ReadWrite' }]);
+      expect(keyMatchesOperation(key, 'my-bucket', 'put')).toBe(true);
+    });
+
+    it('does not match ReadWrite on different bucket', () => {
+      const key = makeKey([{ bucket: 'other-bucket', role: 'ReadWrite' }]);
       expect(keyMatchesOperation(key, 'my-bucket', 'put')).toBe(false);
     });
   });

--- a/packages/iam/src/index.ts
+++ b/packages/iam/src/index.ts
@@ -19,7 +19,6 @@ export {
 } from './lib/access-key/create';
 export { type GetAccessKeyOptions, getAccessKey } from './lib/access-key/get';
 export {
-  type AccessKey,
   type ListAccessKeysOptions,
   type ListAccessKeysResponse,
   listAccessKeys,
@@ -46,6 +45,13 @@ export {
   type RotateAccessKeyResponse,
   rotateAccessKey,
 } from './lib/access-key/rotate';
+export {
+  ACCESS_KEY_ROLES,
+  type AccessKey,
+  type AccessKeyRole,
+  type BucketRoleAssignment,
+  type BucketScopedRole,
+} from './lib/access-key/types';
 export {
   type CreateOrganizationOptions,
   type CreateOrganizationResponse,

--- a/packages/iam/src/lib/access-key/assign.ts
+++ b/packages/iam/src/lib/access-key/assign.ts
@@ -1,6 +1,7 @@
 import { createIAMClient, IAM_ENDPOINTS } from '../http-client';
 import type { TigrisIAMConfig, TigrisIAMResponse } from '../types';
 import { getAccessKey } from './get';
+import type { BucketRoleAssignment } from './types';
 
 export type AssignBucketRolesOptions = {
   config?: TigrisIAMConfig;
@@ -11,7 +12,7 @@ export type AssignBucketRolesOptions = {
 */
 export async function assignBucketRoles(
   id: string,
-  roles: { bucket: string; role: 'Editor' | 'ReadOnly' | 'NamespaceAdmin' }[],
+  roles: BucketRoleAssignment[],
   options?: AssignBucketRolesOptions
 ): Promise<TigrisIAMResponse<void, Error>> {
   const { data: client, error } = createIAMClient(options?.config);

--- a/packages/iam/src/lib/access-key/create.ts
+++ b/packages/iam/src/lib/access-key/create.ts
@@ -1,14 +1,11 @@
 import { randomUUID } from 'node:crypto';
 import { createIAMClient, IAM_ENDPOINTS } from '../http-client';
 import type { TigrisIAMConfig, TigrisIAMResponse } from '../types';
-import type { AccessKey } from './list';
+import type { AccessKey, BucketRoleAssignment } from './types';
 
 export type CreateAccessKeyOptions = {
   config?: TigrisIAMConfig;
-  bucketsRole?: {
-    bucket: string;
-    role: 'Editor' | 'ReadOnly';
-  }[];
+  bucketsRole?: BucketRoleAssignment[];
 };
 
 type IAMCreateAccessKeyResponse = {

--- a/packages/iam/src/lib/access-key/get.ts
+++ b/packages/iam/src/lib/access-key/get.ts
@@ -1,6 +1,6 @@
 import { createIAMClient, IAM_ENDPOINTS } from '../http-client';
 import type { TigrisIAMConfig, TigrisIAMResponse } from '../types';
-import type { AccessKey, IAMAccessKeysResponse } from './list';
+import type { AccessKey, IAMAccessKeysResponse } from './types';
 
 export type GetAccessKeyOptions = {
   config?: TigrisIAMConfig;

--- a/packages/iam/src/lib/access-key/list.ts
+++ b/packages/iam/src/lib/access-key/list.ts
@@ -1,5 +1,6 @@
 import { createIAMClient, IAM_ENDPOINTS } from '../http-client';
 import type { TigrisIAMConfig, TigrisIAMResponse } from '../types';
+import type { AccessKey, IAMAccessKeysResponse } from './types';
 
 export type ListAccessKeysOptions = {
   limit?: number;
@@ -7,41 +8,10 @@ export type ListAccessKeysOptions = {
   config?: TigrisIAMConfig;
 };
 
-export type AccessKey = {
-  id: string;
-  name: string;
-  secret?: string;
-  createdAt: Date;
-  status: 'active' | 'inactive';
-  organizationId?: string;
-  roles?: {
-    bucket: string;
-    role: 'Editor' | 'ReadOnly' | 'NamespaceAdmin';
-  }[];
-};
-
 export type ListAccessKeysResponse = {
   accessKeys: AccessKey[];
   paginationToken?: string;
   hasMore: boolean;
-};
-
-export type IAMAccessKeysResponse = {
-  IsTruncated: boolean;
-  Marker: string;
-  Keys: {
-    access_key_id: string;
-    created_at: string;
-    creator: string;
-    human_creator: string;
-    namespace_id: string;
-    status: 'active' | 'inactive';
-    username: string;
-    buckets_role: {
-      bucket: string;
-      role: 'Editor' | 'ReadOnly';
-    }[];
-  }[];
 };
 
 export async function listAccessKeys(

--- a/packages/iam/src/lib/access-key/types.ts
+++ b/packages/iam/src/lib/access-key/types.ts
@@ -1,0 +1,54 @@
+/**
+ * Roles that can be granted to an access key on a bucket.
+ *
+ * `NamespaceAdmin` is org-wide and is only valid when paired with the `*`
+ * wildcard bucket — see `assignBucketRoles` for the enforcement.
+ */
+export const ACCESS_KEY_ROLES = [
+  'ReadOnly',
+  'ReadWrite',
+  'Editor',
+  'NamespaceAdmin',
+] as const;
+
+export type AccessKeyRole = (typeof ACCESS_KEY_ROLES)[number];
+
+/**
+ * Roles that are valid on a concrete (non-wildcard) bucket.
+ *
+ * `NamespaceAdmin` is excluded: it is org-wide and only meaningful paired with
+ * the `*` bucket, so it cannot be granted on a single named bucket.
+ */
+export type BucketScopedRole = Exclude<AccessKeyRole, 'NamespaceAdmin'>;
+
+/** A single bucket-scoped role grant on an access key. */
+export type BucketRoleAssignment = {
+  bucket: string;
+  role: AccessKeyRole;
+};
+
+export type AccessKey = {
+  id: string;
+  name: string;
+  secret?: string;
+  createdAt: Date;
+  status: 'active' | 'inactive';
+  organizationId?: string;
+  roles?: BucketRoleAssignment[];
+};
+
+/** Raw IAM `ListAccessKeys` response, shared by `list` and `get`. */
+export type IAMAccessKeysResponse = {
+  IsTruncated: boolean;
+  Marker: string;
+  Keys: {
+    access_key_id: string;
+    created_at: string;
+    creator: string;
+    human_creator: string;
+    namespace_id: string;
+    status: 'active' | 'inactive';
+    username: string;
+    buckets_role: BucketRoleAssignment[];
+  }[];
+};


### PR DESCRIPTION
## What

Adds the `ReadWrite` access key role, and makes `@tigrisdata/iam` the single source of truth for role types instead of the six inline copies scattered across three packages.

`ReadWrite` grants object read and write on a bucket, sitting between `ReadOnly` and `Editor`. It is accepted anywhere a bucket role is:

- `assignBucketRoles()` and `createAccessKey()` in `@tigrisdata/iam`
- `tigris access-keys assign <id> --bucket <b> --role ReadWrite`
- `credentials.role` on agent-kit's `createWorkspace()` / `createForks()`

## Why the type moved

The union was declared inline in **four** places in `iam` and duplicated again in `cli` and `agent-kit`. The copies had already drifted apart, which is how the bug below survived. Adding a fifth role should mean editing one file, not six.

It now lives in `packages/iam/src/lib/access-key/types.ts`, following the existing `policy/types.ts` and `users/types.ts` precedent — pure domain types there, `*Options`/`*Response` stay beside their functions. Exported from the package root as:

| Export | Purpose |
| --- | --- |
| `AccessKeyRole` | The flat union, derived from the const array |
| `ACCESS_KEY_ROLES` | `readonly` tuple for runtime validation |
| `BucketRoleAssignment` | The `{ bucket, role }` pair, previously written longhand in 4 places |

The type is derived from a const array rather than declared as a bare union because the CLI needs a **runtime** list for `validRoles.includes(…)` and its `Valid roles are: …` error message. A type-only export would have forced the CLI to keep its own hardcoded copy, defeating the purpose.

`iam` is the right home rather than `storage`: roles are an IAM concept, `iam` is the dependency-graph leaf (no workspace deps), and both `cli` and `agent-kit` already depend on it — so this costs **zero new dependencies**. Routing it through `storage` would have forced `iam` to depend on `storage` and drag the AWS SDK into a package that currently has none.

`AccessKey` and `IAMAccessKeysResponse` moved to the same module — both lived in `list.ts` and were already imported by `get.ts`/`create.ts`, so they were folder-shared in practice.

## Bug fixed along the way

`createAccessKey`'s `bucketsRole` option and the raw `IAMAccessKeysResponse.buckets_role` wire type both excluded `NamespaceAdmin` — even though `assignBucketRoles` explicitly *sends* it in that field and the API returns it. The public `AccessKey.roles` silently widened it back. All three now agree.

## Behavior change worth a look

`presign.ts` gated presigned `put` on `role === 'Editor'`. That would have rejected valid `ReadWrite` keys, so it now accepts `Editor || ReadWrite`; `get` accepts any of the three bucket-scoped roles. This is the one place the new role changes runtime behavior rather than just widening a type.

Note `NamespaceAdmin` remains out of the `--role` choices in `specs.yaml` (it is reachable via `--admin`), while `ACCESS_KEY_ROLES.includes()` still accepts it — matching the previous `validRoles` behavior exactly.

## Compatibility

No public API break. `AccessKey` still exports from the package root, just from a different module — verified in the built `dist/index.d.ts`. Widening `AccessKey.roles` is non-breaking unless a consumer switches exhaustively over the union.

## Testing

- Full `pnpm build` across all 7 packages + the playground app — green
- `tsc --noEmit` clean on `iam`, `cli`, `agent-kit`
- 939 CLI unit tests pass across 30 files, including `specs-completeness.test.ts` which validates `specs.yaml`
- `presign.test.ts` 16 → 22 tests; added `ReadWrite` coverage for `get`, `put`, wildcard, and wrong-bucket cases, since no existing test exercised the new role
- `biome check` clean across 196 files
- `packages/cli/README.md` regenerated via `pnpm updatedocs` rather than hand-edited

Live integration suites (`cli.test.ts`, agent-kit `integration.test.ts`) were not run locally — they need real credentials, so they run in CI.

Changeset included: `iam` / `agent-kit` / `cli` all `minor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes IAM/access-key typing and presign key-matching logic; incorrect role handling could block valid keys or widen signing eligibility, though scope is limited to SDK/CLI/agent-kit.
> 
> **Overview**
> Introduces the **`ReadWrite`** access key role (object read/write on a bucket, between `ReadOnly` and `Editor`) and wires it through IAM APIs, **`tigris access-keys assign --role ReadWrite`**, agent-kit **`credentials.role`** on `createWorkspace` / `createForks`, and **`createAccessKey` / `assignBucketRoles`**.
> 
> Access key role types move to a single module in **`@tigrisdata/iam`** (`AccessKeyRole`, `ACCESS_KEY_ROLES`, `BucketRoleAssignment`, `BucketScopedRole`, plus shared `AccessKey` / IAM list types). The CLI drops its local `validRoles` list in favor of **`ACCESS_KEY_ROLES`**; agent-kit widens credential roles from `Editor | ReadOnly` to **`BucketScopedRole`**.
> 
> **Type fix:** `createAccessKey`’s `bucketsRole` and the raw IAM `buckets_role` wire type now include **`NamespaceAdmin`**, matching what assign/list already handle.
> 
> **Runtime behavior:** **`presign`** auto-key selection treats **`ReadWrite`** like write-capable for `put` and read-capable for `get` (previously only `Editor` could presign puts). Docs/specs and **`presign.test.ts`** cover the new role.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2949801ba4bd4cad7f4aa0ca1fd91509d019d98a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->