### PR TITLE
feat: add bucket sharing to the SDK and CLI

### DIFF
--- a/.changeset/share-bucket-cli.md
+++ b/.changeset/share-bucket-cli.md
@@ -1,0 +1,28 @@
+---
+'@tigrisdata/cli': minor
+---
+
+Add `tigris buckets share` and show shares in `tigris buckets get`.
+
+```bash
+tigris buckets share my-bucket --organization --role ReadOnly
+tigris buckets share my-bucket --team tmid_MQQUhV --role Editor
+tigris buckets share my-bucket --user uid_MQQUhV --role ReadOnly
+tigris buckets share my-bucket --team tmid_A,tmid_B --role Editor,ReadOnly
+tigris buckets share my-bucket --reset
+```
+
+`--organization` gives access to everyone in your organization and takes exactly
+one `--role`. `--team` and `--user` accept comma-separated IDs; a single `--role`
+applies to all of them, otherwise roles pair positionally.
+
+Use one of `--organization`, `--team`, or `--user` per invocation. Because
+shares merge by default, granting to more than one kind of target is just
+running the command more than once.
+
+Shares merge by default — a grant for a target you name is updated, and targets
+you do not name keep their access. Pass `--override` to replace the list
+outright, or `--reset` to remove every share.
+
+`tigris buckets get` now shows a `Shared With` row listing the organization
+grant first, then teams, then users.

--- a/.changeset/share-bucket.md
+++ b/.changeset/share-bucket.md
@@ -1,0 +1,35 @@
+---
+'@tigrisdata/storage': minor
+---
+
+Add `shareBucket()` and expose bucket shares on `getBucketInfo()`.
+
+`shareBucket()` grants access to your whole organization, to specific teams, or
+to specific users:
+
+```ts
+await shareBucket('my-bucket', {
+  organization: { role: 'ReadOnly' },
+  team: [{ teamId: 'tmid_MQQUhV', role: 'Editor' }],
+  user: [{ userId: 'uid_MQQUhV', role: 'ReadOnly' }],
+});
+```
+
+Shares **merge** by default: a target you name has its role updated, and targets
+you do not name keep their access. Granting one team access therefore cannot
+silently revoke your organization-wide grant. This costs a `getBucketInfo` call,
+and a failure to read the current shares is surfaced rather than writing a
+truncated list.
+
+Pass `override: true` to make the shares you provide the complete list — anything
+omitted loses access — and `{ override: true, team: [], user: [] }` to remove
+every share. A call with no targets at all is rejected rather than treated as a
+clear.
+
+`getBucketInfo()` returns `settings.shares` in the same shape: `team` and `user`
+are always arrays (empty when nothing is shared that way) and `organization` is
+absent unless the bucket is shared org-wide.
+
+Roles are `ReadOnly`, `ReadWrite`, or `Editor`, typed as `BucketShareRole`. The
+org-wide `NamespaceAdmin` role is not accepted: a share always targets one
+concrete bucket.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -541,6 +541,7 @@ Create, inspect, update, and delete buckets. Buckets are top-level containers th
 | `tigris buckets lifecycle` (lc) | Manage bucket lifecycle rules. Each rule combines an optional storage-class transition and/or expiration (TTL), scoped to an optional key prefix |
 | `tigris buckets set-notifications` | Configure object event notifications on a bucket. Sends webhook requests to a URL when objects are created, updated, or deleted |
 | `tigris buckets set-cors` | Configure CORS rules on a bucket. Each invocation adds a rule unless --override or --reset is used |
+| `tigris buckets share` | Share a bucket with your whole organization, specific teams, or specific users. Existing shares are kept unless --override or --reset is used |
 
 #### `tigris buckets list` (l)
 
@@ -936,6 +937,33 @@ tigris buckets set-cors my-bucket --origins '*' --methods GET,HEAD
 tigris buckets set-cors my-bucket --origins https://example.com --methods GET,POST --headers Content-Type,Authorization --max-age 3600
 tigris buckets set-cors my-bucket --origins https://example.com --override
 tigris buckets set-cors my-bucket --reset
