### PR TITLE
feat: add Cache-Control support to the SDK and CLI

### DIFF
--- a/.changeset/cache-control-support.md
+++ b/.changeset/cache-control-support.md
@@ -1,0 +1,24 @@
+---
+'@tigrisdata/storage': minor
+---
+
+Add `Cache-Control` support to uploads.
+
+`put()` accepts a `cacheControl` option, stored with the object and returned by
+Tigris on every read. Public buckets otherwise fall back to
+`public, max-age=3600` for recognised static asset types.
+
+```ts
+await put('assets/app.abc123.js', body, {
+  access: 'public',
+  cacheControl: 'public, max-age=31536000, immutable',
+});
+```
+
+`getSignedUploadUrl()` accepts the same option, so browser uploads can be locked
+to a cache policy — on the PUT contract it comes back as a required
+`Cache-Control` header, and on the POST contract it is baked into the form
+policy.
+
+`head()` now returns the stored value as `cacheControl`, and `put()` echoes it
+back on `PutResponse`.

--- a/.changeset/cli-cache-control.md
+++ b/.changeset/cli-cache-control.md
@@ -1,0 +1,18 @@
+---
+'@tigrisdata/cli': minor
+---
+
+Add `--cache-control` to `objects put` and `cp`, and report it in `stat`.
+
+The value is stored with the uploaded object and returned by Tigris on every
+read:
+
+```sh
+tigris objects put my-bucket app.js ./app.js \
+  --cache-control 'public, max-age=31536000, immutable'
+
+tigris cp ./dist/ t3://my-bucket/assets/ -r \
+  --cache-control 'public, max-age=31536000, immutable'
+```
+
+On `cp` it applies to local-to-remote uploads only, matching `--access`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -390,11 +390,13 @@ tigris cp <src> <dest> [flags]
 |------|-------------|
 | `-r, --recursive` | Copy directories recursively |
 | `-a, --access` | Access level for uploaded objects (only applies to local-to-remote uploads) |
+| `--cache-control` | Cache-Control header stored with uploaded objects (only applies to local-to-remote uploads) |
 
 **Examples:**
 ```bash
 tigris cp ./file.txt t3://my-bucket/file.txt
 tigris cp ./logo.png t3://my-bucket/logo.png --access public
+tigris cp ./dist/ t3://my-bucket/assets/ -r --cache-control 'public, max-age=31536000, immutable'
 tigris cp t3://my-bucket/file.txt ./local-copy.txt
 tigris cp t3://my-bucket/src/ t3://my-bucket/dest/ -r
 tigris cp ./images/ t3://my-bucket/images/ -r
@@ -1136,6 +1138,7 @@ tigris objects put <bucket> [key] [file] [flags]
 |------|-------------|
 | `-a, --access` | Access level (default: private) |
 | `-t, --content-type` | Content type (auto-detected from extension if omitted) |
+| `--cache-control` | Cache-Control header stored with the object and returned on every read (e.g. "public, max-age=31536000, immutable") |
 | `--format` | Output format (default: table) |
 
 **Examples:**
@@ -1143,6 +1146,7 @@ tigris objects put <bucket> [key] [file] [flags]
 tigris objects put my-bucket report.pdf ./report.pdf
 tigris objects put t3://my-bucket/report.pdf ./report.pdf
 tigris objects put my-bucket logo.png ./logo.png --access public --content-type image/png
+tigris objects put my-bucket app.js ./app.js --cache-control 'public, max-age=31536000, immutable'
 echo 'hello' | tigris objects put t3://my-bucket/hello.txt
 cat report.pdf | tigris objects put my-bucket report.pdf --content-type application/pdf
 ```

