### PR TITLE
fix(cli-shell): default to path-style addressing, as agent-shell does

### DIFF
--- a/.changeset/cli-shell-path-style.md
+++ b/.changeset/cli-shell-path-style.md
@@ -1,0 +1,5 @@
+---
+'@tigrisdata/cli-shell': patch
+---
+
+Default to S3 path-style addressing (`TIGRIS_FORCE_PATH_STYLE=true`), as `@tigrisdata/agent-shell` does. In a browser, virtual-hosted URLs put each bucket on its own subdomain — a separate origin with its own CORS policy — so bucket-scoped commands such as `objects list` failed with CORS errors. Path style sends them to `<endpoint>/<bucket>/...` on the one origin. A caller's `env` still overrides it.

--- a/.github/workflows/deploy-agent-shell-playground.yml
+++ b/.github/workflows/deploy-agent-shell-playground.yml
@@ -1,7 +1,8 @@
 name: Deploy agent-shell playground
 
 # Deploys apps/agent-shell-playground to Fly.io on pushes to main that touch
-# the app or its @tigrisdata/agent-shell dependency, plus manual dispatch.
+# the app or the packages it serves — @tigrisdata/agent-shell at / and
+# @tigrisdata/cli-shell at /cli — plus manual dispatch.
 # The Dockerfile (pierrezemb/gostatic) serves the Vite `dist/` built in CI,
 # so we build first, then `flyctl deploy` ships the static bundle.
 on:
@@ -9,6 +10,7 @@ on:
     branches: [main]
     paths:
       - 'packages/agent-shell/**'
+      - 'packages/cli-shell/**'
       - 'apps/agent-shell-playground/**'
   workflow_dispatch:
 
@@ -30,7 +32,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # Builds @tigrisdata/agent-shell (workspace dep) then the playground.
+      # `...` builds the workspace deps first — @tigrisdata/agent-shell and
+      # @tigrisdata/cli-shell (and its @tigrisdata/cli) — then the playground.
       - name: Build playground
         run: pnpm --filter agent-shell-playground... build
 

--- a/packages/cli-shell/README.md
+++ b/packages/cli-shell/README.md
@@ -126,7 +126,7 @@ unaffected because its device flow has no callback URI.
 | --- | --- |
 | `auth` | Auth0 domain/clientId/audience overrides |
 | `accessKey` | Sign in with an access key instead of OAuth |
-| `env` | Extra environment variables the CLI can read |
+| `env` | Extra environment variables the CLI can read. `TIGRIS_FORCE_PATH_STYLE` defaults to `true` — a page cannot reach per-bucket subdomains cross-origin — and can be overridden here |
 | `welcome` | Replace the banner, or `false` for none |
 | `onReady` | Receives the `ShellEngine` for imperative use |
 | `className`, `style` | Applied to the container |

--- a/packages/cli-shell/src/repl/host.ts
+++ b/packages/cli-shell/src/repl/host.ts
@@ -58,7 +58,11 @@ export function createReplHost(options: HostOptions): BrowserHost {
     },
 
     get env() {
-      return env?.() ?? {};
+      // Path-style addressing, as agent-shell defaults to. A page cannot
+      // reach per-bucket subdomains (`<bucket>.<endpoint>`): each is its own
+      // origin with its own CORS policy, so bucket-scoped calls must go to
+      // `<endpoint>/<bucket>/...` instead. The caller's env still wins.
+      return { TIGRIS_FORCE_PATH_STYLE: 'true', ...env?.() };
     },
 
     confirm: async (message, options) => {

--- a/packages/cli-shell/test/host.test.ts
+++ b/packages/cli-shell/test/host.test.ts
@@ -230,6 +230,23 @@ describe('createReplHost', () => {
     });
   });
 
+  it('defaults the CLI to path-style addressing', () => {
+    // Regression: without this the CLI used virtual-hosted URLs
+    // (`<bucket>.<endpoint>`), and every bucket-scoped request from a page
+    // was a cross-origin call to a host with no CORS headers.
+    const host = createReplHost({ io: makeIO([]) });
+    expect(host.env?.TIGRIS_FORCE_PATH_STYLE).toBe('true');
+  });
+
+  it('lets the caller override path-style addressing', () => {
+    const host = createReplHost({
+      io: makeIO([]),
+      env: () => ({ TIGRIS_FORCE_PATH_STYLE: 'false', OTHER: 'kept' }),
+    });
+    expect(host.env?.TIGRIS_FORCE_PATH_STYLE).toBe('false');
+    expect(host.env?.OTHER).toBe('kept');
+  });
+
   it('routes refreshSession to the supplied handler', async () => {
     const refreshSession = vi.fn(async () => {});
     const host = createReplHost({ io: makeIO([]), refreshSession });


### PR DESCRIPTION
## What

Two commits:

1. **`fix(cli-shell)`** — cli-shell now defaults `TIGRIS_FORCE_PATH_STYLE=true` in the CLI's environment, exactly as `@tigrisdata/agent-shell` defaults `forcePathStyle: true`. A caller's `env` still overrides it. Patch changeset included.

2. **`ci(repo)`** — the Fly deploy of `agent-shell-playground` now also triggers on `packages/cli-shell/**`, since the playground serves cli-shell at `/cli`.

## Why

In a browser, S3's default virtual-hosted addressing puts each bucket on its own subdomain (`https://<bucket>.<endpoint>/…`) — a separate origin with its own CORS policy, and the bucket subdomains return no CORS headers. So bucket-scoped commands such as `objects list` failed with CORS errors from the shell. The CLI already honours `TIGRIS_FORCE_PATH_STYLE` (`provider.ts`); nobody was setting it in the browser. Path style sends those requests to `<endpoint>/<bucket>/…` on the one origin the page already talks to.

## Testing

- cli-shell: 99 tests (two new: the default is present; a caller override wins), lint clean, builds; the default is in `dist`.
- Verified live in the playground: `t3 objects list somebucket` from the page now requests `https://t3.storage.dev/somebucket/?list-type=2` — bucket in the path, preflight 200 — where it previously targeted `https://somebucket.t3.storage.dev/…`.
- Workflow YAML validated; push `paths` are `packages/agent-shell/**`, `packages/cli-shell/**`, `apps/agent-shell-playground/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Browser-only default env for existing CLI S3 addressing behavior; caller override preserved and covered by tests.
> 
> **Overview**
> **`@tigrisdata/cli-shell`** now injects `TIGRIS_FORCE_PATH_STYLE=true` into the browser CLI environment (matching `@tigrisdata/agent-shell`), so bucket operations hit `<endpoint>/<bucket>/…` on the same origin instead of virtual-hosted bucket subdomains that fail CORS in the page. Callers can still override via the `env` prop; README and a patch changeset document the default.
> 
> **CI** — the agent-shell playground Fly deploy workflow also runs when `packages/cli-shell/**` changes, since the playground serves cli-shell at `/cli`.
> 
> Tests cover the default and caller override in `host.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40a32bc631c16875186f3d7de5350afd665a7f52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->