+```
+
+#### `tigris buckets share`
+
+Share a bucket with your whole organization, specific teams, or specific users. Existing shares are kept unless --override or --reset is used
+
+```
+tigris buckets share <name> [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `-org, --organization` | Give access to everyone in your organization. Takes exactly one --role and cannot be combined with --team or --user |
+| `-t, --team` | Team ID to share with (can specify multiple, comma-separated). Each team is paired positionally with a --role value |
+| `-u, --user` | User ID to share with (can specify multiple, comma-separated). Each user is paired positionally with a --role value |
+| `-r, --role` | Role to grant (can specify multiple, comma-separated). A single role applies to every target; otherwise each role pairs with the corresponding --team or --user value |
+| `--override` | Replace all existing shares instead of merging with them |
+| `--reset` | Remove all shares from the bucket |
+
+**Examples:**
+```bash
+tigris buckets share my-bucket --organization --role ReadOnly
+tigris buckets share my-bucket --team tmid_MQQUhV --role Editor
+tigris buckets share my-bucket --user uid_MQQUhV --role ReadOnly
+tigris buckets share my-bucket --team tmid_A,tmid_B --role Editor,ReadOnly
+tigris buckets share my-bucket --team tmid_MQQUhV --role Editor --override
+tigris buckets share my-bucket --reset
 ```
 
 ### `tigris snapshots` (s)

--- a/packages/cli/src/lib/buckets/share.ts
+++ b/packages/cli/src/lib/buckets/share.ts
@@ -1,0 +1,140 @@
+import { getStorageConfigWithOrg } from '@auth/provider.js';
+import {
+  type BucketShareRole,
+  type BucketSharesInput,
+  shareBucket,
+} from '@tigrisdata/storage';
+import { failWithError } from '@utils/exit.js';
+import { msg, printStart, printSuccess } from '@utils/messages.js';
+import { getFormat, getOption } from '@utils/options.js';
+
+const context = msg('buckets', 'share');
+
+const validRoles: BucketShareRole[] = ['ReadOnly', 'ReadWrite', 'Editor'];
+
+function normalizeToArray(value: string | string[] | undefined): string[] {
+  if (!value) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+export default async function share(options: Record<string, unknown>) {
+  printStart(context);
+
+  const format = getFormat(options);
+
+  const name = getOption<string>(options, ['name']);
+  const organization = getOption<boolean>(options, ['organization', 'org']);
+  const teams = normalizeToArray(
+    getOption<string | string[]>(options, ['team', 't'])
+  );
+  const users = normalizeToArray(
+    getOption<string | string[]>(options, ['user', 'u'])
+  );
+  const roles = normalizeToArray(
+    getOption<string | string[]>(options, ['role', 'r'])
+  );
+  const override = getOption<boolean>(options, ['override']);
+  const reset = getOption<boolean>(options, ['reset']);
+
+  if (!name) {
+    failWithError(context, 'Bucket name is required');
+  }
+
+  const targets = [
+    organization ? 'organization' : undefined,
+    teams.length > 0 ? 'team' : undefined,
+    users.length > 0 ? 'user' : undefined,
+  ].filter(Boolean);
+
+  if (reset) {
+    if (targets.length > 0 || roles.length > 0 || override) {
+      failWithError(context, 'Cannot use --reset with other options');
+    }
+  } else {
+    if (targets.length === 0) {
+      failWithError(
+        context,
+        'Provide --organization, --team, --user, or --reset'
+      );
+    }
+
+    if (targets.length > 1) {
+      failWithError(
+        context,
+        `Use only one of --organization, --team, or --user at a time (got ${targets.join(', ')}). Shares merge by default, so run the command once per target.`
+      );
+    }
+
+    if (roles.length === 0) {
+      failWithError(context, 'At least one --role is required');
+    }
+
+    for (const role of roles) {
+      if (!validRoles.includes(role as BucketShareRole)) {
+        failWithError(
+          context,
+          `Invalid role "${role}". Valid roles are: ${validRoles.join(', ')}`
+        );
+      }
+    }
+  }
+
+  const ids = teams.length > 0 ? teams : users;
+
+  if (
+    !reset &&
+    !organization &&
+    roles.length !== 1 &&
+    roles.length !== ids.length
+  ) {
+    failWithError(
+      context,
+      `Number of roles (${roles.length}) must be 1 or match number of ${targets[0]}s (${ids.length})`
+    );
+  }
+
+  if (!reset && organization && roles.length !== 1) {
+    failWithError(context, '--organization takes exactly one --role');
+  }
+
+  const finalConfig = await getStorageConfigWithOrg();
+
+  const roleAt = (i: number) =>
+    (roles.length === 1 ? roles[0] : roles[i]) as BucketShareRole;
+
+  const shares: BucketSharesInput = reset
+    ? { team: [], user: [] }
+    : {
+        ...(organization ? { organization: { role: roleAt(0) } } : {}),
+        ...(teams.length > 0
+          ? { team: teams.map((teamId, i) => ({ teamId, role: roleAt(i) })) }
+          : {}),
+        ...(users.length > 0
+          ? { user: users.map((userId, i) => ({ userId, role: roleAt(i) })) }
+          : {}),
+      };
+
+  // `shareBucket` merges by default; --override and --reset both replace the
+  // whole list, --reset with nothing in it.
+  const { error } = await shareBucket(name, {
+    ...shares,
+    override: reset || override === true,
+    config: finalConfig,
+  });
+
+  if (error) {
+    failWithError(context, error);
+  }
+
+  if (format === 'json') {
+    console.log(
+      JSON.stringify({
+        action: reset ? 'reset' : 'shared',
+        bucket: name,
+        shares,
+      })
+    );
+  }
+
+  printSuccess(context, { name });
+}

--- a/packages/cli/src/specs.yaml
+++ b/packages/cli/src/specs.yaml
@@ -1330,6 +1330,54 @@ commands:
             description: Clear all CORS rules on the bucket
             type: flag
 
+      # share
+      - name: share
+        description: Share a bucket with your whole organization, specific teams, or specific users. Existing shares are kept unless --override or --reset is used
+        examples:
+          - "tigris buckets share my-bucket --organization --role ReadOnly"
+          - "tigris buckets share my-bucket --team tmid_MQQUhV --role Editor"
+          - "tigris buckets share my-bucket --user uid_MQQUhV --role ReadOnly"
+          - "tigris buckets share my-bucket --team tmid_A,tmid_B --role Editor,ReadOnly"
+          - "tigris buckets share my-bucket --team tmid_MQQUhV --role Editor --override"
+          - "tigris buckets share my-bucket --reset"
+        messages:
+          onStart: 'Updating bucket shares...'
+          onSuccess: 'Shares updated for bucket {{name}}'
+          onFailure: 'Failed to update bucket shares'
+        arguments:
+          - name: name
+            description: Name of the bucket
+            type: positional
+            required: true
+            examples:
+              - my-bucket
+          - name: organization
+            alias: org
+            description: Give access to everyone in your organization. Takes exactly one --role and cannot be combined with --team or --user
+            type: flag
+          - name: team
+            alias: t
+            description: Team ID to share with (can specify multiple, comma-separated). Each team is paired positionally with a --role value
+            multiple: true
+          - name: user
+            alias: u
+            description: User ID to share with (can specify multiple, comma-separated). Each user is paired positionally with a --role value
+            multiple: true
+          - name: role
+            alias: r
+            description: Role to grant (can specify multiple, comma-separated). A single role applies to every target; otherwise each role pairs with the corresponding --team or --user value
+            multiple: true
+            options:
+              - ReadOnly
+              - ReadWrite
+              - Editor
+          - name: override
+            description: Replace all existing shares instead of merging with them
+            type: flag
+          - name: reset
+            description: Remove all shares from the bucket
+            type: flag
+
   #########################
   # Manage forks (removed)
   #########################

--- a/packages/cli/src/utils/bucket-info.ts
+++ b/packages/cli/src/utils/bucket-info.ts
@@ -146,6 +146,19 @@ export function buildBucketInfo(data: BucketInfoResponse) {
     });
   }
 