--- a/packages/cli/src/lib/cp.ts
+++ b/packages/cli/src/lib/cp.ts
@@ -104,7 +104,8 @@ async function uploadFile(
   key: string,
   config: Awaited<ReturnType<typeof getStorageConfig>>,
   showProgress = false,
-  access?: 'public' | 'private'
+  access?: 'public' | 'private',
+  cacheControl?: string
 ): Promise<{ error?: string }> {
   let fileSize: number | undefined;
   try {
@@ -123,6 +124,7 @@ async function uploadFile(
     ...calculateUploadParams(fileSize),
     ...(contentType ? { contentType } : {}),
     ...(access ? { access } : {}),
+    ...(cacheControl ? { cacheControl } : {}),
     onUploadProgress: showProgress
       ? ({ loaded }) => {
           if (fileSize !== undefined && fileSize > 0) {
@@ -258,7 +260,8 @@ async function copyLocalToRemote(
   destParsed: ParsedPath,
   config: Awaited<ReturnType<typeof getStorageConfig>>,
   recursive: boolean,
-  access?: 'public' | 'private'
+  access?: 'public' | 'private',
+  cacheControl?: string
 ) {
   const localPath = resolveLocalPath(src);
   const isWildcard = src.includes('*');
@@ -293,7 +296,8 @@ async function copyLocalToRemote(
         destKey,
         config,
         false,
-        access
+        access,
+        cacheControl
       );
       if (result.error) {
         console.error(`Failed to upload ${file}: ${result.error}`);
@@ -370,7 +374,8 @@ async function copyLocalToRemote(
         destKey,
         config,
         false,
-        access
+        access,
+        cacheControl
       );
       if (result.error) {
         console.error(`Failed to upload ${file}: ${result.error}`);
@@ -425,7 +430,8 @@ async function copyLocalToRemote(
       destKey,
       config,
       !_jsonMode,
-      access
+      access,
+      cacheControl
     );
     if (result.error) {
       exitWithError(result.error);
@@ -849,6 +855,10 @@ export default async function cp(options: Record<string, unknown>) {
 
   const recursive = !!getOption<boolean>(options, ['recursive', 'r']);
   const accessArg = getOption<string>(options, ['access', 'a', 'A']);
+  const cacheControl = getOption<string>(options, [
+    'cache-control',
+    'cacheControl',
+  ]);
   const format = getFormat(options);
   _jsonMode = format === 'json';
 
@@ -871,6 +881,13 @@ export default async function cp(options: Record<string, unknown>) {
     );
   }
 
+  // Same reasoning as --access: Cache-Control is stored on the object at write
+  // time, and the only write a cp performs is an upload. copy() can't carry it
+  // and a downloaded file has nowhere to put it.
+  if (cacheControl !== undefined && direction !== 'local-to-remote') {
+    exitWithError('--cache-control only applies to local-to-remote uploads.');
+  }
+
   const config = await getStorageConfig({ withCredentialProvider: true });
 
   switch (direction) {
@@ -879,7 +896,14 @@ export default async function cp(options: Record<string, unknown>) {
       if (!destParsed.bucket) {
         exitWithError('Invalid destination path');
       }
-      await copyLocalToRemote(src, destParsed, config, recursive, access);
+      await copyLocalToRemote(
+        src,
+        destParsed,
+        config,
+        recursive,
+        access,
+        cacheControl
+      );
       break;
     }
     case 'remote-to-local': {

--- a/packages/cli/src/lib/objects/put.ts
+++ b/packages/cli/src/lib/objects/put.ts
@@ -25,6 +25,10 @@ export default async function putObject(options: Record<string, unknown>) {
     't',
     'T',
   ]);
+  const cacheControl = getOption<string>(options, [
+    'cache-control',
+    'cacheControl',
+  ]);
   const format = getFormat(options);
 
   if (!bucketArg) {
@@ -81,6 +85,7 @@ export default async function putObject(options: Record<string, unknown>) {
   const { data, error } = await put(key, body, {
     access: access === 'public' ? 'public' : 'private',
     contentType: resolvedContentType,
+    cacheControl,
     ...uploadParams,
     onUploadProgress: ({ loaded, percentage }) => {
       if (fileSize !== undefined && fileSize > 0) {
@@ -109,6 +114,7 @@ export default async function putObject(options: Record<string, unknown>) {
       path: data.path,
       size: formatSize(data.size ?? fileSize ?? 0),
       contentType: data.contentType || '-',
+      cacheControl: data.cacheControl || '-',
       modified: data.modified,
     },
   ];
@@ -117,6 +123,7 @@ export default async function putObject(options: Record<string, unknown>) {
     { key: 'path', header: 'Path' },
     { key: 'size', header: 'Size' },
     { key: 'contentType', header: 'Content-Type' },
+    { key: 'cacheControl', header: 'Cache-Control' },
     { key: 'modified', header: 'Modified' },
   ]);
 

--- a/packages/cli/src/lib/stat.ts
+++ b/packages/cli/src/lib/stat.ts
@@ -105,6 +105,7 @@ export default async function stat(options: Record<string, unknown>) {
     { metric: 'Size', value: formatSize(data.size) },
     { metric: 'Content-Type', value: data.contentType || 'N/A' },
     { metric: 'Content-Disposition', value: data.contentDisposition || 'N/A' },
+    { metric: 'Cache-Control', value: data.cacheControl || 'N/A' },
     { metric: 'Modified', value: data.modified.toISOString() },
   ];
 

--- a/packages/cli/src/specs.yaml
+++ b/packages/cli/src/specs.yaml
@@ -516,6 +516,7 @@ commands:
     examples:
       - "tigris cp ./file.txt t3://my-bucket/file.txt"
       - "tigris cp ./logo.png t3://my-bucket/logo.png --access public"
+      - "tigris cp ./dist/ t3://my-bucket/assets/ -r --cache-control 'public, max-age=31536000, immutable'"
       - "tigris cp t3://my-bucket/file.txt ./local-copy.txt"
       - "tigris cp t3://my-bucket/src/ t3://my-bucket/dest/ -r"
       - "tigris cp ./images/ t3://my-bucket/images/ -r"
@@ -549,6 +550,8 @@ commands:
         description: Access level for uploaded objects (only applies to local-to-remote uploads)
         alias: a
         options: *access_options
+      - name: cache-control
+        description: Cache-Control header stored with uploaded objects (only applies to local-to-remote uploads)
 
   # mv
   - name: mv
@@ -1629,6 +1632,7 @@ commands:
           - "tigris objects put my-bucket report.pdf ./report.pdf"
           - "tigris objects put t3://my-bucket/report.pdf ./report.pdf"
           - "tigris objects put my-bucket logo.png ./logo.png --access public --content-type image/png"
+          - "tigris objects put my-bucket app.js ./app.js --cache-control 'public, max-age=31536000, immutable'"
           - "echo 'hello' | tigris objects put t3://my-bucket/hello.txt"
           - "cat report.pdf | tigris objects put my-bucket report.pdf --content-type application/pdf"
         messages:
@@ -1664,6 +1668,8 @@ commands:
           - name: content-type
             description: Content type (auto-detected from extension if omitted)
             alias: t
+          - name: cache-control
+            description: Cache-Control header stored with the object and returned on every read (e.g. "public, max-age=31536000, immutable")
           - name: format
             description: Output format
             options: [json, table, xml]

--- a/packages/storage/src/lib/object/head.ts
+++ b/packages/storage/src/lib/object/head.ts
@@ -12,6 +12,7 @@ export type HeadOptions = {
 };
 
 export type HeadResponse = {
+  cacheControl: string;
   contentDisposition: string;
   contentType: string;
   etag: string;
@@ -53,6 +54,7 @@ export async function head(
             modified: res.LastModified ?? new Date(),
             contentType: res.ContentType ?? '',
             contentDisposition: res.ContentDisposition ?? '',
+            cacheControl: res.CacheControl ?? '',
             etag: res.ETag ?? '',
             metadata: res.Metadata ?? {},
             url: await getSignedUrl(tigrisClient, head, {

--- a/packages/storage/src/lib/object/put.ts
+++ b/packages/storage/src/lib/object/put.ts
@@ -24,6 +24,14 @@ export type PutOptions = {
   allowOverwrite?: boolean;
   contentType?: string;
   contentDisposition?: 'attachment' | 'inline';
+  /**
+   * `Cache-Control` header stored with the object and returned on every read.
+   * Tigris honors it at the edge; when omitted, public buckets fall back to
+   * `public, max-age=3600` for recognised static asset types.
+   *
+   * @example 'public, max-age=31536000, immutable'
+   */
+  cacheControl?: string;
   metadata?: Record<string, string>;
   multipart?: boolean;
   partSize?: number;
@@ -34,6 +42,7 @@ export type PutOptions = {
 };
 
 export type PutResponse = {
+  cacheControl: string | undefined;
   contentDisposition: string | undefined;
   contentType: string | undefined;
   etag: string;
@@ -88,6 +97,7 @@ export async function put(
       Body: body,
       ContentType: options?.contentType ?? undefined,
       ContentDisposition: contentDisposition,
+      CacheControl: options?.cacheControl ?? undefined,
       Metadata: options?.metadata,
       ACL: access,
     },
@@ -158,6 +168,7 @@ export async function put(
 
   return {
     data: {
+      cacheControl: options?.cacheControl ?? undefined,
       contentDisposition: options?.contentDisposition ?? undefined,
       contentType: options?.contentType ?? undefined,
       etag,

--- a/packages/storage/src/lib/object/signed-upload-url.ts
+++ b/packages/storage/src/lib/object/signed-upload-url.ts
@@ -27,6 +27,14 @@ export type GetSignedUploadUrlOptions = {
    * matching header; with POST, the value is baked into the form.
    */
   contentType?: string;
+  /**
+   * Locks the upload's `Cache-Control`. Works in both contracts — on PUT it's
+   * returned as a required header the client must send; on POST it's baked
+   * into the form.
+   *
+   * @example 'public, max-age=31536000, immutable'
+   */
+  cacheControl?: string;
   /** Maximum body size in bytes. POST-only (no PUT equivalent). */
   maxSize?: number;
   /** Minimum body size in bytes. POST-only (no PUT equivalent). */
@@ -104,6 +112,7 @@ async function createPutContract(
       Bucket: bucket,
       Key: key,
       ContentType: options.contentType,
+      CacheControl: options.cacheControl,
       Metadata: normalizedMetadata,
       ACL: acl,
     });
@@ -112,6 +121,9 @@ async function createPutContract(
     const headers: Record<string, string> = {};
     if (options.contentType) {
       headers['Content-Type'] = options.contentType;
+    }
+    if (options.cacheControl) {
+      headers['Cache-Control'] = options.cacheControl;
     }
     if (acl) {
       headers[TigrisHeaders.ACL] = acl;
@@ -148,6 +160,11 @@ async function createPostContract(
   if (options.contentType) {
     fields['Content-Type'] = options.contentType;
     conditions.push({ 'Content-Type': options.contentType });
+  }
+
+  if (options.cacheControl) {
+    fields['Cache-Control'] = options.cacheControl;
+    conditions.push({ 'Cache-Control': options.cacheControl });
   }
 
   if (options.maxSize !== undefined || options.minSize !== undefined) {

--- a/packages/storage/src/test/integration.test.ts
+++ b/packages/storage/src/test/integration.test.ts
@@ -292,6 +292,40 @@ describe.skipIf(skipTests)('Tigris Storage Integration Tests', () => {
       await remove(etagFileName, { config });
     });
 
+    // Tigris stores the Cache-Control given at write time and returns it on
+    // every read. The release pipeline depends on this to mark versioned CLI
+    // artifacts immutable and the install scripts short-lived, so assert the
+    // header actually round-trips rather than just that put() accepted it.
+    it('should round-trip cacheControl through put and head', async () => {
+      const ccFileName = `test-cache-control-${Date.now()}.txt`;
+      const cacheControl = 'public, max-age=31536000, immutable';
+
+      const putResult = await put(ccFileName, testFileContent, {
+        cacheControl,
+        config,
+      });
+      expect(putResult.error).toBeUndefined();
+      expect(putResult.data?.cacheControl).toBe(cacheControl);
+
+      const headResult = await head(ccFileName, { config });
+      expect(headResult.error).toBeUndefined();
+      expect(headResult.data?.cacheControl).toBe(cacheControl);
+
+      await remove(ccFileName, { config });
+    });
+
+    it('should leave cacheControl empty when none was set', async () => {
+      const plainFileName = `test-no-cache-control-${Date.now()}.txt`;
+
+      await put(plainFileName, testFileContent, { config });
+
+      const headResult = await head(plainFileName, { config });
+      expect(headResult.error).toBeUndefined();
+      expect(headResult.data?.cacheControl).toBe('');
+
+      await remove(plainFileName, { config });
+    });
+
     it('should return undefined data for non-existent files', async () => {
       const result = await head('non-existent-file.txt', {
         config,


### PR DESCRIPTION
## What

Adds `Cache-Control` support to the storage SDK and surfaces it in the CLI.

[Tigris honours cache headers set at write time](https://www.tigrisdata.com/docs/objects/caching/#cache-headers), but neither the SDK nor the CLI had a way to set them — so callers had to drop down to the AWS SDK or `aws s3 cp` to mark an object immutable.

## Commits

1. **`feat(storage)`** — `cacheControl` option on `put()` and `getSignedUploadUrl()`; `head()` returns the stored value; `put()` echoes it back.
2. **`feat(cli)`** — `--cache-control` on `objects put` and `cp`; `stat` reports it.

## Usage

```ts
await put('assets/app.abc123.js', body, {
  access: 'public',
  cacheControl: 'public, max-age=31536000, immutable',
});
```

```sh
tigris cp ./dist/ t3://my-bucket/assets/ -r \
  --cache-control 'public, max-age=31536000, immutable'
```

On `cp` the flag applies to local-to-remote uploads only, matching how `--access` already behaves — Cache-Control is written with the object, and an upload is the only write a `cp` performs.

For presigned uploads it works in both contracts: on PUT it comes back as a required `Cache-Control` header the client must send, on POST it is baked into the form policy.

## Testing

Added integration coverage asserting the header actually round-trips through Tigris (`put` → `head`), rather than only that `put()` accepted the option — plus a case pinning the default-empty behaviour when it is omitted. Verified against a real bucket, along with the CLI paths for both `objects put` and `cp`.

Full suite green: `pnpm lint`, `pnpm -r build`, `pnpm -r test` (31/31 CLI test files, 1193 passed).

## Notes

`HeadResponse` gains a required `cacheControl: string` field, matching the existing `contentType` / `contentDisposition` style. This is additive to a returned object, so no caller breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive options and response fields on upload/metadata paths; incorrect Cache-Control strings could affect CDN/browser caching for public assets but do not change auth or data integrity.
> 
> **Overview**
> Adds end-to-end **`Cache-Control`** on object writes so callers can set cache policy without dropping to raw S3 APIs.
> 
> In **`@tigrisdata/storage`**, `put()` and `getSignedUploadUrl()` accept optional `cacheControl` (sent as S3 `CacheControl`; presigned PUT requires the header, POST bakes it into policy). `head()` exposes the stored value on `HeadResponse`, and `put()` echoes it on `PutResponse`. Integration tests assert round-trip via `put` → `head` and empty string when omitted.
> 
> In **`@tigrisdata/cli`**, `--cache-control` is wired for **`objects put`** and **`cp`** (local-to-remote only, with validation mirroring `--access`). **`stat`** and put success output show the value. CLI specs/README and changesets document the minor releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96442937b9f750d63d72218711d2dddea0f6f550. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->