### PR TITLE
chore(cli-shell): drop the playground prefill and make its port configurable

### DIFF
--- a/apps/cli-shell-playground/src/App.tsx
+++ b/apps/cli-shell-playground/src/App.tsx
@@ -1,16 +1,6 @@
 import { TigrisShell } from '@tigrisdata/cli-shell';
 
-declare const __PREFILL__: { accessKeyId: string; secretAccessKey: string };
-
+// Sign in from inside the shell: `tigris login` offers OAuth or an access key.
 export function App() {
-  const prefill =
-    typeof __PREFILL__ === 'undefined'
-      ? { accessKeyId: '', secretAccessKey: '' }
-      : __PREFILL__;
-
-  // Pre-fills from the repo-root .env in dev so the shell is usable straight
-  // away; without it, sign in from inside the shell with `login`.
-  const accessKey = prefill.accessKeyId ? prefill : undefined;
-
-  return <TigrisShell accessKey={accessKey} />;
+  return <TigrisShell />;
 }

--- a/apps/cli-shell-playground/vite.config.ts
+++ b/apps/cli-shell-playground/vite.config.ts
@@ -1,27 +1,18 @@
 import react from '@vitejs/plugin-react';
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig } from 'vite';
 
-export default defineConfig(({ mode }) => {
-  // Local testing convenience: pre-fill the access key from the repo-root .env
-  // so the demo is one click. Dev server only; this app is never published.
-  const rootEnv =
-    mode === 'development' ? loadEnv(mode, '../..', 'TIGRIS_') : {};
-
-  return {
-    plugins: [react()],
-    resolve: {
-      alias: {
-        // just-bash's browser bundle references node:zlib for gzip/gunzip/zcat.
-        // Nothing else needs it, so a throwing stub is the whole cost of
-        // running a virtual bash in the browser.
-        'node:zlib': new URL('./src/stubs/zlib.ts', import.meta.url).pathname,
-      },
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    // `PORT=3456 pnpm dev` to run alongside something else on 3000.
+    port: Number(process.env.PORT) || 3000,
+  },
+  resolve: {
+    alias: {
+      // just-bash's browser bundle references node:zlib for gzip/gunzip/zcat.
+      // Nothing else needs it, so a throwing stub is the whole cost of
+      // running a virtual bash in the browser.
+      'node:zlib': new URL('./src/stubs/zlib.ts', import.meta.url).pathname,
     },
-    define: {
-      __PREFILL__: JSON.stringify({
-        accessKeyId: rootEnv.TIGRIS_STORAGE_ACCESS_KEY_ID ?? '',
-        secretAccessKey: rootEnv.TIGRIS_STORAGE_SECRET_ACCESS_KEY ?? '',
-      }),
-    },
-  };
+  },
 });


### PR DESCRIPTION
## What

- `apps/cli-shell-playground` no longer reads `TIGRIS_STORAGE_*` from the repo-root `.env` and injects it as `__PREFILL__`. The shell starts signed out; `tigris login` offers OAuth or an access key, as it does for a user.
- The dev server listens on `PORT` when set (`PORT=3456 pnpm dev`), 3000 otherwise.

## Why

The prefill was a testing convenience from #286. With the shell landed, the demo should behave the way an embedder's page would.

## Testing

- `vite build` passes; the component typechecks; biome is clean.
- Verified live: `PORT=3456` served on 3456, the default served on 3000.

No changeset: the app is private and never published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Private playground-only dev UX changes; no published package or auth logic changes.
> 
> **Overview**
> The **cli-shell-playground** demo no longer auto-signs in from repo-root `TIGRIS_STORAGE_*` env vars. Vite’s `loadEnv`, the `__PREFILL__` define, and the `accessKey` prop on `TigrisShell` are removed so the app starts **signed out** and auth goes through **`tigris login`** (OAuth or access key), like a real embed.
> 
> The Vite config is flattened to a static `defineConfig` and the dev server **honors `PORT`** (default **3000**), e.g. `PORT=3456 pnpm dev`. The `node:zlib` stub alias is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d729a9eff7a4f68c633aab31eb0b858485b2868e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->