+  const shares = data.settings.shares;
+  const sharedWith = [
+    ...(shares.organization
+      ? [`Everyone in organization (${shares.organization.role})`]
+      : []),
+    ...shares.team.map((t) => `${t.teamId} (${t.role})`),
+    ...shares.user.map((u) => `${u.userId} (${u.role})`),
+  ];
+
+  if (sharedWith.length) {
+    info.push({ label: 'Shared With', value: sharedWith.join(', ') });
+  }
+
   if (data.settings.notifications) {
     info.push({
       label: 'Notifications',

--- a/packages/cli/test/utils/bucket-info.test.ts
+++ b/packages/cli/test/utils/bucket-info.test.ts
@@ -19,6 +19,7 @@ function makeResponse(overrides: Record<string, unknown> = {}) {
       softDelete: { enabled: false },
       allowObjectAcl: false,
       corsRules: [],
+      shares: { team: [], user: [] },
       customDomain: undefined,
       additionalHeaders: undefined,
       lifecycleRules: undefined,

--- a/packages/cli/test/utils/bucket-info.test.ts
+++ b/packages/cli/test/utils/bucket-info.test.ts
@@ -328,6 +328,62 @@ describe('buildBucketInfo', () => {
     });
   });
 
+  describe('shares', () => {
+    it('does not add shares when nothing is shared', () => {
+      const info = buildBucketInfo(makeResponse());
+      expect(findValue(info, 'Shared With')).toBeUndefined();
+    });
+
+    it('names the organization grant in plain language', () => {
+      const info = buildBucketInfo(
+        makeResponse({
+          settings: {
+            ...makeResponse().settings,
+            shares: { organization: { role: 'ReadOnly' }, team: [], user: [] },
+          },
+        })
+      );
+      expect(findValue(info, 'Shared With')).toBe(
+        'Everyone in organization (ReadOnly)'
+      );
+    });
+
+    it('lists teams and users', () => {
+      const info = buildBucketInfo(
+        makeResponse({
+          settings: {
+            ...makeResponse().settings,
+            shares: {
+              team: [{ teamId: 'tmid_MQQUhV', role: 'Editor' }],
+              user: [{ userId: 'uid_MQQUhV', role: 'ReadWrite' }],
+            },
+          },
+        })
+      );
+      expect(findValue(info, 'Shared With')).toBe(
+        'tmid_MQQUhV (Editor), uid_MQQUhV (ReadWrite)'
+      );
+    });
+
+    it('orders organization before teams and users', () => {
+      const info = buildBucketInfo(
+        makeResponse({
+          settings: {
+            ...makeResponse().settings,
+            shares: {
+              organization: { role: 'ReadOnly' },
+              team: [{ teamId: 'tmid_A', role: 'Editor' }],
+              user: [{ userId: 'uid_A', role: 'ReadWrite' }],
+            },
+          },
+        })
+      );
+      expect(findValue(info, 'Shared With')).toBe(
+        'Everyone in organization (ReadOnly), tmid_A (Editor), uid_A (ReadWrite)'
+      );
+    });
+  });
+
   describe('notifications', () => {
     it('does not add notifications when undefined', () => {
       const info = buildBucketInfo(makeResponse());

--- a/packages/storage/src/lib/bucket/info.ts
+++ b/packages/storage/src/lib/bucket/info.ts
@@ -6,10 +6,14 @@ import type {
   BucketLocations,
   BucketMigration,
   BucketNotification,
+  BucketShares,
   BucketTtl,
   StorageClass,
 } from './types';
-import type { GetBucketInfoApiResponseBody } from './utils/api';
+import {
+  type GetBucketInfoApiResponseBody,
+  ORGANIZATION_TEAM_ID,
+} from './utils/api';
 import { parseBucketLocations } from './utils/regions';
 
 export type GetBucketInfoOptions = {
@@ -62,6 +66,8 @@ export type BucketInfoResponse = {
     corsRules: BucketCorsRule[];
     additionalHeaders?: GetBucketInfoApiResponseBody['additional_http_headers'];
     notifications?: BucketNotification;
+    /** Who this bucket is shared with. */
+    shares: BucketShares;
   };
   sizeInfo: {
     numberOfObjects: number | undefined;
@@ -90,6 +96,28 @@ function mapNotification(
   }
 
   return base;
+}
+
+/**
+ * Split the flat wire array into its three grant targets. The organization
+ * grant arrives as the reserved `team_id` sentinel rather than its own field.
+ */
+function mapShares(
+  shares: GetBucketInfoApiResponseBody['shares']
+): BucketShares {
+  const result: BucketShares = { team: [], user: [] };
+
+  for (const share of shares ?? []) {
+    if (share.team_id === ORGANIZATION_TEAM_ID) {
+      result.organization = { role: share.role };
+    } else if (share.team_id) {
+      result.team.push({ teamId: share.team_id, role: share.role });
+    } else if (share.user_id) {
+      result.user.push({ userId: share.user_id, role: share.role });
+    }
+  }
+
+  return result;
 }
 
 export async function getBucketInfo(
@@ -205,6 +233,7 @@ export async function getBucketInfo(
         notifications: response.data.object_notifications
           ? mapNotification(response.data.object_notifications)
           : undefined,
+        shares: mapShares(response.data.shares),
       },
       sizeInfo: {
         numberOfObjects: response.data.estimated_unique_rows ?? undefined,

--- a/packages/storage/src/lib/bucket/share.merge.test.ts
+++ b/packages/storage/src/lib/bucket/share.merge.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { BucketShares } from './types';
+
+vi.mock('./info', () => ({ getBucketInfo: vi.fn() }));
+vi.mock('./set/set', () => ({ setBucketSettings: vi.fn() }));
+
+const { getBucketInfo } = await import('./info');
+const { setBucketSettings } = await import('./set/set');
+const { shareBucket } = await import('./share');
+
+const existing: BucketShares = {
+  organization: { role: 'ReadOnly' },
+  team: [
+    { teamId: 'tmid_KEEP', role: 'Editor' },
+    { teamId: 'tmid_EDIT', role: 'ReadOnly' },
+  ],
+  user: [{ userId: 'uid_KEEP', role: 'ReadWrite' }],
+};
+
+/** The `shares` array handed to the PATCH helper. */
+function sentShares() {
+  return vi.mocked(setBucketSettings).mock.calls[0][1]?.body?.shares;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getBucketInfo).mockResolvedValue({
+    data: { settings: { shares: existing } },
+  } as never);
+  vi.mocked(setBucketSettings).mockResolvedValue({
+    data: { bucket: 'my-bucket', updated: true },
+  });
+});
+
+describe('shareBucket merge (default)', () => {
+  it('keeps targets that were not named', async () => {
+    await shareBucket('my-bucket', {
+      team: [{ teamId: 'tmid_NEW', role: 'Editor' }],
+    });
+
+    expect(sentShares()).toEqual([
+      { team_id: 'all', role: 'ReadOnly' },
+      { team_id: 'tmid_KEEP', role: 'Editor' },
+      { team_id: 'tmid_EDIT', role: 'ReadOnly' },
+      { team_id: 'tmid_NEW', role: 'Editor' },
+      { user_id: 'uid_KEEP', role: 'ReadWrite' },
+    ]);
+  });
+
+  it('updates the role of a team that was named, without duplicating it', async () => {
+    await shareBucket('my-bucket', {
+      team: [{ teamId: 'tmid_EDIT', role: 'Editor' }],
+    });
+
+    const teams = sentShares()?.filter((s) => s.team_id === 'tmid_EDIT');
+    expect(teams).toEqual([{ team_id: 'tmid_EDIT', role: 'Editor' }]);
+  });
+
+  it('keeps the organization grant when only a team is named', async () => {
+    await shareBucket('my-bucket', {
+      team: [{ teamId: 'tmid_NEW', role: 'Editor' }],
+    });
+
+    expect(sentShares()).toContainEqual({ team_id: 'all', role: 'ReadOnly' });
+  });
+
+  it('replaces the organization grant when one is provided', async () => {
+    await shareBucket('my-bucket', { organization: { role: 'Editor' } });
+
+    const org = sentShares()?.filter((s) => s.team_id === 'all');
+    expect(org).toEqual([{ team_id: 'all', role: 'Editor' }]);
+  });
+
+  it('keeps existing users when only a user is named', async () => {
+    await shareBucket('my-bucket', {
+      user: [{ userId: 'uid_NEW', role: 'ReadOnly' }],
+    });
+
+    expect(sentShares()).toContainEqual({
+      user_id: 'uid_KEEP',
+      role: 'ReadWrite',
+    });
+  });
+
+  it('surfaces a read failure instead of writing a truncated list', async () => {
+    vi.mocked(getBucketInfo).mockResolvedValue({
+      error: new Error('boom'),
+    } as never);
+
+    const { error } = await shareBucket('my-bucket', {
+      team: [{ teamId: 'tmid_NEW', role: 'Editor' }],
+    });
+
+    expect(error?.message).toBe('boom');
+    expect(setBucketSettings).not.toHaveBeenCalled();
+  });
+});
+
+describe('shareBucket override', () => {
+  it('does not read existing shares', async () => {
+    await shareBucket('my-bucket', {
+      override: true,
+      team: [{ teamId: 'tmid_NEW', role: 'Editor' }],
+    });
+
+    expect(getBucketInfo).not.toHaveBeenCalled();
+  });
+
+  it('drops every target that was omitted', async () => {
+    await shareBucket('my-bucket', {
+      override: true,
+      team: [{ teamId: 'tmid_NEW', role: 'Editor' }],
+    });
+
+    expect(sentShares()).toEqual([{ team_id: 'tmid_NEW', role: 'Editor' }]);
+  });
+
+  it('clears every share when given empty arrays', async () => {
+    await shareBucket('my-bucket', {
+      override: true,
+      team: [],
+      user: [],
+    });
+
+    expect(sentShares()).toEqual([]);
+  });
+});

--- a/packages/storage/src/lib/bucket/share.test.ts
+++ b/packages/storage/src/lib/bucket/share.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+
+import { shareBucket } from './share';
+
+/**
+ * Every case here fails validation before `setBucketSettings` is reached, so
+ * none of them touch the network.
+ */
+describe('shareBucket validation', () => {
+  it('rejects a call with no share targets at all', async () => {
+    const { error } = await shareBucket('my-bucket');
+    expect(error?.message).toContain('No shares provided');
+  });
+
+  it('points at the override form for removing every share', async () => {
+    const { error } = await shareBucket('my-bucket');
+    expect(error?.message).toContain('override: true');
+  });
+
+  it('accepts explicit empty arrays as a clear-all request', async () => {
+    const { error } = await shareBucket('my-bucket', {
+      override: true,
+      team: [],
+      user: [],
+      config: { accessKeyId: '', secretAccessKey: '' },
+    });
+    expect(error?.message).not.toContain('No shares provided');
+  });
+
+  describe('organization', () => {
+    it('rejects a missing role', async () => {
+      const { error } = await shareBucket('my-bucket', {
+        organization: {} as never,
+      });
+      expect(error?.message).toBe('Share for organization: role is required');
+    });
+
+    it('rejects an unknown role', async () => {
+      const { error } = await shareBucket('my-bucket', {
+        organization: { role: 'Owner' as never },
+      });
+      expect(error?.message).toContain(
+        'Share for organization: invalid role "Owner"'
+      );
+    });
+
+    it('rejects NamespaceAdmin, which is not bucket-scoped', async () => {
+      const { error } = await shareBucket('my-bucket', {
+        organization: { role: 'NamespaceAdmin' as never },
+      });
+      expect(error?.message).toContain('invalid role "NamespaceAdmin"');
+    });
+  });
+
+  describe('team', () => {
+    it('rejects a missing teamId', async () => {
+      const { error } = await shareBucket('my-bucket', {
+        team: [{ teamId: '', role: 'Editor' }],
+      });
+      expect(error?.message).toBe('Share for team 1: teamId is required');
+    });
+
+    it('reports the index of the offending team', async () => {
+      const { error } = await shareBucket('my-bucket', {
+        team: [
+          { teamId: 'tmid_A', role: 'Editor' },
+          { teamId: 'tmid_B', role: 'Nope' as never },
+        ],
+      });
+      expect(error?.message).toContain('Share for team 2:');
+    });
+
+    it('rejects the reserved organization sentinel as a teamId', async () => {
+      const { error } = await shareBucket('my-bucket', {
+        team: [{ teamId: 'all', role: 'Editor' }],
+      });
+      expect(error?.message).toContain('"all" is reserved');
+    });
+
+    it('rejects duplicate grants for the same team', async () => {
+      const { error } = await shareBucket('my-bucket', {
+        team: [
+          { teamId: 'tmid_A', role: 'Editor' },
+          { teamId: 'tmid_A', role: 'ReadOnly' },
+        ],
+      });
+      expect(error?.message).toBe('Duplicate team share for "tmid_A"');
+    });
+  });
+
+  describe('user', () => {
+    it('rejects a missing userId', async () => {
+      const { error } = await shareBucket('my-bucket', {
+        user: [{ userId: '', role: 'ReadOnly' }],
+      });
+      expect(error?.message).toBe('Share for user 1: userId is required');
+    });
+
+    it('rejects an unknown role', async () => {
+      const { error } = await shareBucket('my-bucket', {
+        user: [{ userId: 'uid_A', role: 'Owner' as never }],
+      });
+      expect(error?.message).toContain('Share for user 1: invalid role');
+    });
+
+    it('rejects duplicate grants for the same user', async () => {
+      const { error } = await shareBucket('my-bucket', {
+        user: [
+          { userId: 'uid_A', role: 'Editor' },
+          { userId: 'uid_A', role: 'ReadOnly' },
+        ],
+      });
+      expect(error?.message).toBe('Duplicate user share for "uid_A"');
+    });
+
+    it('does not collide a user id with an identical team id', async () => {
+      const { error } = await shareBucket('my-bucket', {
+        override: true,
+        team: [{ teamId: 'shared_id', role: 'Editor' }],
+        user: [{ userId: 'shared_id', role: 'ReadOnly' }],
+        config: { accessKeyId: '', secretAccessKey: '' },
+      });
+      expect(error?.message).not.toContain('Duplicate');
+    });
+  });
+
+  it('accepts every bucket-scoped role on every target', async () => {
+    for (const role of ['ReadOnly', 'ReadWrite', 'Editor'] as const) {
+      const { error } = await shareBucket('my-bucket', {
+        override: true,
+        organization: { role },
+        team: [{ teamId: 'tmid_A', role }],
+        user: [{ userId: 'uid_A', role }],
+        config: { accessKeyId: '', secretAccessKey: '' },
+      });
+      // Never a validation error — only a config/transport one.
+      expect(error?.message).not.toContain('invalid role');
+      expect(error?.message).not.toContain('is required');
+    }
+  });
+});

--- a/packages/storage/src/lib/bucket/share.ts
+++ b/packages/storage/src/lib/bucket/share.ts
@@ -1,0 +1,174 @@
+import type { TigrisStorageConfig, TigrisStorageResponse } from '../types';
+import { getBucketInfo } from './info';
+import { type SetBucketSettingsOptions, setBucketSettings } from './set/set';
+import {
+  type BucketShareRole,
+  type BucketShares,
+  type BucketSharesInput,
+  bucketShareRoles,
+  type UpdateBucketResponse,
+} from './types';
+import { type BucketApiShare, ORGANIZATION_TEAM_ID } from './utils/api';
+
+export type ShareBucketOptions = BucketSharesInput & {
+  /**
+   * Replace the bucket's entire share list instead of merging into it.
+   *
+   * Defaults to `false`: targets you do not name keep their access, and a
+   * target you do name has its role updated. Set to `true` to make the shares
+   * you pass the complete list — anything omitted loses access.
+   */
+  override?: boolean;
+  config?: Omit<TigrisStorageConfig, 'bucket'>;
+};
+
+/**
+ * Share a bucket with the whole organization, specific teams, or specific
+ * users.
+ *
+ * Merges into the bucket's existing shares by default, which costs a
+ * `getBucketInfo` call. Pass `override: true` to replace the list outright —
+ * with `{ override: true, team: [], user: [] }` removing every share.
+ */
+export async function shareBucket(
+  bucketName: string,
+  options?: ShareBucketOptions
+): Promise<TigrisStorageResponse<UpdateBucketResponse, Error>> {
+  const { organization, team, user, override, config } = options ?? {};
+
+  if (organization === undefined && team === undefined && user === undefined) {
+    return {
+      error: new Error(
+        'No shares provided. Pass `organization`, `team`, or `user` — or `{ override: true, team: [], user: [] }` to remove every share.'
+      ),
+    };
+  }
+
+  const validationError = validate(organization, team, user);
+  if (validationError) {
+    return { error: validationError };
+  }
+
+  let shares: BucketShares = {
+    organization,
+    team: team ?? [],
+    user: user ?? [],
+  };
+
+  if (!override) {
+    const { data, error } = await getBucketInfo(bucketName, { config });
+
+    if (error) {
+      return { error };
+    }
+
+    shares = merge(data.settings.shares, shares);
+  }
+
+  const body: SetBucketSettingsOptions['body'] = { shares: serialize(shares) };
+
+  return setBucketSettings(bucketName, { body, config });
+}
+
+/**
+ * Overlay `next` on `existing`: a target named in `next` has its role
+ * replaced, and every other target keeps the access it already had.
+ */
+function merge(existing: BucketShares, next: BucketShares): BucketShares {
+  const namedTeams = new Set(next.team.map((t) => t.teamId));
+  const namedUsers = new Set(next.user.map((u) => u.userId));
+
+  return {
+    organization: next.organization ?? existing.organization,
+    team: [
+      ...existing.team.filter((t) => !namedTeams.has(t.teamId)),
+      ...next.team,
+    ],
+    user: [
+      ...existing.user.filter((u) => !namedUsers.has(u.userId)),
+      ...next.user,
+    ],
+  };
+}
+
+function serialize(shares: BucketShares): BucketApiShare[] {
+  return [
+    ...(shares.organization
+      ? [{ team_id: ORGANIZATION_TEAM_ID, role: shares.organization.role }]
+      : []),
+    ...shares.team.map((t) => ({ team_id: t.teamId, role: t.role })),
+    ...shares.user.map((u) => ({ user_id: u.userId, role: u.role })),
+  ];
+}
+
+function validate(
+  organization: BucketSharesInput['organization'],
+  team: BucketSharesInput['team'],
+  user: BucketSharesInput['user']
+): Error | undefined {
+  if (organization) {
+    const error = validateRole(organization.role, 'organization');
+    if (error) return error;
+  }
+
+  for (let i = 0; i < (team?.length ?? 0); i++) {
+    const share = team![i];
+    const label = `team ${i + 1}`;
+
+    if (!share.teamId) {
+      return new Error(`Share for ${label}: teamId is required`);
+    }
+
+    if (share.teamId === ORGANIZATION_TEAM_ID) {
+      return new Error(
+        `Share for ${label}: "${ORGANIZATION_TEAM_ID}" is reserved — use the \`organization\` option to share with everyone.`
+      );
+    }
+
+    const error = validateRole(share.role, label);
+    if (error) return error;
+  }
+
+  for (let i = 0; i < (user?.length ?? 0); i++) {
+    const share = user![i];
+    const label = `user ${i + 1}`;
+
+    if (!share.userId) {
+      return new Error(`Share for ${label}: userId is required`);
+    }
+
+    const error = validateRole(share.role, label);
+    if (error) return error;
+  }
+
+  return (
+    findDuplicate(team?.map((t) => t.teamId) ?? [], 'team') ??
+    findDuplicate(user?.map((u) => u.userId) ?? [], 'user')
+  );
+}
+
+function validateRole(
+  role: BucketShareRole | undefined,
+  label: string
+): Error | undefined {
+  if (!role) {
+    return new Error(`Share for ${label}: role is required`);
+  }
+
+  if (!bucketShareRoles.includes(role)) {
+    return new Error(
+      `Share for ${label}: invalid role "${role}". Valid roles are: ${bucketShareRoles.join(', ')}`
+    );
+  }
+}
+
+function findDuplicate(ids: string[], label: string): Error | undefined {
+  const seen = new Set<string>();
+
+  for (const id of ids) {
+    if (seen.has(id)) {
+      return new Error(`Duplicate ${label} share for "${id}"`);
+    }
+    seen.add(id);
+  }
+}

--- a/packages/storage/src/lib/bucket/types.ts
+++ b/packages/storage/src/lib/bucket/types.ts
@@ -94,6 +94,62 @@ export type BucketLifecycleRule = {
   filter?: BucketLifecycleFilter;
 };
 
+export const bucketShareRoles = ['ReadOnly', 'ReadWrite', 'Editor'] as const;
+
+/**
+ * Roles that can be granted on a bucket through a share.
+ *
+ * The org-wide `NamespaceAdmin` role has no meaning here — a share always
+ * targets one concrete bucket.
+ *
+ * Declared here rather than reused from `@tigrisdata/iam`: bucket shares grant
+ * a *team* or *user* access, access-key roles grant a *credential* access. The
+ * two vocabularies coincide today but are independent, and `storage` does not
+ * depend on `iam`.
+ */
+export type BucketShareRole = (typeof bucketShareRoles)[number];
+
+/** Grant to everyone in the organization. */
+export type OrganizationShare = {
+  role: BucketShareRole;
+};
+
+/** Grant to a single team. */
+export type TeamShare = {
+  teamId: string;
+  role: BucketShareRole;
+};
+
+/** Grant to a single user. */
+export type UserShare = {
+  userId: string;
+  role: BucketShareRole;
+};
+
+/**
+ * Who a bucket is shared with, as returned by `getBucketInfo`.
+ *
+ * `team` and `user` are always present — empty when nothing is shared that
+ * way. `organization` is absent unless the bucket is shared org-wide.
+ */
+export type BucketShares = {
+  /** Access for everyone in the organization. */
+  organization?: OrganizationShare;
+  team: TeamShare[];
+  user: UserShare[];
+};
+
+/**
+ * Who to share a bucket with. Every field is optional, but at least one must
+ * be provided.
+ */
+export type BucketSharesInput = {
+  /** Give access to everyone in your organization. */
+  organization?: OrganizationShare;
+  team?: TeamShare[];
+  user?: UserShare[];
+};
+
 export type BucketCorsRule = {
   allowedOrigins: string | string[];
   allowedMethods?: string | string[];

--- a/packages/storage/src/lib/bucket/utils/api.ts
+++ b/packages/storage/src/lib/bucket/utils/api.ts
@@ -1,4 +1,4 @@
-import type { StorageClass } from '../types';
+import type { BucketShareRole, StorageClass } from '../types';
 
 type BucketApiNotifications =
   | Record<string, never>
@@ -73,8 +73,22 @@ type BucketApiSettings = {
   object_notifications?: BucketApiNotifications;
   soft_delete?: { enabled: true; retention_days: number } | { enabled: false };
   additional_http_headers?: { 'X-Content-Type-Options': 'nosniff' } | null;
+  shares?: BucketApiShare[];
   type?: 0 | 1;
 };
+
+/**
+ * A single share on the wire. Exactly one of `team_id` / `user_id` is set;
+ * the organization-wide grant is `team_id: 'all'`.
+ */
+export type BucketApiShare = {
+  team_id?: string;
+  user_id?: string;
+  role: BucketShareRole;
+};
+
+/** Wire sentinel in `team_id` meaning "everyone in the organization". */
+export const ORGANIZATION_TEAM_ID = 'all';
 
 export type GetBucketInfoApiResponseBody = BucketApiSettings & {
   ForkInfo?: {

--- a/packages/storage/src/server.ts
+++ b/packages/storage/src/server.ts
@@ -55,6 +55,7 @@ export {
   type SetBucketTypeOptions,
   setBucketType,
 } from './lib/bucket/set/type';
+export { type ShareBucketOptions, shareBucket } from './lib/bucket/share';
 export {
   type BucketSnapshot,
   type CreateBucketSnapshotOptions,
@@ -77,6 +78,9 @@ export type {
   BucketMigration,
   BucketNotification,
   BucketOwner,
+  BucketShareRole,
+  BucketShares,
+  BucketSharesInput,
   BucketsStats,
   BucketTtl,
   BucketType,
@@ -84,8 +88,11 @@ export type {
   NotificationEvent,
   NotificationEventName,
   NotificationResponse,
+  OrganizationShare,
   StorageClass,
+  TeamShare,
   UpdateBucketResponse,
+  UserShare,
 } from './lib/bucket/types';
 export { type UpdateBucketOptions, updateBucket } from './lib/bucket/update';
 export {


### PR DESCRIPTION
## What

Adds bucket sharing to the SDK and the CLI — granting bucket access to your whole organization, to specific teams, or to specific users. This was previously a console-only feature with no SDK or CLI surface.

Two commits, each independently green:

| | |
|---|---|
| `8c06fdd` | `feat(storage)` — `shareBucket()` + `getBucketInfo().settings.shares` |
| `d5cf796` | `feat(cli)` — `tigris buckets share` + `Shared With` in `buckets get` |

## SDK

```ts
await shareBucket('my-bucket', {
  organization: { role: 'ReadOnly' },
  team: [{ teamId: 'tmid_MQQUhV', role: 'Editor' }],
  user: [{ userId: 'uid_MQQUhV', role: 'ReadOnly' }],
});
```

`getBucketInfo().settings.shares` returns the same shape, so read and write mirror each other. Two types back it: `BucketSharesInput` (all fields optional, for writes) and `BucketShares` (for reads, where `team`/`user` are always arrays and `organization` is absent unless set) — so code reading results never has to guard an optional array.

### Shares merge by default

This is the main design decision in the PR. The wire PATCH replaces the entire `shares` field, so a naive pass-through would mean this:

```ts
// bucket shared with the org, a team, and a user
await shareBucket('my-bucket', { team: [{ teamId: 'tmid_X', role: 'Editor' }] });
// → org grant and user grant silently deleted
```

Granting one team access should not revoke your organization. So `shareBucket` reads the current shares and overlays yours: a target you name has its role updated, targets you omit keep their access. `override: true` restores replace semantics and skips the read; `{ override: true, team: [], user: [] }` clears everything.

Two consequences worth reviewing:

- The default path costs a `getBucketInfo` call, and `shareBucket` can now fail for a *read* reason.
- **A failed read aborts the write.** If `getBucketInfo` errors we return the error and never call `setBucketSettings` — otherwise a transient read failure would persist a truncated list and delete shares. Pinned by a test.

This is deliberately *unlike* `setBucketCors`, which replaces unless you pass `override: false` explicitly (the check is `if (options.override === false)`, so leaving it undefined replaces). That API's default is easy to get wrong, and I did not want to reproduce it for something that can revoke access.

### Wire mapping

`shares` is added once to `BucketApiSettings`. Since `GetBucketInfoApiResponseBody` extends it, the PATCH body and the `?metadata` response are typed from a single declaration.

The wire is a flat array in which the organization grant is the reserved sentinel `team_id: 'all'`. `getBucketInfo` splits that back into `organization` / `team` / `user`, and `shareBucket` rejects `'all'` passed as a `teamId` with a message pointing at the `organization` option — so the sentinel cannot be smuggled in to produce two conflicting org grants.

### Roles

`BucketShareRole` is `ReadOnly | ReadWrite | Editor`, declared in `storage` rather than reused from `@tigrisdata/iam`. Shares grant a *team or user* access while access-key roles grant a *credential* access; the vocabularies coincide today but are independent, and `storage` does not depend on `iam`. The org-wide `NamespaceAdmin` is rejected, since a share always targets one concrete bucket.

## CLI

```bash
tigris buckets share my-bucket --organization --role ReadOnly
tigris buckets share my-bucket --team tmid_MQQUhV --role Editor
tigris buckets share my-bucket --user uid_MQQUhV --role ReadOnly
tigris buckets share my-bucket --team tmid_A,tmid_B --role Editor,ReadOnly
tigris buckets share my-bucket --reset
```

`--organization` takes exactly one `--role`. `--team`/`--user` accept comma-separated IDs; a single `--role` applies to all, otherwise roles pair positionally. Use one of the three per invocation — because shares merge, granting to more than one kind of target is just running the command again.

`--override` and `--reset` both map onto the SDK's `override` flag, so the merge logic lives in exactly one place. `buckets get` gains a `Shared With` row listing the organization first, then teams, then users.

Note `command-registry.ts` is generated and gitignored — `specs.yaml` is what registers the command, and the registry rebuilds from it.

## Testing

- Full `pnpm build` exit 0; storage **147** unit tests, CLI **947**; biome clean
- **Each commit verified in isolation**, not just the final state — after committing storage I stashed the remaining CLI work and re-ran build + tests against commit 1 alone (build 0, storage 147, CLI 371)
- New `share.merge.test.ts` covers merge/override semantics against mocked `getBucketInfo`/`setBucketSettings`, asserting exact wire arrays so the cases fail under replace semantics rather than passing vacuously
- `share.test.ts` covers validation and touches no network — every case returns before the transport call
- `packages/cli/README.md` regenerated with `pnpm updatedocs` rather than hand-edited

Live integration suites were not run locally (they need real credentials) — they run in CI.

Changesets included: `storage` minor, `cli` minor.

## ⚠️ One thing to verify before merging

**The `user_id` wire key is an inference.** The console request I worked from only ever contained `team_id`, so user shares are modelled as entries in the same `shares` array keyed `user_id`. If the gateway encodes them differently, the fix is confined to three places: `BucketApiShare` in `utils/api.ts`, `serialize()` in `share.ts`, and `mapShares()` in `info.ts`.

The `team_id: 'all'` sentinel and the `Editor`/`ReadOnly` role vocabulary were observed directly and are not assumptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes who can access buckets (authorization) and default merge semantics affect whether existing shares are preserved or revoked; the `user_id` wire format is noted as unverified against the gateway.
> 
> **Overview**
> Adds **bucket sharing** to `@tigrisdata/storage` and the CLI—org-wide, team, or user grants with `ReadOnly` / `ReadWrite` / `Editor` roles.
> 
> The SDK exposes **`shareBucket()`** and **`getBucketInfo().settings.shares`**, mapping the API’s flat `shares` array (org grant as `team_id: 'all'`) into structured `organization` / `team` / `user` shapes. **`shareBucket` merges by default**: it reads current shares, updates only named targets, and aborts the write if that read fails so partial updates cannot wipe other grants. **`override: true`** (or empty team/user arrays) replaces or clears the full list.
> 
> The CLI adds **`tigris buckets share`** with `--organization`, `--team`, `--user`, `--role`, `--override`, and `--reset`, enforcing one target kind per invocation and delegating merge logic to the SDK. **`tigris buckets get`** shows a **Shared With** row (org, then teams, then users). Docs, changesets, and unit tests cover validation, merge/override behavior, and display formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5cf7962ecc52160b97d829b8122f45bf76c7bde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->